### PR TITLE
fix: docker buildx version, jd open errors

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit.sh.tftpl
@@ -30,6 +30,19 @@ if [[ "$OS" == "Amazon Linux" ]]; then
         systemctl enable docker
     else
         echo "Docker is already installed"
+
+        # Get latest buildx version dynamically
+        BUILDX_VERSION=$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+        echo "Installing buildx $${BUILDX_VERSION}..."
+
+        ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g')
+
+        mkdir -p /usr/local/lib/docker/cli-plugins
+        curl -SL "https://github.com/docker/buildx/releases/download/$${BUILDX_VERSION}/buildx-$${BUILDX_VERSION}.linux-$${ARCH}" \
+            -o /usr/local/lib/docker/cli-plugins/docker-buildx
+        chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
+
+        docker buildx version
     fi
     
     # Check if docker-compose is already installed

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -334,8 +334,7 @@ def open(
     """
     with cmd_utils.project_dir(project_dir):
         handler = OpenHandler()
-        url = handler.get_url()
-        handler.open_url(url)
+        handler.open()
 
 
 @runner.app.command()

--- a/libs/jupyter-deploy/jupyter_deploy/engine/engine_open.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/engine_open.py
@@ -33,12 +33,19 @@ class EngineOpenHandler:
         """Return the URL to access the notebook app, or the empty string if it cannot be resolved."""
         try:
             url_outdef = self.output_handler.get_declared_output_def("open_url", outdefs.StrTemplateOutputDefinition)
-        except (ValueError, KeyError, NotImplementedError, TypeError) as e:
+        except (ValueError, NotImplementedError, TypeError) as e:
             console = self.get_console()
             console.print(
                 f":x: Could not retrieve the declared value 'open_url' in the manifest. Error details: {e}",
                 style="red",
             )
+            return ""
+        except KeyError as _:
+            console = self.get_console()
+            console.print(":warning: URL not available.", style="yellow")
+            console.print("This is normal if you have not deployed the project.", style="yellow")
+            console.line()
+            console.print("Run [bold cyan]jd config[/] then [bold cyan]jd up[/].")
             return ""
 
         if not url_outdef.value:

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/show_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/show_handler.py
@@ -36,12 +36,12 @@ class ShowHandler(BaseProjectHandler):
         if show_info:
             console.line()
             self._show_project_basic_info()
-        if show_outputs:
-            console.line()
-            self._show_project_outputs()
         if show_variables:
             console.line()
             self._show_project_variables()
+        if show_outputs:
+            console.line()
+            self._show_project_outputs()
 
     def _show_project_basic_info(self) -> None:
         """Display basic project information."""

--- a/libs/jupyter-deploy/jupyter_deploy/manifest.py
+++ b/libs/jupyter-deploy/jupyter_deploy/manifest.py
@@ -123,6 +123,11 @@ class JupyterDeployManifestV1(BaseModel):
             raise NotImplementedError(f"No implementation found for command: {cmd_name}")
         return command
 
+    def has_command(self, cmd_name: str) -> bool:
+        """Return true if the manifest defines the command, false otherwise."""
+        command = next((cmd for cmd in (self.commands or []) if cmd.cmd == cmd_name), None)
+        return command is not None
+
     def get_requirements(self) -> list[JupyterDeployRequirementV1]:
         """Return the list of requirements as declared in the manifest."""
         return self.requirements or []

--- a/libs/jupyter-deploy/tests/unit/cli/test_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app.py
@@ -759,15 +759,10 @@ class TestOpenCommand(unittest.TestCase):
 
     def get_mock_open_handler(self) -> tuple[Mock, dict[str, Mock]]:
         mock_open_handler = Mock()
-        mock_get_url = Mock()
         mock_open_url = Mock()
 
-        mock_open_handler.get_url = mock_get_url
-        mock_open_handler.open_url = mock_open_url
-
-        mock_get_url.return_value = "https://example.com/jupyter"
-
-        return mock_open_handler, {"get_url": mock_get_url, "open_url": mock_open_url}
+        mock_open_handler.open = mock_open_url
+        return mock_open_handler, {"open": mock_open_url}
 
     @patch("jupyter_deploy.cli.app.OpenHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -782,8 +777,7 @@ class TestOpenCommand(unittest.TestCase):
 
         assert result.exit_code == 0
         mock_project_ctx_manager.assert_called_once_with(None)
-        mock_open_fns["get_url"].assert_called_once()
-        mock_open_fns["open_url"].assert_called_once_with("https://example.com/jupyter")
+        mock_open_fns["open"].assert_called_once()
 
     @patch("jupyter_deploy.cli.app.OpenHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -798,8 +792,7 @@ class TestOpenCommand(unittest.TestCase):
 
         assert result.exit_code == 0
         mock_project_ctx_manager.assert_called_once_with("/custom/path")
-        mock_open_fns["get_url"].assert_called_once()
-        mock_open_fns["open_url"].assert_called_once_with("https://example.com/jupyter")
+        mock_open_fns["open"].assert_called_once()
 
 
 class TestShowCommand(unittest.TestCase):

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_open_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_open_handler.py
@@ -1,7 +1,3 @@
-import json
-import os
-from collections.abc import Generator
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -9,18 +5,6 @@ import pytest
 from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.handlers.project.open_handler import OpenHandler
 from jupyter_deploy.manifest import JupyterDeployManifestV1
-
-# Define the constant locally since it was removed from tf_constants
-TF_STATEFILE = "terraform.tfstate"
-
-
-@pytest.fixture
-def mock_cwd(tmp_path: Path) -> Generator[Path, None, None]:
-    """Create a temporary directory and set it as the current working directory."""
-    original_dir = os.getcwd()
-    os.chdir(tmp_path)
-    yield tmp_path
-    os.chdir(original_dir)
 
 
 @pytest.fixture
@@ -34,21 +18,9 @@ def mock_manifest() -> JupyterDeployManifestV1:
                 "engine": "terraform",
                 "version": "1.0.0",
             },
+            "values": [{"name": "open_url", "source": "output", "source-key": "jupyter_url"}],
         }
     )
-
-
-@pytest.fixture
-def mock_tfstate(mock_cwd: Path) -> Path:
-    """Create a mock terraform.tfstate file with a jupyter_url output."""
-    tfstate_content = {
-        "version": 4,
-        "outputs": {"jupyter_url": {"value": "https://example.com/jupyter", "type": "string"}},
-    }
-    tfstate_path = mock_cwd / TF_STATEFILE
-    with open(tfstate_path, "w") as f:
-        json.dump(tfstate_content, f)
-    return tfstate_path
 
 
 class TestOpenHandler:
@@ -61,44 +33,38 @@ class TestOpenHandler:
             assert handler.engine == EngineType.TERRAFORM
             assert handler.project_manifest == mock_manifest
 
-    def test_open_url_success(self, mock_manifest: JupyterDeployManifestV1) -> None:
-        """Test that open_url opens the URL in a web browser, and outputs the URL and cookies help message."""
+    def test_open_success(self, mock_manifest: JupyterDeployManifestV1) -> None:
+        """Test that open opens the URL in a web browser, and outputs the URL and cookies help message."""
         with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve_manifest:
             mock_retrieve_manifest.return_value = mock_manifest
             handler = OpenHandler()
             with (
+                patch.object(handler._handler, "get_url", return_value="https://example.com/jupyter") as mock_get_url,
                 patch("webbrowser.open", return_value=True) as mock_open,
                 patch.object(handler.console, "print") as mock_print,
             ):
-                handler.open_url("https://example.com/jupyter")
+                handler.open()
+                mock_get_url.assert_called_once()
                 mock_open.assert_called_once_with("https://example.com/jupyter", new=2)
-                assert mock_print.call_count == 2
+                assert mock_print.call_count >= 2
                 assert "Opening Jupyter" in mock_print.call_args_list[0][0][0]
-                assert "cookies" in mock_print.call_args_list[1][0][0]
-
-    def test_open_url_empty(self, mock_manifest: JupyterDeployManifestV1) -> None:
-        """Test that open_url doesn't do anything when the URL is empty."""
-        with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve_manifest:
-            mock_retrieve_manifest.return_value = mock_manifest
-            handler = OpenHandler()
-            with patch("webbrowser.open") as mock_open, patch.object(handler.console, "print") as mock_print:
-                handler.open_url("")
-                mock_open.assert_not_called()
-                mock_print.assert_not_called()
 
     def test_open_url_error(self, mock_manifest: JupyterDeployManifestV1) -> None:
         """Test that open_url handles errors when opening the URL."""
         with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve_manifest:
             mock_retrieve_manifest.return_value = mock_manifest
             handler = OpenHandler()
+
             with (
+                patch.object(handler._handler, "get_url", return_value="https://example.com/jupyter") as mock_get_url,
                 patch("webbrowser.open", return_value=False) as mock_open,
                 patch.object(handler.console, "print") as mock_print,
             ):
-                handler.open_url("https://example.com/jupyter")
+                handler.open()
+                mock_get_url.assert_called_once()
                 mock_open.assert_called_once_with("https://example.com/jupyter", new=2)
-                assert mock_print.call_count == 3
-                assert "Failed to open URL" in mock_print.call_args_list[2][0][0]
+                assert mock_print.call_count == 2
+                assert "Failed to open URL" in mock_print.call_args_list[1][0][0]
 
     def test_open_url_insecure(self, mock_manifest: JupyterDeployManifestV1) -> None:
         """Test that open_url doesn't open non-HTTPS urls."""
@@ -106,10 +72,12 @@ class TestOpenHandler:
             mock_retrieve_manifest.return_value = mock_manifest
             handler = OpenHandler()
             with (
+                patch.object(handler._handler, "get_url", return_value="http://example.com/jupyter") as mock_get_url,
                 patch("webbrowser.open") as mock_open,
                 patch.object(handler.console, "print") as mock_print,
             ):
-                handler.open_url("http://example.com/jupyter")
+                handler.open()
+                mock_get_url.assert_called_once()
                 mock_open.assert_not_called()
                 mock_print.assert_called_once()
                 assert "Insecure URL detected" in mock_print.call_args[0][0]

--- a/libs/jupyter-deploy/tests/unit/test_manifest.py
+++ b/libs/jupyter-deploy/tests/unit/test_manifest.py
@@ -58,3 +58,15 @@ class TestJupyterDeployManifestV1(unittest.TestCase):
         )
         with self.assertRaises(NotImplementedError):
             manifest.get_command("cmd_does_not_exist")
