### PR TITLE
fix: custom oauth error page

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-compose.yml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-compose.yml.tftpl
@@ -31,7 +31,7 @@ services:
       - "traefik.http.routers.jupyter.entrypoints=websecure"
       - "traefik.http.routers.jupyter.tls.certresolver=letsencrypt"
       - "traefik.http.services.jupyter.loadbalancer.server.port=8888"
-      - "traefik.http.routers.jupyter.middlewares=oauth-errors@docker,oauth-auth@docker"
+      - "traefik.http.routers.jupyter.middlewares=oauth-errors@docker,oauth-auth@docker,oauth-faults@docker"
     volumes:
       - /mnt/jupyter-data:/home/jovyan
       - /var/run/docker.sock:/var/run/docker.sock
@@ -79,6 +79,8 @@ services:
         tag: "docker.oauth"
     depends_on:
       - fluent-bit
+    volumes:
+      - ./static:/var/www/static:ro
     labels:
       - "traefik.enable=true"
       # Main service definition
@@ -101,11 +103,20 @@ services:
       - "traefik.http.middlewares.oauth-errors.errors.status=401-403"
       - "traefik.http.middlewares.oauth-errors.errors.service=oauth"
       - "traefik.http.middlewares.oauth-errors.errors.query=/oauth2/sign_in?rd={url}"
+      # 500 error handling middleware
+      - "traefik.http.middlewares.oauth-faults.errors.status=500-599"
+      - "traefik.http.middlewares.oauth-faults.errors.service=oauth"
+      - "traefik.http.middlewares.oauth-faults.errors.query=/static/oauth_error_500.html"
+      # Static files router have direct access without auth
+      - "traefik.http.routers.static.rule=Host(`${full_domain}`) && PathPrefix(`/static/`)"
+      - "traefik.http.routers.static.service=oauth"
+      - "traefik.http.routers.static.entrypoints=websecure"
+      - "traefik.http.routers.static.tls.certresolver=letsencrypt"
       # Auth domain routing
       - "traefik.http.routers.oauth.rule=Host(`${full_domain}`) && PathPrefix(`/oauth2/`)"
       - "traefik.http.routers.oauth.entrypoints=websecure"
       - "traefik.http.routers.oauth.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.oauth.middlewares=auth-headers@docker"
+      - "traefik.http.routers.oauth.middlewares=auth-headers@docker,oauth-faults@docker"
       - "traefik.http.routers.oauth.service=oauth"
     networks:
       - web
@@ -126,8 +137,11 @@ services:
       - OAUTH2_PROXY_COOKIE_SECRET=$${OAUTH_SECRET}
       - OAUTH2_PROXY_COOKIE_SECURE=true
       - OAUTH2_PROXY_REVERSE_PROXY=true
-      - OAUTH2_PROXY_UPSTREAMS=https://${full_domain}/
+      - OAUTH2_PROXY_UPSTREAMS=https://${full_domain}/,file:///var/www/static/#/static/
       - OAUTH2_PROXY_WHITELIST_DOMAINS=${full_domain}
+      - OAUTH2_PROXY_CUSTOM_TEMPLATES_DIR=/var/www/static
+      - OAUTH2_PROXY_SKIP_AUTH_ROUTE=/static/=
+      - OAUTH2_PROXY_SKIP_AUTH_REGEX=^/static/.*$
   traefik:
     image: traefik:latest
     container_name: traefik

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/static/oauth_error_500.html.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/static/oauth_error_500.html.tftpl
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Authorization Failure</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.6;
+            color: #333;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        h1 {
+            color: #e53e3e;
+            border-bottom: 1px solid #ddd;
+            padding-bottom: 10px;
+        }
+        h2 {
+            margin-top: 30px;
+            color: #2c5282;
+        }
+        .section {
+            background-color: #f8f9fa;
+            border-radius: 5px;
+            padding: 20px;
+            margin-bottom: 20px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+        }
+        ol {
+            padding-left: 25px;
+        }
+        li {
+            margin-bottom: 15px;
+        }
+        a {
+            color: #3182ce;
+            text-decoration: none;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+        code {
+            background-color: #edf2f7;
+            padding: 2px 4px;
+            border-radius: 3px;
+            font-family: monospace;
+        }
+    </style>
+</head>
+<body>
+    <h1>OAuth Access Failure</h1>
+
+    <div class="section">
+        <p>There was a problem authenticating your GitHub identity or verifying your access permissions.</p>
+    </div>
+
+    <h2>Troubleshooting</h2>
+
+    <div class="section">
+        <ol>
+            <li>
+                <strong>Verify your GitHub OAuth app configuration</strong>
+                <p>Check your GitHub OAuth application <a href="https://github.com/settings/developers" target="_blank">settings</a>:</p>
+                <ul>
+                    <li>Homepage URL must be <code>https://${full_domain}</code></li>
+                    <li>Authorization callback URL must be <code>https://${full_domain}/oauth2/callback</code></li>
+                </ul>
+            </li>
+
+            <li>
+                <strong>Verify that your GitHub identity is authorized to access the app</strong>
+                <p>Use the following Jupyter Deploy commands to verify the allowlisted entities:</p>
+                <ul>
+                    <li><code>jd users list</code> - List allowed users</li>
+                    <li><code>jd organization get</code> - Check allowed organization</li>
+                    <li><code>jd teams get</code> - Check allowed teams</li>
+                </ul>
+            </li>
+
+            <li>
+                <strong>When allowlisting with a GitHub organization, grant the OAuth app permission to access the organization</strong>
+                <p>You may need to reset the tokens already issued by GitHub:</p>
+                <ol>
+                    <li>Go to the <a href="https://github.com/settings/developers" target="_blank">OAuth app settings</a></li>
+                    <li>Find your OAuth app</li>
+                    <li>Click "Revoke all users token"</li>
+                    <li>Try to log on again</li>
+                </ol>
+            </li>
+        </ol>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This PR addresses #46 , and shows a custom error page with clear next steps so that users can self-serve when they see authorization error.

### Implementation
- add a `oauth2-faults` middleware on `oauth` service config in `docker-compose`
- capture 500 errors from `oauth` service with the fault middleware
- redirect to `/static/oauth_error_500.html`
- add an `.tftpl` static html file for authentication failure
-  upload the html to `/opt/docker/static` in the SsmDocument `CloudInit`

### Testing
- redeployed from scratch --> verified authorized path still works
- removed access --> verified error page correctly displayed

### Screenshot
<img width="967" height="948" alt="failure" src="https://github.com/user-attachments/assets/384e2e0a-51b7-4ba1-bda9-9417d90a6279" />
