### PR TITLE
feat: Automate log rotation

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/README.md
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/README.md
@@ -11,7 +11,7 @@ This project:
 - sets up an IAM role to enable SSM access
 - passes on the root volume of the AMI
 - adds an EBS volume which will mount on the Jupyter Server container
-- configures automatic rotation for Traefik logs with customizable settings
+- configures automatic rotation for all log files under /var/log/services/ with customizable settings
 - creates an SSM instance-startup script, which references several files:
     - `cloudinit.sh.tftpl` for the basic setup of the instance
     - `docker-compose.yml.tftpl` for the docker services to run in the instance
@@ -137,9 +137,9 @@ No modules.
 | oauth_allowed_usernames | `list(string)` | `[]` | The list of GitHub usernames to allowlist |
 | oauth_app_client_id | `string` | Required | The client ID of the OAuth app |
 | oauth_app_client_secret | `string` | Required | The client secret of the OAuth app |
-| traefik_logs_rotation_size | `number` | `100` | The size in megabytes at which to rotate Traefik log files |
-| traefik_logs_max_count | `number` | `180` | The maximum amount of rotated Traefik log files to retain |
-| traefik_logs_max_age | `number` | `180` | The maximum number of days from creation to retain any logfile |
+| logs_rotation_size_mb | `number` | `50` | The size in megabytes at which to rotate log files under /var/log/services/ |
+| max_log_files_count | `number` | `180` | The maximum amount of rotated log files to retain for each service |
+| log_files_retention_days | `number` | `180` | The maximum number of days from creation to retain any logfile |
 | custom_tags | `map(string)` | `{}` | The custom tags to add to all the resources |
 
 ## Outputs

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/cloudinit.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/cloudinit.sh.tftpl
@@ -147,9 +147,8 @@ chmod 600 /opt/docker/acme.json
 
 # Create the log dirs and files
 mkdir -p /var/log/services
-mkdir -p /var/log/services/traefik
 touch /var/log/services/jupyter.log
-touch /var/log/services/traefik/traefik.log
+touch /var/log/services/traefik.log
 touch /var/log/services/oauth.log
 touch /var/log/services/logrotate.log
 touch /var/log/services/logrotate.status

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/defaults-all.tfvars
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/defaults-all.tfvars
@@ -1,14 +1,14 @@
 # defaults.tfvars
-region                         = "us-west-2"
-instance_type                  = "t3.medium"
-key_pair_name                  = null
-ami_id                         = null
-volume_size_gb                 = 30
-volume_type                    = "gp3"
-iam_role_prefix                = "Jupyter-deploy-ec2-base"
-oauth_provider                 = "github"
-oauth_app_secret_prefix        = "Jupyter-deploy-ec2-base"
-traefik_logs_rotation_size     = 50
-traefik_logs_max_count         = 180
-traefik_logs_max_age           = 180
-custom_tags                    = {}
+region                   = "us-west-2"
+instance_type            = "t3.medium"
+key_pair_name            = null
+ami_id                   = null
+volume_size_gb           = 30
+volume_type              = "gp3"
+iam_role_prefix          = "Jupyter-deploy-ec2-base"
+oauth_provider           = "github"
+oauth_app_secret_prefix  = "Jupyter-deploy-ec2-base"
+logs_rotation_size_mb    = 50
+max_log_files_count      = 180
+log_files_retention_days = 180
+custom_tags              = {}

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/docker-compose.yml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/docker-compose.yml.tftpl
@@ -116,9 +116,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     command: |
       sh -c '
-        mkdir -p /logs/traefik
         docker logs -f jupyter >> /logs/jupyter.log 2>&1 &
-        docker logs -f traefik >> /logs/traefik/traefik.log 2>&1 &
+        docker logs -f traefik >> /logs/traefik.log 2>&1 &
         docker logs -f oauth >> /logs/oauth.log 2>&1 &
         wait
       '
@@ -139,13 +138,13 @@ services:
     volumes:
       - /var/log/services:/var/log/services
     environment:
