### PR TITLE
fix: generalize docker buildx upgrade

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/local-await-server.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/local-await-server.sh.tftpl
@@ -233,7 +233,7 @@ main(){
             echo "Instance is ready!"
             ready=true
         elif [ "$INNER_STATUS" = "INITIALIZING" ]; then
-            echo "Instance still inializing..."
+            echo "Instance still initializing..."
             sleep 10
             attempts=$((attempts+1))
         elif [ "$INNER_STATUS" = "FETCHING_CERTIFICATES" ]; then

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/variables.tf
@@ -214,7 +214,7 @@ variable "oauth_allowed_org" {
 
     If specified, all members of this organization will be allowed access.
     
-    Enter "" if you don't want to authorize by organization membership, 
+    Leave blank if you don't want to authorize by organization membership, 
     but note that you must provide a value for oauth_allowed_usernames instead.
 
     Example: my-org
@@ -260,18 +260,15 @@ variable "oauth_app_client_id" {
     Client ID of the OAuth app that will control access to your jupyter notebooks.
 
     You must create an OAuth app first in your Github account.
-    1. Open GitHub: https://github.com/
-    2. Select your user icon on the top right
-    3. Select 'Settings'
-    4. On the left nav, select 'Developer settings'
-    5. Go to 'OAuth Apps'
-    6. Select 'New OAuth App'
-    7. Select an app name, for example: Jupyter-ec2-base
-    8. Input home page URL: https://<subdomain>.<domain>
-    9. Application description: add your description or leave blank
-    10. Authorization callback URL: https://<subdomain>.<domain>/oauth2/callback
-    11. Select 'Register Application'
-    12. Retrieve the Client ID
+    1. If you already have an OAuth app, select it from https://github.com/settings/developers
+    2. Or create a new OAuth app at: https://github.com/settings/applications/new
+    3. 'Application name': Jupyter-ec2-base or any name you choose
+    4. 'Homepage URL': https://<subdomain>.<domain>
+    5. 'Application description': add your description or leave blank
+    6. 'Authorization callback URL': https://<subdomain>.<domain>/oauth2/callback
+    7. Leave 'Enable Device Flow' unticked
+    8. Select 'Register Application'
+    9. Retrieve the Client ID
     Full instructions: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app
 
     Example: 00000aaaaa11111bbbbb

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit.sh.tftpl
@@ -30,20 +30,20 @@ if [[ "$OS" == "Amazon Linux" ]]; then
         systemctl enable docker
     else
         echo "Docker is already installed"
-
-        # Get latest buildx version dynamically
-        BUILDX_VERSION=$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-        echo "Installing buildx $${BUILDX_VERSION}..."
-
-        ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g')
-
-        mkdir -p /usr/local/lib/docker/cli-plugins
-        curl -SL "https://github.com/docker/buildx/releases/download/$${BUILDX_VERSION}/buildx-$${BUILDX_VERSION}.linux-$${ARCH}" \
-            -o /usr/local/lib/docker/cli-plugins/docker-buildx
-        chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
-
-        docker buildx version
     fi
+
+    # Get latest buildx version dynamically
+    BUILDX_VERSION=$(curl -s https://api.github.com/repos/docker/buildx/releases/latest | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+    echo "Installing buildx $${BUILDX_VERSION}..."
+
+    ARCH=$(uname -m | sed 's/x86_64/amd64/g' | sed 's/aarch64/arm64/g')
+
+    mkdir -p /usr/local/lib/docker/cli-plugins
+    curl -SL "https://github.com/docker/buildx/releases/download/$${BUILDX_VERSION}/buildx-$${BUILDX_VERSION}.linux-$${ARCH}" \
+        -o /usr/local/lib/docker/cli-plugins/docker-buildx
+    chmod +x /usr/local/lib/docker/cli-plugins/docker-buildx
+
+    docker buildx version
     
     # Check if docker-compose is already installed
     if ! command -v docker-compose &> /dev/null; then


### PR DESCRIPTION
This PR generalizes the fix for `docker buildx` install of #102 .

Also in this PR:
- improve inline help for `var.oauth_allowed_org` (leave blank instead of `""` which causes issues)
- improve inline help for `var.oauth_app_client_id` by providing direct links instead of `click here, click there` instructions
- fix typo in waiter script

### Testing
- deployed base template from scratch