### PR TITLE
release: v0.2.1

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/__init__.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/__init__.py
@@ -4,4 +4,4 @@ Relies on traefik for proxy, letsencrypt to generate the TLS certificate
 and external oauth provider.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/main.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/main.tf
@@ -15,7 +15,7 @@ resource "random_id" "postfix" {
 }
 locals {
   template_name    = "tf-aws-ec2-base"
-  template_version = "0.2.0"
+  template_version = "0.2.1"
 
   default_tags = {
     Source   = "jupyter-deploy"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -1,434 +1,434 @@
 schema_version: 1
 template:
-  name: "tf-aws-ec2-base"
-  engine: "terraform"
-  version: "0.2.0"
+  name: tf-aws-ec2-base
+  engine: terraform
+  version: 0.2.1
 requirements:
-  - name: "terraform"
-  - name: "awscli"
-  - name: "jq"
+- name: terraform
+- name: awscli
+- name: jq
 values:
-  - name: "open_url"
-    source: "output"
-    source-key: "jupyter_url"
-  - name: "aws_region"
-    source: "output"
-    source-key: "region"
-  - name: "persisting_resources"
-    source: "output"
-    source-key: "persisting_resources"
+- name: open_url
+  source: output
+  source-key: jupyter_url
+- name: aws_region
+  source: output
+  source-key: region
+- name: persisting_resources
+  source: output
+  source-key: persisting_resources
 commands:
-  - cmd: "host.status"
-    sequence:
-      - api-name: "aws.ec2.describe-instance-status"
-        arguments:
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-    results:
-      - result-name: "host.status"
-        source: "result"
-        source-key: "[0].InstanceStateName"
-  - cmd: "host.stop"
-    sequence:
-      - api-name: "aws.ec2.stop-instance"
-        arguments:
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-      - api-name: "aws.ec2.wait-for-stopped"
-        arguments:
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-  - cmd: "host.start"
-    sequence:
-      - api-name: "aws.ec2.start-instance"
-        arguments:
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-      - api-name: "aws.ec2.wait-for-running"
-        arguments:
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-  - cmd: "host.restart"
-    sequence:
-      - api-name: "aws.ec2.reboot-instance"
-        arguments:
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-      - api-name: "aws.ec2.wait-for-running"
-        arguments:
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-  - cmd: "host.connect"
-    sequence:
-      - api-name: "aws.ssm.start-session"
-        arguments:
-          - api-attribute: "target_id"
-            source: "output"
-            source-key: "instance_id"
-  - cmd: "server.status"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "server_status_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-    results:
-      - result-name: "server.status"
-        source: "result"
-        source-key: "[0].StandardOutputContent"
-  - cmd: "server.start"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "server_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-          - api-attribute: "service"
-            source: "cli"
-            source-key: "service"
-  - cmd: "server.stop"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "server_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-          - api-attribute: "service"
-            source: "cli"
-            source-key: "service"
-  - cmd: "server.restart"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "server_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-          - api-attribute: "service"
-            source: "cli"
-            source-key: "service"
-  - cmd: "users.add"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_users_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "users"
-            source: "cli"
-            source-key: "users"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    updates:
-      - variable-name: "oauth_allowed_usernames"
-        source: "result"
-        source-key: "[1].StandardOutputContent"
-        transform: "comma-separated-str-to-list-str"
-  - cmd: "users.remove"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_users_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "users"
-            source: "cli"
-            source-key: "users"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    updates:
-      - variable-name: "oauth_allowed_usernames"
-        source: "result"
-        source-key: "[1].StandardOutputContent"
-        transform: "comma-separated-str-to-list-str"
-  - cmd: "users.set"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_users_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "users"
-            source: "cli"
-            source-key: "users"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    updates:
-      - variable-name: "oauth_allowed_usernames"
-        source: "result"
-        source-key: "[1].StandardOutputContent"
-        transform: "comma-separated-str-to-list-str"
-  - cmd: "users.list"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    results:
-      - result-name: "users.list"
-        source: "result"
-        source-key: "[0].StandardOutputContent"
-        transform: "comma-separated-str-to-list-str"
-  - cmd: "teams.add"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_teams_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "teams"
-            source: "cli"
-            source-key: "teams"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    updates:
-      - variable-name: "oauth_allowed_teams"
-        source: "result"
-        source-key: "[1].StandardOutputContent"
-        transform: "comma-separated-str-to-list-str"
-  - cmd: "teams.remove"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_teams_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "teams"
-            source: "cli"
-            source-key: "teams"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    updates:
-      - variable-name: "oauth_allowed_teams"
-        source: "result"
-        source-key: "[1].StandardOutputContent"
-        transform: "comma-separated-str-to-list-str"
-  - cmd: "teams.set"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_teams_update_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "teams"
-            source: "cli"
-            source-key: "teams"
-          - api-attribute: "action"
-            source: "cli"
-            source-key: "action"
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    updates:
-      - variable-name: "oauth_allowed_teams"
-        source: "result"
-        source-key: "[1].StandardOutputContent"
-        transform: "comma-separated-str-to-list-str"
-  - cmd: "teams.list"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    results:
-      - result-name: "teams.list"
-        source: "result"
-        source-key: "[0].StandardOutputContent"
-        transform: "comma-separated-str-to-list-str"
-  - cmd: "organization.set"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_org_set_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "organization"
-            source: "cli"
-            source-key: "organization"
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    updates:
-      - variable-name: "oauth_allowed_org"
-        source: "result"
-        source-key: "[1].StandardOutputContent"
-  - cmd: "organization.unset"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_org_unset_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    updates:
-      - variable-name: "oauth_allowed_org"
-        source: "result"
-        source-key: "[1].StandardOutputContent"
-  - cmd: "organization.get"
-    sequence:
-      - api-name: "aws.ssm.wait-command-sync"
-        arguments:
-          - api-attribute: "document_name"
-            source: "output"
-            source-key: "auth_check_document"
-          - api-attribute: "instance_id"
-            source: "output"
-            source-key: "instance_id"
-          - api-attribute: "category"
-            source: "cli"
-            source-key: "category"
-    results:
-      - result-name: "organization.get"
-        source: "result"
-        source-key: "[0].StandardOutputContent"
+- cmd: host.status
+  sequence:
+  - api-name: aws.ec2.describe-instance-status
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+  results:
+  - result-name: host.status
+    source: result
+    source-key: '[0].InstanceStateName'
+- cmd: host.stop
+  sequence:
+  - api-name: aws.ec2.stop-instance
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+  - api-name: aws.ec2.wait-for-stopped
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+- cmd: host.start
+  sequence:
+  - api-name: aws.ec2.start-instance
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+  - api-name: aws.ec2.wait-for-running
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+- cmd: host.restart
+  sequence:
+  - api-name: aws.ec2.reboot-instance
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+  - api-name: aws.ec2.wait-for-running
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+- cmd: host.connect
+  sequence:
+  - api-name: aws.ssm.start-session
+    arguments:
+    - api-attribute: target_id
+      source: output
+      source-key: instance_id
+- cmd: server.status
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: server_status_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+  results:
+  - result-name: server.status
+    source: result
+    source-key: '[0].StandardOutputContent'
+- cmd: server.start
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: server_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: action
+      source: cli
+      source-key: action
+    - api-attribute: service
+      source: cli
+      source-key: service
+- cmd: server.stop
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: server_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: action
+      source: cli
+      source-key: action
+    - api-attribute: service
+      source: cli
+      source-key: service
+- cmd: server.restart
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: server_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: action
+      source: cli
+      source-key: action
+    - api-attribute: service
+      source: cli
+      source-key: service
+- cmd: users.add
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_users_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: users
+      source: cli
+      source-key: users
+    - api-attribute: action
+      source: cli
+      source-key: action
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  updates:
+  - variable-name: oauth_allowed_usernames
+    source: result
+    source-key: '[1].StandardOutputContent'
+    transform: comma-separated-str-to-list-str
+- cmd: users.remove
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_users_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: users
+      source: cli
+      source-key: users
+    - api-attribute: action
+      source: cli
+      source-key: action
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  updates:
+  - variable-name: oauth_allowed_usernames
+    source: result
+    source-key: '[1].StandardOutputContent'
+    transform: comma-separated-str-to-list-str
+- cmd: users.set
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_users_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: users
+      source: cli
+      source-key: users
+    - api-attribute: action
+      source: cli
+      source-key: action
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  updates:
+  - variable-name: oauth_allowed_usernames
+    source: result
+    source-key: '[1].StandardOutputContent'
+    transform: comma-separated-str-to-list-str
+- cmd: users.list
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  results:
+  - result-name: users.list
+    source: result
+    source-key: '[0].StandardOutputContent'
+    transform: comma-separated-str-to-list-str
+- cmd: teams.add
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_teams_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: teams
+      source: cli
+      source-key: teams
+    - api-attribute: action
+      source: cli
+      source-key: action
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  updates:
+  - variable-name: oauth_allowed_teams
+    source: result
+    source-key: '[1].StandardOutputContent'
+    transform: comma-separated-str-to-list-str
+- cmd: teams.remove
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_teams_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: teams
+      source: cli
+      source-key: teams
+    - api-attribute: action
+      source: cli
+      source-key: action
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  updates:
+  - variable-name: oauth_allowed_teams
+    source: result
+    source-key: '[1].StandardOutputContent'
+    transform: comma-separated-str-to-list-str
+- cmd: teams.set
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_teams_update_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: teams
+      source: cli
+      source-key: teams
+    - api-attribute: action
+      source: cli
+      source-key: action
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  updates:
+  - variable-name: oauth_allowed_teams
+    source: result
+    source-key: '[1].StandardOutputContent'
+    transform: comma-separated-str-to-list-str
+- cmd: teams.list
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  results:
+  - result-name: teams.list
+    source: result
+    source-key: '[0].StandardOutputContent'
+    transform: comma-separated-str-to-list-str
+- cmd: organization.set
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_org_set_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: organization
+      source: cli
+      source-key: organization
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  updates:
+  - variable-name: oauth_allowed_org
+    source: result
+    source-key: '[1].StandardOutputContent'
+- cmd: organization.unset
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_org_unset_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  updates:
+  - variable-name: oauth_allowed_org
+    source: result
+    source-key: '[1].StandardOutputContent'
+- cmd: organization.get
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: auth_check_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: category
+      source: cli
+      source-key: category
+  results:
+  - result-name: organization.get
+    source: result
+    source-key: '[0].StandardOutputContent'

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pixi.jupyter.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pixi.jupyter.toml
@@ -1,9 +1,13 @@
 [workspace]
-channels = ["conda-forge"]
+channels = [
+    "conda-forge",
+]
 description = "A basic image with jupyterlab and server-documents"
 name = "jupyter-pixi"
-platforms = ["linux-64"]
-version = "0.2.0"
+platforms = [
+    "linux-64",
+]
+version = "0.2.1"
 
 [tasks]
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter"
-version = "0.2.0"
+version = "0.2.1"
 description = "A basic image with jupyterlab and server-documents"
 requires-python = ">=3.12"
 dependencies = [

--- a/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "jupyter-deploy-tf-aws-ec2-base"
-version = "0.2.0"
+version = "0.2.1"
 description = "Base terraform template to deploy jupyter notebook on AWS EC2."
 readme = "README.md"
 authors = [
     { name = "Jonathan Guinegagne", email = "jggg@amazon.com" },
     { name = "Michael Chin", email = "chnmch@amazon.com" },
-    { name = "Brian Granger", email = "brgrange@amazon.com" }
+    { name = "Brian Granger", email = "brgrange@amazon.com" },
 ]
 requires-python = ">=3.12"
 dependencies = [
@@ -20,22 +20,14 @@ dependencies = [
 aws_ec2_base = "jupyter_deploy_tf_aws_ec2_base.template:TEMPLATE_PATH"
 
 [build-system]
-requires = ["hatchling"]
+requires = [
+    "hatchling",
+]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["jupyter_deploy_tf_aws_ec2_base"]
-
-[dependency-groups]
-dev = [
-    "jupyter-deploy",
-    "mypy>=1.15.0",
-    "pytest>=8.3.5",
-    "pytest-cov>=6.1.1",
-    "python-hcl2>=7.2.1",
-    "pyyaml>=6.0.2",
-    "ruff>=0.11.8",
-    "types-pyyaml>=6.0.12.20250516",
+packages = [
+    "jupyter_deploy_tf_aws_ec2_base",
 ]
 
 [tool.mypy]
@@ -43,38 +35,49 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 check_untyped_defs = true
-mypy_path = ["."]
-packages = ["jupyter_deploy_tf_aws_ec2_base"]
+mypy_path = [
+    ".",
+]
+packages = [
+    "jupyter_deploy_tf_aws_ec2_base",
+]
 
 [tool.ruff]
-extend-exclude = [".conda/"]
+extend-exclude = [
+    ".conda/",
+]
 line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E",  # pydocstyle
-    "F",  # pyflakes
-    "UP",  # pyupgrade
-    "B",  # flake8-bugbear
-    "SIM",  # flake8-simplify
-    "I"   # isort
+    "E",
+    "F",
+    "UP",
+    "B",
+    "SIM",
+    "I",
 ]
 
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
-
 docstring-code-format = true
 docstring-code-line-length = 40
 
 [tool.pytest.ini_options]
 addopts = "--cov=jupyter_deploy_tf_aws_ec2_base --cov-report=term-missing --cov-report=xml --cov-report=html"
-testpaths = ["tests/unit"]
+testpaths = [
+    "tests/unit",
+]
 
 [tool.coverage.run]
-source = ["jupyter_deploy_tf_aws_ec2_base"]
-omit = ["tests/*"]
+source = [
+    "jupyter_deploy_tf_aws_ec2_base",
+]
+omit = [
+    "tests/*",
+]
 
 [tool.coverage.report]
 exclude_lines = [
@@ -88,5 +91,17 @@ exclude_lines = [
 fail_under = 80
 show_missing = true
 
-[tool.uv.sources]
-jupyter-deploy = { workspace = true }
+[tool.uv.sources.jupyter-deploy]
+workspace = true
+
+[dependency-groups]
+dev = [
+    "jupyter-deploy",
+    "mypy>=1.15.0",
+    "pytest>=8.3.5",
+    "pytest-cov>=6.1.1",
+    "python-hcl2>=7.2.1",
+    "pyyaml>=6.0.2",
+    "ruff>=0.11.8",
+    "types-pyyaml>=6.0.12.20250516",
+]

--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy"
-version = "0.2.0"
+version = "0.2.1"
 description = "CLI based tool to deploy Jupyter application that integrates with infrastructure as code frameworks."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev-dependencies = [
     "typer>=0.15.4",
     "rich>=10.11.0",
     "parameterized>=0.9.0",
+    "tomli-w>=1.2.0",
 ]
 
 [tool.mypy]

--- a/scripts/upgrade_base_template_version.py
+++ b/scripts/upgrade_base_template_version.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Script to upgrade version information across all files in the jupyter-deploy-tf-aws-ec2-base template.
+
+Usage:
+    python scripts/upgrade_tf_aws_ec2_base_version.py NEW_VERSION
+"""
+
+import argparse
+import re
+import sys
+import tomllib
+import tomli_w
+from pathlib import Path
+import yaml
+
+
+def update_pyproject_toml(file_path: Path, new_version: str) -> None:
+    """Update version in pyproject.toml file."""
+    # Read the current content as bytes (required by tomllib)
+    with open(file_path, "rb") as f:
+        data = tomllib.load(f)
+
+    # Update the version
+    data["project"]["version"] = new_version
+
+    # Write the updated content back
+    with open(file_path, "wb") as f:
+        tomli_w.dump(data, f)
+
+    print(f"✓ Updated version in {file_path}")
+
+
+def update_init_py(file_path: Path, new_version: str) -> None:
+    """Update __version__ in __init__.py file."""
+    content = file_path.read_text()
+    updated_content = re.sub(
+        r'__version__\s*=\s*["\']([^"\']+)["\']',
+        f'__version__ = "{new_version}"',
+        content,
+    )
+
+    if content == updated_content:
+        print(f"! Warning: No version pattern found in {file_path}")
+    else:
+        file_path.write_text(updated_content)
+        print(f"✓ Updated version in {file_path}")
+
+
+def update_manifest_yaml(file_path: Path, new_version: str) -> None:
+    """Update version in manifest.yaml file."""
+    with open(file_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    # Update the version
+    data["template"]["version"] = new_version
+
+    # Write the updated content back
+    with open(file_path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+    print(f"✓ Updated version in {file_path}")
+
+
+def update_main_tf(file_path: Path, new_version: str) -> None:
+    """Update template_version in main.tf file."""
+    content = file_path.read_text()
+    updated_content = re.sub(
+        r'template_version\s*=\s*["\']([^"\']+)["\']',
+        f'template_version = "{new_version}"',
+        content,
+    )
+
+    if content == updated_content:
+        print(f"! Warning: No template_version pattern found in {file_path}")
+    else:
+        file_path.write_text(updated_content)
+        print(f"✓ Updated version in {file_path}")
+
+
+def update_jupyter_pyproject_toml(file_path: Path, new_version: str) -> None:
+    """Update version in pyproject.jupyter.toml file."""
+    # Read the current content as bytes (required by tomllib)
+    with open(file_path, "rb") as f:
+        data = tomllib.load(f)
+
+    # Update the version
+    data["project"]["version"] = new_version
+
+    # Write the updated content back
+    with open(file_path, "wb") as f:
+        tomli_w.dump(data, f)
+
+    print(f"✓ Updated version in {file_path}")
+
+
+def update_jupyter_pixi_toml(file_path: Path, new_version: str) -> None:
+    """Update version in pixi.jupyter.toml file."""
+    # Read the current content as bytes (required by tomllib)
+    with open(file_path, "rb") as f:
+        data = tomllib.load(f)
+
+    # Update the version
+    data["workspace"]["version"] = new_version
+
+    # Write the updated content back
+    with open(file_path, "wb") as f:
+        tomli_w.dump(data, f)
+
+    print(f"✓ Updated version in {file_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Update version across all project files."
+    )
+    parser.add_argument("new_version", help="New version string (e.g., '0.2.1')")
+
+    args = parser.parse_args()
+    new_version = args.new_version
+
+    # Base path to the project
+    project_path = (
+        Path(__file__).parent.parent / "libs" / "jupyter-deploy-tf-aws-ec2-base"
+    )
+
+    if not project_path.exists():
+        print(f"Error: Project path {project_path} not found")
+        sys.exit(1)
+
+    print(f"Updating all version references to: {new_version}\n")
+
+    # File paths
+    pyproject_path = project_path / "pyproject.toml"
+    init_path = project_path / "jupyter_deploy_tf_aws_ec2_base" / "__init__.py"
+    manifest_path = (
+        project_path / "jupyter_deploy_tf_aws_ec2_base" / "template" / "manifest.yaml"
+    )
+    main_tf_path = (
+        project_path
+        / "jupyter_deploy_tf_aws_ec2_base"
+        / "template"
+        / "engine"
+        / "main.tf"
+    )
+    jupyter_pyproject_path = (
+        project_path
+        / "jupyter_deploy_tf_aws_ec2_base"
+        / "template"
+        / "services"
+        / "jupyter"
+        / "pyproject.jupyter.toml"
+    )
+    jupyter_pixi_path = (
+        project_path
+        / "jupyter_deploy_tf_aws_ec2_base"
+        / "template"
+        / "services"
+        / "jupyter-pixi"
+        / "pixi.jupyter.toml"
+    )
+
+    # Update files
+    update_pyproject_toml(pyproject_path, new_version)
+    update_init_py(init_path, new_version)
+    update_manifest_yaml(manifest_path, new_version)
+    update_main_tf(main_tf_path, new_version)
+    update_jupyter_pyproject_toml(jupyter_pyproject_path, new_version)
+    update_jupyter_pixi_toml(jupyter_pixi_path, new_version)
+
+    print("\nVersion update completed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -255,6 +255,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "rich" },
     { name = "ruff" },
+    { name = "tomli-w" },
     { name = "typer" },
 ]
 
@@ -270,12 +271,13 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "rich", specifier = ">=10.11.0" },
     { name = "ruff", specifier = ">=0.11.8" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
     { name = "typer", specifier = ">=0.15.4" },
 ]
 
 [[package]]
 name = "jupyter-deploy-tf-aws-ec2-base"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "libs/jupyter-deploy-tf-aws-ec2-base" }
 dependencies = [
     { name = "boto3" },
@@ -680,6 +682,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
PR to prepare release of:
- `jupyter-deploy`: `0.2.1`
- `jupyter-deploy-tf-aws-ec2-base`: `0.2.1`

Also in this PR:
- add script to upgrade versions of base template in all places. Run as `uv run --script scripts/upgrade_base_template_version.py VERSION`