-      - LOGS_DIRECTORIES=/var/log/services/traefik
+      - LOGS_DIRECTORIES=/var/log/services
       - LOG_FILE_ENDINGS=log
-      - LOGROTATE_MAXAGE=${traefik_logs_max_age}
-      - LOGROTATE_SIZE=${traefik_logs_rotation_size}M
+      - LOGROTATE_MAXAGE=${log_files_retention_days}
+      - LOGROTATE_SIZE=${logs_rotation_size_mb}M
       - LOGROTATE_DATEFORMAT=-%Y-%m-%dT%H:%M:%S
       - TZ=UTC
-      - LOGROTATE_COPIES=${traefik_logs_max_count}
+      - LOGROTATE_COPIES=${max_log_files_count}
       - LOGROTATE_COMPRESSION=compress
       - LOGROTATE_LOGFILE=/var/log/services/logrotate.log
       - LOGROTATE_STATUSFILE=/var/log/services/logrotate.status

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/docker-startup.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/docker-startup.sh.tftpl
@@ -22,7 +22,7 @@ fi
 # memory management: attempt to allocate 95% of memory to jupyter
 # while keeping enough memory for other containers
 TOTAL_MEMORY_MB=$(free -m | awk '/^Mem:/{print $2}')
-MAX_MEM_RESERVATION_MB=$((TOTAL_MEMORY_MB - 320))
+MAX_MEM_RESERVATION_MB=$((TOTAL_MEMORY_MB - 384))
 PERC_MEM_RESERVATION_MB=$((TOTAL_MEMORY_MB * 95 / 100))
 
 JUPYTER_MEM_LIMIT_MB=$(( PERC_MEM_RESERVATION_MB < MAX_MEM_RESERVATION_MB ? PERC_MEM_RESERVATION_MB : MAX_MEM_RESERVATION_MB ))

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/main.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/main.tf
@@ -333,9 +333,9 @@ data "local_file" "refresh_oauth_cookie" {
 
 # variables consistency checks
 locals {
-  full_domain                = "${var.subdomain}.${var.domain}"
-  github_auth_valid          = var.oauth_provider != "github" || (var.oauth_allowed_usernames != null && length(var.oauth_allowed_usernames) > 0) || (var.oauth_allowed_org != null && length(var.oauth_allowed_org) > 0)
-  teams_have_org             = var.oauth_allowed_teams == null || length(var.oauth_allowed_teams) == 0 || (var.oauth_allowed_org != null && length(var.oauth_allowed_org) > 0)
+  full_domain       = "${var.subdomain}.${var.domain}"
+  github_auth_valid = var.oauth_provider != "github" || (var.oauth_allowed_usernames != null && length(var.oauth_allowed_usernames) > 0) || (var.oauth_allowed_org != null && length(var.oauth_allowed_org) > 0)
+  teams_have_org    = var.oauth_allowed_teams == null || length(var.oauth_allowed_teams) == 0 || (var.oauth_allowed_org != null && length(var.oauth_allowed_org) > 0)
 }
 
 locals {
@@ -351,16 +351,16 @@ locals {
     oauth_secret_arn = aws_secretsmanager_secret.oauth_github_client_secret.arn,
   })
   docker_compose_file = templatefile("${path.module}/docker-compose.yml.tftpl", {
-    oauth_provider                 = var.oauth_provider
-    full_domain                    = local.full_domain
-    github_client_id               = var.oauth_app_client_id
-    aws_region                     = data.aws_region.current.region
-    allowed_github_usernames       = local.allowed_github_usernames
-    allowed_github_org             = local.allowed_github_org
-    allowed_github_teams           = local.allowed_github_teams
-    traefik_logs_rotation_size     = var.traefik_logs_rotation_size
-    traefik_logs_max_count         = var.traefik_logs_max_count
-    traefik_logs_max_age           = var.traefik_logs_max_age
+    oauth_provider           = var.oauth_provider
+    full_domain              = local.full_domain
+    github_client_id         = var.oauth_app_client_id
+    aws_region               = data.aws_region.current.region
+    allowed_github_usernames = local.allowed_github_usernames
+    allowed_github_org       = local.allowed_github_org
+    allowed_github_teams     = local.allowed_github_teams
+    logs_rotation_size_mb    = var.logs_rotation_size_mb
+    max_log_files_count      = var.max_log_files_count
+    log_files_retention_days = var.log_files_retention_days
   })
   traefik_config_file = templatefile("${path.module}/traefik.yml.tftpl", {
     letsencrypt_notification_email = var.letsencrypt_email

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/variables.tf
@@ -259,11 +259,11 @@ variable "oauth_app_client_secret" {
   sensitive   = true
 }
 
-variable "traefik_logs_rotation_size" {
+variable "logs_rotation_size_mb" {
   description = <<-EOT
-    The size in megabytes at which to rotate Traefik log files.
+    The size in megabytes at which to rotate log files under /var/log/services/.
     
-    When the traefik.log file reaches this size, it will be rotated (a new log file will be created
+    When a log file reaches this size, it will be rotated (a new log file will be created
     and the old one will be compressed and archived).
 
     Recommended: 50
@@ -271,38 +271,38 @@ variable "traefik_logs_rotation_size" {
   type        = number
 
   validation {
-    condition     = var.traefik_logs_rotation_size > 0
-    error_message = "The traefik_logs_rotation_size value must be greater than 0."
+    condition     = var.logs_rotation_size_mb > 0
+    error_message = "The logs_rotation_size_mb value must be greater than 0."
   }
 }
 
-variable "traefik_logs_max_count" {
+variable "max_log_files_count" {
   description = <<-EOT
-    The maximum number of Traefik log files to retain at any given time.
+    The maximum number of log files to retain at any given time for each service.
     
-    When the retention limit has been reached, the current oldest Traefik logfile will be deleted.
+    When the retention limit has been reached, the current oldest logfile will be deleted.
 
     Recommended: 180
   EOT
   type        = number
 
   validation {
-    condition     = var.traefik_logs_max_count > 0
-    error_message = "The traefik_logs_max_count must be greater than 0."
+    condition     = var.max_log_files_count > 0
+    error_message = "The max_log_files_count must be greater than 0."
   }
 }
 
-variable "traefik_logs_max_age" {
+variable "log_files_retention_days" {
   description = <<-EOT
-    Remove rotated Traefik log files older than the specified number of days.
+    Remove rotated log files older than the specified number of days.
 
     Recommended: 180
   EOT
   type        = number
 
   validation {
-    condition     = var.traefik_logs_max_age > 0
-    error_message = "The traefik_logs_max_age value must be greater than 0."
+    condition     = var.log_files_retention_days > 0
+    error_message = "The log_files_retention_days value must be greater than 0."
   }
 }
 


### PR DESCRIPTION
This PR updates the base template to add automated and configurable log rotation for all logfiles under `/var/log/services`, by adding a new `log-rotator` sidecar container to manage usage of `logrotate`.

**To manage this, we add four new default template variables:**
- `logs_rotation_size_mb`: `logrotate` `size` equivalent
- `max_log_files_count`: `logrotate` `rotate` equivalent
- `log_files_retention_days`: `logrotate` `maxage` equivalent

**By default, the `log-rotator` sidecar will monitor `/var/log/services/` and continuously run a cron job that:**
1) At 10s intervals, checks the current size of each log
2) Checks this against the current value of `traefik_logs_rotation_size`
3) Rotates any log that has exceeded the size limit
4) And stores the old log content to a compressed and timestamped archive file in the same directory.

**Separately, logfiles will also be cleaned up and deleted if either:**
1) A logfile's age exceeds the value of `log_files_retention_days` (defaults to 180 days)
2) The total number of logfiles/archives exceeds the value of `max_log_files_count`. In conjunction with `logs_rotation_size_mb`, this helps ensure that we have an upper limit for the cumulative size per log type.

Follow up items:
- The [`blacklabelops/logrotate`](https://github.com/blacklabelops/logrotate) image that we are using has not been updated in a while, need to find a good alternative with active maintainers.
- Add the ability to send rotated logs to CloudWatch, per https://github.com/jupyter-ai-contrib/jupyter-deploy/issues/7.