+
+    def test_manifest_v1_has_command_found(self) -> None:
+        manifest = JupyterDeployManifestV1(
+            **self.manifest_v1_parsed_content  # type: ignore
+        )
+        self.assertTrue(manifest.has_command("host.status"))
+
+    def test_manifest_v1_has_command_not_found(self) -> None:
+        manifest = JupyterDeployManifestV1(
+            **self.manifest_v1_parsed_content  # type: ignore
+        )
+        self.assertFalse(manifest.has_command("i.do.not.exist"))


### PR DESCRIPTION
This PR fixes a regression with a `docker buildx` incompatible version. It occurs when 1) the AMI has `docker` installed, and 2) the `buildx` version is out of date.

This is important because it affects x86 GPU instances.

Also in this PR:
- improve `jd open` devX by a) provide trouble-shooting steps, b) do not show a stack trace on `jd open` if the project wasn't deployed, and provide next steps
- improve `jd show` latency by showing `variables` before `outputs`

### Screenshots
**Trouble-shooting**
<img width="459" height="163" alt="Screenshot 2025-10-28 at 7 06 41 PM" src="https://github.com/user-attachments/assets/84338d5f-c2d3-495f-a6de-18cf9038e47d" />

**Not deployed**
<img width="389" height="74" alt="Screenshot 2025-10-28 at 7 07 03 PM" src="https://github.com/user-attachments/assets/3bcab05b-e1a0-462f-ac9d-f73aac715492" />

