### PR TITLE
feat: tls ngrok infra

### DIFF
--- a/src/jupyter_deploy/presets/terraform/aws/ec2/tls-via-ngrok/README.md
+++ b/src/jupyter_deploy/presets/terraform/aws/ec2/tls-via-ngrok/README.md
@@ -1,24 +1,62 @@
-# AWS EC2 instance running a Jupyter Server using ngrok for TLS
+# AWS EC2 instance in the default VPC running a Jupyter Server using ngrok for TLS
 ------
-
 This terraform project creates an EC2 instance in the default VPC that connects to ngrok for TLS.
 
-Boots the EC2 instance, install docker, execute the docker-compose file.
+The instance is configured so that you can access it using [AWS SSM](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html).\
 
-The instance can be accessed using AWS SSM.
+This project:
+- places the instance in the first subnet of the default VPC
+- select the latest AL 2023 AMI for `x86_64` architecture
+- sets up an IAM role to enable SSM access
+- passes on the a root volume of the AMI
+- adds an EBS volume which will mount on the Jupyter Server container
 
 ## Usage
-
+This terraform project is meant to be used with `jupyter-deploy`.
 
 ## Requirements
+| Name | Version |
+|---|---|
+| terraform | >= 1.0 |
+| aws | >= 4.66 |
+| | |
 
 ## Providers
+| Name | Version |
+|---|---|
+| aws | >= 4.66 |
+| | |
 
 ## Modules
+No modules.
 
 ## Resources
