### PR TITLE
feat: support cli inputs and previous results in cmd runner

### DIFF
--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
@@ -42,7 +42,7 @@ class ServerHandler(BaseProjectHandler):
 
         console = self.get_console()
         runner = cmd_runner.ManifestCommandRunner(console=console, output_handler=self._output_handler)
-        resolved_resultdefs = runner.run_command_sequence(command)
+        resolved_resultdefs = runner.run_command_sequence(command, cli_paramdefs={})
 
         # extract result - we already checked the source
         cmd_result = resolved_resultdefs.get(cmd_result_def.source_key)

--- a/libs/jupyter-deploy/jupyter_deploy/provider/resolved_clidefs.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/resolved_clidefs.py
@@ -1,0 +1,25 @@
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+S = TypeVar("S")
+
+
+class ResolvedCliParameter(BaseModel, Generic[S]):
+    """Wrapper class for a value passed to a CLI command by the user."""
+
+    model_config = ConfigDict(extra="allow")
+    parameter_name: str
+    value: S
+
+
+class StrResolvedCliParameter(ResolvedCliParameter[str]):
+    """Wrapper class for string value passed to a CLI command by the user."""
+
+    pass
+
+
+class ListStrResolvedCliParameter(ResolvedCliParameter[list[str]]):
+    """Wrapper class for list of strings value passed to a CLI command by the user."""
+
+    pass


### PR DESCRIPTION
This PR wraps up unfinished work on #56 to a/ reference the result of previous instruction as argument for subsequent instructions in a command sequence, and b/ reference cli parameters values passed by the user to any instruction.

Address #58 

This will unblock `jd user add <users>` where the `<users>` would be a `list[str]`.

An example manifest command could look like:
 ```yaml
  - cmd: "user.add"
    sequence:
      - api-name: "aws.ssm.wait-command-with-param-sync"
        arguments:
          - api-attribute: "document_name"
            source: "output"
            source-key: "auth-update"
          - api-attribute: "instance_id"
            source: "output"
            source-key: "instance_id"
          - api-attribute: "new-users"
            source: "cli"
            source-key: "users"
```

### Testing
- verified that `jd server status` still works as expected.