### PR TITLE
fix: jd init - default to help if no path input

### DIFF
--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from typing import Annotated
 
@@ -41,12 +42,12 @@ runner = JupyterDeployCliRunner()
 @runner.app.command()
 def init(
     path: Annotated[
-        str,
+        str | None,
         typer.Argument(
             help="Path to the directory where jupyter-deploy will create your project files. "
             "Pass '.' to use your current working directory."
         ),
-    ],
+    ] = None,
     engine: Annotated[
         EngineType, typer.Option("--engine", "-E", help="Infrastructure as code software to manage your resources.")
     ] = EngineType.TERRAFORM,
@@ -73,6 +74,10 @@ def init(
     Target project path must be specified. If the path is not empty, prompts
     for confirmation before overwriting existing content.
     """
+    if path is None:
+        init_help_cmds = ["jupyter", "deploy", "init", "--help"]
+        subprocess.run(init_help_cmds)
+        return
     project = InitHandler(
         project_dir=path,
         engine=engine,

--- a/libs/jupyter-deploy/tests/unit/cli/test_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app.py
@@ -351,10 +351,13 @@ class TestInitCommand(unittest.TestCase):
         self.mock_clear_project_path.assert_not_called()
         self.mock_setup.assert_not_called()
 
-    def test_init_command_requires_output_path(self) -> None:
-        """Test that the init command requires the output_path argument."""
+    @patch("subprocess.run")
+    def test_init_command_calls_help_when_no_path(self, mock_subprocess_run: Mock) -> None:
+        mock_subprocess_run.return_value = Mock(returncode=0)
+
         runner = CliRunner()
         result = runner.invoke(app_runner.app, ["init"])
 
-        self.assertNotEqual(result.exit_code, 0, "init command should fail without path")
-        self.assertTrue("Missing argument 'PATH'" in result.stdout)
+        self.assertEqual(result.exit_code, 0, "init command should succeed without path")
+
+        mock_subprocess_run.assert_called_once_with(["jupyter", "deploy", "init", "--help"])


### PR DESCRIPTION
Added a minor update to `jd init` to return the output of `--help` instead of failing when the `path` positional argument is not supplied.

Before:
<img width="1198" alt="Screenshot 2025-06-05 at 1 13 27 PM" src="https://github.com/user-attachments/assets/52932f88-9874-4b28-ae1e-d9519220b366" />

After:
<img width="1197" alt="Screenshot 2025-06-05 at 1 09 28 PM" src="https://github.com/user-attachments/assets/2306a4c6-857a-4fa2-a4f8-9cf3009c370f" />