+| Name | Type |
+|---|---|
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource | 
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_ebs_volume.jupyter_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
+| [aws_volume_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
+| | |
 
 ## Inputs
+| Name | Type | Default | Description |
+|---|---|---|---|
+| aws_region | `string` | `null` | AWS region where the resources should be created |
+| instance_type | `string` | `t3.micro` | The type of instance to start |
+| key_name | `string` | `null` | The name of key pair |
+| ami_id | `string` | `null` | The ID of the AMI to use for the instance |
+| jupyter_data_volume_size | `number` | `30` | The size in GB of the EBS volume the Jupyter Server has access to |
+| jupyter_data_volume_type | `string` | `gp3` | The type of EBS volume the Jupyter Server will has access to |
+| iam_role_prefix | `string` | `JD-TlsViaNgrok-Exec` | The prefix for the name of the IAM role for the instance |
+| custom_tags | `map(string)` | `{}` | The custom tags to add to all the resources |
+| | |
 
 ## Outputs
-
+| Name | Description |
+|---|---|
+| [aws_instance.id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#id-2) | The ID of the EC2 instance |
+| | |

--- a/src/jupyter_deploy/presets/terraform/aws/ec2/tls-via-ngrok/main.tf
+++ b/src/jupyter_deploy/presets/terraform/aws/ec2/tls-via-ngrok/main.tf
@@ -50,21 +50,21 @@ resource "aws_security_group" "ec2_jupyter_server_sg" {
   description = "Security group for the EC2 instance serving the JupyterServer"
   vpc_id      = data.aws_vpc.default.id
 
-  # Allow SSH access
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # Disallow SSH access (we'll use aws ssm instead)
+  # ingress {
+  #   from_port   = 22
+  #   to_port     = 22
+  #   protocol    = "tcp"
+  #   cidr_blocks = ["0.0.0.0/0"]
+  # }
 
-  # Allow HTTPS access
-  ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # disallow direct HTTPS access for now
+  # ingress {
+  #   from_port   = 443
+  #   to_port     = 443
+  #   protocol    = "tcp"
+  #   cidr_blocks = ["0.0.0.0/0"]
+  # }
 
   # Allow all outbound traffic
   egress {
@@ -108,21 +108,32 @@ data "aws_ami" "amazon_linux_2023" {
   }
 }
 
+locals {
+  root_block_device = [
+    for device in data.aws_ami.amazon_linux_2023.block_device_mappings :
+    device if device.device_name == data.aws_ami.amazon_linux_2023.root_device_name
+  ][0]
+}
+
+
 # Define EC2 instance
 resource "aws_instance" "ec2_jupyter_server" {
   ami                    = coalesce(var.ami_id, data.aws_ami.amazon_linux_2023.id)
   instance_type          = var.instance_type
-  subnet_id              = data.aws_subnet.first_subnet_of_default_vpc
+  subnet_id              = data.aws_subnet.first_subnet_of_default_vpc.id
   vpc_security_group_ids = [aws_security_group.ec2_jupyter_server_sg.id]
   key_name               = var.key_name
   tags                   = local.combined_tags
   
   # Root volume configuration
   root_block_device {
-    volume_size = 10
-    volume_type = "gp2"
-    encrypted   = true
+    volume_size = local.root_block_device.ebs.volume_size
+    volume_type = try(local.root_block_device.ebs.volume_type, "gp3")
+    encrypted   = try(local.root_block_device.ebs.encrypted, true)
   }
+
+  # IAM instance profile configuration
+  iam_instance_profile = aws_iam_instance_profile.server_instance_profile.name
 }
 
 # Define the IAM role
@@ -139,7 +150,7 @@ data "aws_iam_policy_document" "server_assume_role_policy" {
 }
 
 resource "aws_iam_role" "execution_role" {
-  name = var.iam_role_name
+  name_prefix = "${var.iam_role_name_prefix}-"
   description = "Execution role for the JupyterServer instance, with access to SSM"
 
   assume_role_policy = data.aws_iam_policy_document.server_assume_role_policy.json
@@ -155,7 +166,7 @@ resource "aws_iam_role_policy_attachment" "execution_role_ssm_policy_attachment"
 # Define the instance profile
 resource "aws_iam_instance_profile" "server_instance_profile" {
   role = aws_iam_role.execution_role.name
-  name = var.iam_role_name
+  name_prefix = "${var.iam_role_name_prefix}-"
   lifecycle {
     create_before_destroy = true
   }
@@ -165,8 +176,8 @@ resource "aws_iam_instance_profile" "server_instance_profile" {
 # Define EBS volume
 resource "aws_ebs_volume" "jupyter_data" {
   availability_zone = aws_instance.ec2_jupyter_server.availability_zone
-  size              = 10
-  type              = "gp2"
+  size              = var.jupyter_data_volume_size
+  type              = var.jupyter_data_volume_type
   encrypted         = true
 
   tags = local.combined_tags

--- a/src/jupyter_deploy/presets/terraform/aws/ec2/tls-via-ngrok/variables.tf
+++ b/src/jupyter_deploy/presets/terraform/aws/ec2/tls-via-ngrok/variables.tf
@@ -23,10 +23,26 @@ variable "ami_id" {
   default     = null # to pin the AMI (adjust as needed), otherwise defaults to latest AL2023
 }
 
-variable "iam_role_name" {
+variable "jupyter_data_volume_size" {
+  description = "The size in GB of the EBS volume accessible to the jupyter server"
+  type        = number
+  default     = 30
+}
+
+variable "jupyter_data_volume_type" {
+  description = "The type of EBS volume accessible by the jupyter server"
+  type        = string
+  default     = "gp3"
+}
+
+variable "iam_role_name_prefix" {
   description = "Name of the execution IAM role for the EC2 instance of the Jupyter Server"
   type        = string
-  default     = "JupyterDeploy-TlsViaNgrok-ExecutionRole"
+  default     = "JD-TlsViaNgrok-Exec"
+  validation {
+    condition     = length(var.iam_role_name_prefix) <= 37
+    error_message = "Max length for prefix is 38. Input at most 37 chars to account for hyphen postfix."
+  }
 }
 
 variable "custom_tags" {


### PR DESCRIPTION
This PR fixes deployment issues for the terraform infrastructure project created by #3 
1. remove CIDR block variable, do not create new subnet, place the EC2 instance in the first subnet of the default VPC instead
2. infer partition from current terraform config
3. disallow ingress access in the security group (not needed  for aws ssm)
4. use AL2023 (latest) instead of AL2 (EOL)
5. fix root volume deployment issue by inferring the characteristics from the AMI (cannot leave blank, Terraform infers the wrong value and the deployment fails)
6. use a prefix instead of a name for the IAM role
7. add markdown for the project

**Testing**
- `jupyter-deploy terraform generate -p sandbox/sb1`
- then `cd sandbox/sb1`
- `terraform init`
- `terraform plan`
- `terraform apply`
- verify that the instance is running in console
- verify that we can ssm into the instance with `aws ssm start --target <instance-id>`
