### PR TITLE
fix: path conflict

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-compose.yml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-compose.yml.tftpl
@@ -106,9 +106,9 @@ services:
       # 500 error handling middleware
       - "traefik.http.middlewares.oauth-faults.errors.status=500-599"
       - "traefik.http.middlewares.oauth-faults.errors.service=oauth"
-      - "traefik.http.middlewares.oauth-faults.errors.query=/static/oauth_error_500.html"
+      - "traefik.http.middlewares.oauth-faults.errors.query=/oauth2-static/oauth_error_500.html"
       # Static files router have direct access without auth
-      - "traefik.http.routers.static.rule=Host(`${full_domain}`) && PathPrefix(`/static/`)"
+      - "traefik.http.routers.static.rule=Host(`${full_domain}`) && PathPrefix(`/oauth2-static/`)"
       - "traefik.http.routers.static.service=oauth"
       - "traefik.http.routers.static.entrypoints=websecure"
       - "traefik.http.routers.static.tls.certresolver=letsencrypt"
@@ -137,11 +137,11 @@ services:
       - OAUTH2_PROXY_COOKIE_SECRET=$${OAUTH_SECRET}
       - OAUTH2_PROXY_COOKIE_SECURE=true
       - OAUTH2_PROXY_REVERSE_PROXY=true
-      - OAUTH2_PROXY_UPSTREAMS=https://${full_domain}/,file:///var/www/static/#/static/
+      - OAUTH2_PROXY_UPSTREAMS=https://${full_domain}/,file:///var/www/static/#/oauth2-static/
       - OAUTH2_PROXY_WHITELIST_DOMAINS=${full_domain}
       - OAUTH2_PROXY_CUSTOM_TEMPLATES_DIR=/var/www/static
-      - OAUTH2_PROXY_SKIP_AUTH_ROUTE=/static/=
-      - OAUTH2_PROXY_SKIP_AUTH_REGEX=^/static/.*$
+      - OAUTH2_PROXY_SKIP_AUTH_ROUTE=/oauth2-static/=
+      - OAUTH2_PROXY_SKIP_AUTH_REGEX=^/oauth2-static/.*$
   traefik:
     image: traefik:latest
     container_name: traefik


### PR DESCRIPTION
Fix conflict introduced by #106  where `https://{full.domain}/static` conflicts w/ jupyter static path, leading to infinite spinner in some cases.