### PR TITLE
feat: server logs

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/README.md
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/README.md
@@ -246,6 +246,7 @@ This project:
 | `region` | The AWS region where the resources were created |
 | `server_status_check_document` | Name of the SSM document to verify if the server is ready to serve traffic |
 | `server_update_document` | Name of the SSM document to control server container operations |
+| `server_logs_document` | Name of the SSM document to print server logs to terminal |
 | `auth_org_unset_document` | Name of the SSM document to remove the allowlisted organization |
 | `auth_check_document` | Name of the SSM document to view authorized users, teams and organization |
 | `auth_users_update_document` | Name of the SSM document to change the authorized users |

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/outputs.tf
@@ -79,6 +79,12 @@ output "server_update_document" {
   value       = aws_ssm_document.server_update.name
 }
 
+# server.logs CLI handling
+output "server_logs_document" {
+  description = "Name of the SSM document to retrieve server container logs."
+  value       = aws_ssm_document.server_logs.name
+}
+
 # Resources that should not be destroyed by `jd down`
 output "persisting_resources" {
   description = "List of identifiers of resources that should not be destroyed (have persist=true)."

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -17,6 +17,10 @@ values:
 - name: persisting_resources
   source: output
   source-key: persisting_resources
+services:
+- jupyter
+- traefik
+- oauth
 commands:
 - cmd: host.status
   sequence:
@@ -134,6 +138,29 @@ commands:
     - api-attribute: service
       source: cli
       source-key: service
+- cmd: server.logs
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: server_logs_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: service
+      source: cli
+      source-key: service
+    - api-attribute: extra
+      source: cli
+      source-key: extra
+  results:
+  - result-name: server.logs
+    source: result
+    source-key: '[0].StandardOutputContent'
+  - result-name: server.errors
+    source: result
+    source-key: '[0].StandardErrorContent'
 - cmd: users.add
   sequence:
   - api-name: aws.ssm.wait-command-sync

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/static/oauth_error_500.html.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/static/oauth_error_500.html.tftpl
@@ -25,15 +25,12 @@
         .section {
             background-color: #f8f9fa;
             border-radius: 5px;
-            padding: 20px;
+            padding: 10px;
             margin-bottom: 20px;
             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
         }
-        ol {
-            padding-left: 25px;
-        }
         li {
-            margin-bottom: 15px;
+            margin-bottom: 10px;
         }
         a {
             color: #3182ce;
@@ -51,7 +48,7 @@
     </style>
 </head>
 <body>
-    <h1>OAuth Access Failure</h1>
+    <h1>Authorization Failure</h1>
 
     <div class="section">
         <p>There was a problem authenticating your GitHub identity or verifying your access permissions.</p>
@@ -63,10 +60,12 @@
         <ol>
             <li>
                 <strong>Verify your GitHub OAuth app configuration</strong>
-                <p>Check your GitHub OAuth application <a href="https://github.com/settings/developers" target="_blank">settings</a>:</p>
+                <p>Find your OAuth app on GitHub <a href="https://github.com/settings/developers" target="_blank">settings page</a>:</p>
                 <ul>
                     <li>Homepage URL must be <code>https://${full_domain}</code></li>
                     <li>Authorization callback URL must be <code>https://${full_domain}/oauth2/callback</code></li>
+                    <li>Verify that the OAuth app Client ID and Client Secret match your Jupyter Deploy config</li>
+                    <li>Look at your oauth service logs with <code>jd server logs -s oauth</code></li>
                 </ul>
             </li>
 
@@ -74,21 +73,20 @@
                 <strong>Verify that your GitHub identity is authorized to access the app</strong>
                 <p>Use the following Jupyter Deploy commands to verify the allowlisted entities:</p>
                 <ul>
-                    <li><code>jd users list</code> - List allowed users</li>
-                    <li><code>jd organization get</code> - Check allowed organization</li>
-                    <li><code>jd teams get</code> - Check allowed teams</li>
+                    <li><code>jd users list</code> - Check allowlisted GitHub usernames</li>
+                    <li><code>jd organization get</code> - Check allowlisted GitHub organization</li>
+                    <li><code>jd teams list</code> - Check allowlisted GitHub teams of the organization</li>
                 </ul>
             </li>
 
             <li>
                 <strong>When allowlisting with a GitHub organization, grant the OAuth app permission to access the organization</strong>
                 <p>You may need to reset the tokens already issued by GitHub:</p>
-                <ol>
-                    <li>Go to the <a href="https://github.com/settings/developers" target="_blank">OAuth app settings</a></li>
-                    <li>Find your OAuth app</li>
-                    <li>Click "Revoke all users token"</li>
+                <ul>
+                    <li>Find your OAuth app on GitHub <a href="https://github.com/settings/developers" target="_blank">settings page</a></li>
+                    <li>Click <code>Revoke all users token</code></li>
                     <li>Try to log on again</li>
-                </ol>
+                </ul>
             </li>
         </ol>
     </div>

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_manifest_yaml.py
@@ -13,8 +13,9 @@ class TestManifest(unittest.TestCase):
     MANIFEST: dict[str, Any] | None = None
     EXPECTED_REQUIREMENTS = ["terraform", "awscli", "jq"]
     EXPECTED_VALUES = ["open_url", "aws_region", "persisting_resources"]
+    EXPECTED_SERVICES = ["jupyter", "traefik", "oauth"]
     EXPECTED_HOST_COMMANDS = ["host.status", "host.start", "host.stop", "host.restart", "host.connect"]
-    EXPECTED_SERVER_COMMANDS = ["server.status", "server.start", "server.stop", "server.restart"]
+    EXPECTED_SERVER_COMMANDS = ["server.status", "server.start", "server.stop", "server.restart", "server.logs"]
     EXPECTED_USERS_COMMANDS = ["users.list", "users.add", "users.remove", "users.set"]
     EXPECTED_TEAMS_COMMANDS = ["teams.list", "teams.add", "teams.remove", "teams.set"]
     EXPECTED_ORGANIZATION_COMMANDS = ["organization.get", "organization.set", "organization.unset"]
@@ -65,6 +66,17 @@ class TestManifest(unittest.TestCase):
 
         for expected_val in self.EXPECTED_VALUES:
             self.assertIn(expected_val, value_names, f"Expected value {expected_val} missing from manifest")
+
+    def test_all_expected_services_declared(self) -> None:
+        """Test that all expected services are declared in the manifest."""
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None, test setup failed")
+            return
+
+        services = self.MANIFEST.get("services", [])
+
+        for expected_service in self.EXPECTED_SERVICES:
+            self.assertIn(expected_service, services, f"Expected value {expected_service} missing from manifest")
 
     def test_all_expected_host_commands_declared(self) -> None:
         """Test that all expected host commands are declared in the manifest."""

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
@@ -138,6 +138,10 @@ class AwsSsmRunner(InstructionRunner):
             "StandardOutputContent": StrResolvedInstructionResult(
                 result_name="StandardOutputContent", value=command_stdout
             ),
+            "StandardErrorContent": StrResolvedInstructionResult(
+                result_name="StandardErrorContent",
+                value=command_stderr,
+            ),
         }
 
     def _start_session(

--- a/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
+++ b/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
@@ -13,6 +13,10 @@ values:
   - name: "aws_region"
     source: "output"
     source-key: "region"
+services:
+  - jupyter
+  - traefik
+  - oauth
 commands:
   - cmd: "host.status"
     sequence:
@@ -123,6 +127,29 @@ commands:
           - api-attribute: "service"
             source: "cli"
             source-key: "service"
+  - cmd: server.logs
+    sequence:
+    - api-name: aws.ssm.wait-command-sync
+      arguments:
+      - api-attribute: document_name
+        source: output
+        source-key: server_logs_document
+      - api-attribute: instance_id
+        source: output
+        source-key: instance_id
+      - api-attribute: service
+        source: cli
+        source-key: service
+      - api-attribute: extra
+        source: cli
+        source-key: extra
+    results:
+    - result-name: server.logs
+      source: result
+      source-key: '[0].StandardOutputContent'
+    - result-name: server.errors
+      source: result
+      source-key: '[0].StandardErrorContent'
   - cmd: "users.add"
     sequence:
       - api-name: "aws.ssm.wait-command-sync"

--- a/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ssm_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ssm_runner.py
@@ -213,6 +213,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
         mock_send_cmd.return_value = {
             "Status": "Success",
             "StandardOutputContent": "Command output",
+            "StandardErrorContent": "Command error",
         }
 
         resolved_arguments: dict[str, ResolvedInstructionArgument] = {
@@ -242,6 +243,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
 
         self.assertEqual(result["Status"].value, "Success")
         self.assertEqual(result["StandardOutputContent"].value, "Command output")
+        self.assertEqual(result["StandardErrorContent"].value, "Command error")
         # There should be at least one print call (for the execute info)
         self.assertGreaterEqual(console.print.call_count, 1)
         # Find the call with the document and instance info

--- a/libs/jupyter-deploy/tests/unit/test_manifest.py
+++ b/libs/jupyter-deploy/tests/unit/test_manifest.py
@@ -5,7 +5,7 @@ from typing import Any
 import yaml
 
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.manifest import JupyterDeployManifestV1
+from jupyter_deploy.manifest import InvalidServiceError, JupyterDeployManifestV1
 
 
 class TestJupyterDeployManifestV1(unittest.TestCase):
@@ -70,3 +70,35 @@ class TestJupyterDeployManifestV1(unittest.TestCase):
             **self.manifest_v1_parsed_content  # type: ignore
         )
         self.assertFalse(manifest.has_command("i.do.not.exist"))
+
+    def test_manifest_v1_get_services(self) -> None:
+        manifest = JupyterDeployManifestV1(
+            **self.manifest_v1_parsed_content  # type: ignore
+        )
+        self.assertListEqual(manifest.get_services(), ["jupyter", "traefik", "oauth"])
+
+    def test_manifest_v1_get_validated_service(self) -> None:
+        manifest = JupyterDeployManifestV1(
+            **self.manifest_v1_parsed_content  # type: ignore
+        )
+        for svc in ["jupyter", "traefik", "oauth"]:
+            self.assertEqual(manifest.get_validated_service(svc), svc)
+
+    def test_manifest_v1_get_validated_service_default_return_first_value(self) -> None:
+        manifest = JupyterDeployManifestV1(
+            **self.manifest_v1_parsed_content  # type: ignore
+        )
+        self.assertEqual(manifest.get_validated_service("default"), "jupyter")
+
+    def test_manifest_v1_get_validated_service_all_allowed(self) -> None:
+        manifest = JupyterDeployManifestV1(
+            **self.manifest_v1_parsed_content  # type: ignore
+        )
+        self.assertEqual(manifest.get_validated_service("all", allow_all=True), "all")
+
+    def test_manifest_v1_get_validated_service_all_disallowed(self) -> None:
+        manifest = JupyterDeployManifestV1(
+            **self.manifest_v1_parsed_content  # type: ignore
+        )
+        with self.assertRaises(InvalidServiceError):
+            manifest.get_validated_service("all", allow_all=False)


### PR DESCRIPTION
This PR adds new `jd server logs` commands to the CLI and update the base template to support it.

### User experience
- `jd server logs` --> defaults  to `jupyter` container logs
- `jd server logs -s <name>` --> target a specific container, e.g. `jd server logs -s oauth`
- supports `docker exec` style additional parameters, e.g.
    - `jd server logs -s oauth -- -n 100` (100 last logs)
    - `jd server logs -s traefik -- "| grep 404"`

### Implementation
- add CLI route
- add server handler
- update `SsmSendCommand` to return stdErr as well
- add a dedicated SSM Document to the base template that does `docker logs {{service}}`
- improve the oauth2 error page to refer to the `jd server logs -s oauth` to help debug

### Testing
- tested end-to-end with a new deployment from scratch
- testing w/ and w/o access --> works as expected
- tested w/ incognito window w/ and w/o access --> login flow works as expected

### Screenshots
**Unauthorized**
<img width="899" height="937" alt="Failure" src="https://github.com/user-attachments/assets/db592c5f-3e0a-44b8-acbd-51d7fb723db3" />

**Server logs command**
<img width="934" height="253" alt="server-help" src="https://github.com/user-attachments/assets/c7557af1-ca80-48dd-b4fc-17ca815db499" />

**Server logs command help**
<img width="1256" height="366" alt="server-logs" src="https://github.com/user-attachments/assets/1c42c835-21a9-4c58-a903-8a31f57c6114" />
