### PR TITLE
release: v0.2.5

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/__init__.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/__init__.py
@@ -4,4 +4,4 @@ Relies on traefik for proxy, letsencrypt to generate the TLS certificate
 and external oauth provider.
 """
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/main.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/main.tf
@@ -15,7 +15,7 @@ resource "random_id" "postfix" {
 
 locals {
   template_name    = "tf-aws-ec2-base"
-  template_version = "0.2.4"
+  template_version = "0.2.5"
 
   default_tags = {
     Source   = "jupyter-deploy"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 template:
   name: tf-aws-ec2-base
   engine: terraform
-  version: 0.2.4
+  version: 0.2.5
 requirements:
 - name: terraform
 - name: awscli

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pixi.jupyter.toml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pixi.jupyter.toml.tftpl
@@ -11,7 +11,7 @@ platforms = [
     "linux-64",
 %{ endif ~}
 ]
-version = "0.2.4"
+version = "0.2.5"
 
 [tasks]
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pyproject.kernel.toml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pyproject.kernel.toml.tftpl
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-uv-kernel"
-version = "0.2.4"
+version = "0.2.5"
 description = "A jupyter kernel configuration managed by UV"
 requires-python = ">=3.12"
 dependencies = [

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml.tftpl
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter"
-version = "0.2.4"
+version = "0.2.5"
 description = "A basic image with jupyterlab and server-documents"
 requires-python = ">=3.12"
 dependencies = [

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.kernel.toml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.kernel.toml.tftpl
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-kernel"
-version = "0.2.4"
+version = "0.2.5"
 description = "A placeholder additional jupyter kernel configuration"
 requires-python = ">=3.12"
 dependencies = []

--- a/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-tf-aws-ec2-base"
-version = "0.2.4"
+version = "0.2.5"
 description = "Base terraform template to deploy a JupyterLab application on an AWS EC2 instance."
 readme = "README.md"
 authors = [

--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy"
-version = "0.2.4"
+version = "0.2.5"
 description = "CLI based tool to deploy Jupyter applications that integrates with infrastructure as code frameworks."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-deploy"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "libs/jupyter-deploy" }
 dependencies = [
     { name = "click" },
@@ -276,7 +276,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-tf-aws-ec2-base"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "libs/jupyter-deploy-tf-aws-ec2-base" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
This PR updates package patch versions:
- `jupyter-deploy`: v0.2.4 > v0.2.5
- `jupyter-deploy-tf-aws-ec2-base`: v0.2.4 > v0.2.5