### PR TITLE
feat: server connect, server/host exec

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/README.md
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/README.md
@@ -248,6 +248,8 @@ This project:
 | `server_status_check_document` | Name of the SSM document to verify if the server is ready to serve traffic |
 | `server_update_document` | Name of the SSM document to control server container operations |
 | `server_logs_document` | Name of the SSM document to print server logs to terminal |
+| `server_exec_document` | Name of the SSM document to execute commands inside server containers |
+| `server_connect_document` | Name of the SSM document to start interactive shell sessions inside server containers (jupyter or traefik) |
 | `auth_org_unset_document` | Name of the SSM document to remove the allowlisted organization |
 | `auth_check_document` | Name of the SSM document to view authorized users, teams and organization |
 | `auth_users_update_document` | Name of the SSM document to change the authorized users |

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/outputs.tf
@@ -91,6 +91,18 @@ output "server_logs_document" {
   value       = aws_ssm_document.server_logs.name
 }
 
+# server.exec CLI handling
+output "server_exec_document" {
+  description = "Name of the SSM document to execute commands inside server containers."
+  value       = aws_ssm_document.server_exec.name
+}
+
+# server.connect CLI handling
+output "server_connect_document" {
+  description = "Name of the SSM document to start interactive shell sessions inside server containers (jupyter or traefik)."
+  value       = aws_ssm_document.server_connect.name
+}
+
 # Resources that should not be destroyed by `jd down`
 output "persisting_resources" {
   description = "List of identifiers of resources that should not be destroyed (have persist=true)."

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -76,6 +76,23 @@ commands:
     - api-attribute: target_id
       source: output
       source-key: instance_id
+- cmd: host.exec
+  sequence:
+  - api-name: aws.ssm.wait-default-shell-command-sync
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: commands
+      source: cli
+      source-key: commands
+  results:
+  - result-name: host.exec.stdout
+    source: result
+    source-key: '[0].StandardOutputContent'
+  - result-name: host.exec.stderr
+    source: result
+    source-key: '[0].StandardErrorContent'
 - cmd: server.status
   sequence:
   - api-name: aws.ssm.wait-command-sync
@@ -161,6 +178,42 @@ commands:
   - result-name: server.errors
     source: result
     source-key: '[0].StandardErrorContent'
+- cmd: server.exec
+  sequence:
+  - api-name: aws.ssm.wait-command-sync
+    arguments:
+    - api-attribute: document_name
+      source: output
+      source-key: server_exec_document
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+    - api-attribute: service
+      source: cli
+      source-key: service
+    - api-attribute: commands
+      source: cli
+      source-key: commands
+  results:
+  - result-name: server.exec.stdout
+    source: result
+    source-key: '[0].StandardOutputContent'
+  - result-name: server.exec.stderr
+    source: result
+    source-key: '[0].StandardErrorContent'
+- cmd: server.connect
+  sequence:
+  - api-name: aws.ssm.start-session
+    arguments:
+    - api-attribute: target_id
+      source: output
+      source-key: instance_id
+    - api-attribute: document_name
+      source: output
+      source-key: server_connect_document
+    - api-attribute: service
+      source: cli
+      source-key: service
 - cmd: users.add
   sequence:
   - api-name: aws.ssm.wait-command-sync

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_server.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_server.py
@@ -1,3 +1,4 @@
+import pexpect
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.oauth2_proxy.github import GitHubOAuth2ProxyApplication
 
@@ -115,3 +116,129 @@ def test_server_logs_piped_command(e2e_deployment: EndToEndDeployment) -> None:
 
     # Assert we got exactly 5 log entries
     assert len(log_entries) == 5, f"Expected exactly 5 log entries with --tail 5, got {len(log_entries)}"
+
+
+def test_server_exec_default_to_jupyter(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that server exec defaults to jupyter service when no service is specified."""
+    # Prerequisites
+    e2e_deployment.ensure_server_running()
+
+    # Execute whoami command without specifying service (should default to jupyter)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", "whoami"])
+
+    # Verify we got output and we're in the jupyter container (jovyan user)
+    assert result.stdout, "Expected non-empty stdout"
+    assert "jovyan" in result.stdout, f"Expected 'jovyan' user (jupyter service), got: {result.stdout}"
+
+
+def test_server_exec_all_services(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that exec works for all services (jupyter, traefik, oauth)."""
+    # Prerequisites
+    e2e_deployment.ensure_server_running()
+
+    # Test jupyter service with whoami (available in jupyter container)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "-s", "jupyter", "--", "whoami"])
+    assert result.stdout, "Expected non-empty stdout for jupyter service"
+    assert "jovyan" in result.stdout, f"Expected 'jovyan' user in jupyter, got: {result.stdout}"
+
+    # Test traefik service with ps | grep traefik
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "server", "exec", "-s", "traefik", "--", "ps", "|", "grep", "traefik"]
+    )
+    assert result.stdout, "Expected non-empty stdout for traefik service"
+    assert "traefik" in result.stdout, f"Expected 'traefik' process in output, got: {result.stdout}"
+
+    # Test oauth service with oauth2-proxy --version (distroless container with no shell)
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "server", "exec", "-s", "oauth", "--", "oauth2-proxy", "--version"]
+    )
+    assert result.stdout, "Expected non-empty stdout for oauth service"
+    assert "oauth2-proxy" in result.stdout, f"Expected 'oauth2-proxy' version in output, got: {result.stdout}"
+
+
+def test_server_exec_failed_command(e2e_deployment: EndToEndDeployment) -> None:
+    """Test server exec with a command that fails."""
+    # Prerequisites
+    e2e_deployment.ensure_server_running()
+
+    # Execute non-existent command in jupyter service
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "server", "exec", "-s", "jupyter", "--", "command_that_does_not_exist"]
+    )
+
+    # Command should complete but indicate failure
+    # Check for error message in output (could be in stdout or stderr)
+    output = result.stdout + result.stderr
+    assert "not found" in output or "command" in output.lower(), f"Expected error message in output, got: {output}"
+
+
+def test_server_connect_default_service(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that we can connect to the default service (jupyter) via SSM and run a simple command."""
+    # Prerequisites
+    e2e_deployment.ensure_server_running()
+    e2e_deployment.wait_for_ssm_ready()
+
+    # Start an interactive jd server connect session (no -s flag, should default to jupyter)
+    with e2e_deployment.cli.spawn_interactive_session("jupyter-deploy server connect") as session:
+        # Wait for the session to start
+        session.expect("Starting SSM session", timeout=10)
+
+        # Send whoami command
+        session.sendline("whoami")
+
+        # Expect jovyan in the output (jupyter container user)
+        session.expect("jovyan", timeout=5)
+
+        # Exit the session
+        session.sendline("exit")
+
+        # Wait for the session to close
+        session.expect(pexpect.EOF, timeout=5)
+
+
+def test_server_connect_jupyter(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that we can connect to the jupyter service via SSM and run a simple command."""
+    # Prerequisites
+    e2e_deployment.ensure_server_running()
+    e2e_deployment.wait_for_ssm_ready()
+
+    # Start an interactive jd server connect session with explicit -s jupyter
+    with e2e_deployment.cli.spawn_interactive_session("jupyter-deploy server connect -s jupyter") as session:
+        # Wait for the session to start
+        session.expect("Starting SSM session", timeout=10)
+
+        # Send whoami command
+        session.sendline("whoami")
+
+        # Expect jovyan in the output (jupyter container user)
+        session.expect("jovyan", timeout=5)
+
+        # Exit the session
+        session.sendline("exit")
+
+        # Wait for the session to close
+        session.expect(pexpect.EOF, timeout=5)
+
+
+def test_server_connect_traefik(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that we can connect to the traefik service via SSM and run a simple command."""
+    # Prerequisites
+    e2e_deployment.ensure_server_running()
+    e2e_deployment.wait_for_ssm_ready()
+
+    # Start an interactive jd server connect session with explicit -s traefik
+    with e2e_deployment.cli.spawn_interactive_session("jupyter-deploy server connect -s traefik") as session:
+        # Wait for the session to start
+        session.expect("Starting SSM session", timeout=10)
+
+        # Send ps command
+        session.sendline("ps")
+
+        # Expect traefik in the output (traefik process)
+        session.expect("traefik", timeout=5)
+
+        # Exit the session
+        session.sendline("exit")
+
+        # Wait for the session to close
+        session.expect(pexpect.EOF, timeout=5)

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
@@ -102,3 +102,42 @@ class ServerHandler(BaseProjectHandler):
         stdout = runner.get_result_value(command, "server.logs", str)
         stderr = runner.get_result_value(command, "server.errors", str)
         return stdout, stderr
+
+    def exec_command(self, service: str, command_args: list[str]) -> tuple[str, str]:
+        """Execute a command inside a service container, return the stdout and stderr."""
+        command = self.project_manifest.get_command("server.exec")
+        validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
+        console = self.get_console()
+        runner = cmd_runner.ManifestCommandRunner(
+            console=console, output_handler=self._output_handler, variable_handler=self._variable_handler
+        )
+
+        # Join command arguments into a single command string for docker exec
+        command_string = " ".join(command_args)
+
+        runner.run_command_sequence(
+            command,
+            cli_paramdefs={
+                "service": StrResolvedCliParameter(parameter_name="service", value=validated_service),
+                "commands": StrResolvedCliParameter(parameter_name="commands", value=command_string),
+            },
+        )
+        stdout = runner.get_result_value(command, "server.exec.stdout", str)
+        stderr = runner.get_result_value(command, "server.exec.stderr", str)
+        return stdout, stderr
+
+    def connect(self, service: str) -> None:
+        """Start an interactive shell session inside a service container."""
+        command = self.project_manifest.get_command("server.connect")
+        validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
+        console = self.get_console()
+        runner = cmd_runner.ManifestCommandRunner(
+            console=console, output_handler=self._output_handler, variable_handler=self._variable_handler
+        )
+
+        runner.run_command_sequence(
+            command,
+            cli_paramdefs={
+                "service": StrResolvedCliParameter(parameter_name="service", value=validated_service),
+            },
+        )

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
@@ -26,6 +26,7 @@ class AwsSsmInstruction(str, Enum):
     """AWS SSM instructions accessible from manifest.commands[].sequence[].api-name."""
 
     SEND_CMD_AND_WAIT_SYNC = "wait-command-sync"
+    SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC = "wait-default-shell-command-sync"
     START_SESSION = "start-session"
 
 
@@ -144,6 +145,67 @@ class AwsSsmRunner(InstructionRunner):
             ),
         }
 
+    def _send_cmd_to_one_instance_using_default_shell_doc_and_wait_sync(
+        self,
+        resolved_arguments: dict[str, ResolvedInstructionArgument],
+        console: rich_console.Console,
+    ) -> dict[str, ResolvedInstructionResult]:
+        # retrieve required parameters
+        instance_id_arg = require_arg(resolved_arguments, "instance_id", StrResolvedInstructionArgument)
+
+        # retrieve optional timeout and wait parameters
+        timeout_seconds = retrieve_optional_arg(
+            resolved_arguments, "timeout_seconds", IntResolvedInstructionArgument, default_value=30
+        )
+        wait_after_send_seconds = retrieve_optional_arg(
+            resolved_arguments, "wait_after_send_seconds", IntResolvedInstructionArgument, default_value=2
+        )
+
+        # retrieve commands parameter (required for this instruction)
+        commands_arg = require_arg(resolved_arguments, "commands", ListStrResolvedInstructionArgument)
+
+        # verify SSM agent connection status
+        if not self._verify_ec2_instance_accessible(instance_id=instance_id_arg.value, console=console):
+            raise InterruptInstructionError
+
+        # provide information to the user
+        console.print(f"Executing command on instance '{instance_id_arg.value}'...")
+
+        response = ssm_command.send_cmd_to_one_instance_and_wait_sync(
+            self.client,
+            document_name="AWS-RunShellScript",
+            instance_id=instance_id_arg.value,
+            timeout_seconds=timeout_seconds.value,
+            wait_after_send_seconds=wait_after_send_seconds.value,
+            commands=commands_arg.value,
+        )
+        command_status = response["Status"]
+        command_stdout = response.get("StandardOutputContent", "").rstrip()
+        command_stderr = response.get("StandardErrorContent", "").rstrip()
+
+        if command_status == "Failed":
+            console.print(":x: command execution failed.", style="red")
+            console.line()
+            if command_stderr:
+                console.print("StandardErrorContent:", style="red")
+                console.line()
+                console.print(command_stderr, style="red")
+            if command_stdout:
+                console.print("StandardOutputContent:", style="red")
+                console.line()
+                console.print(command_stdout, style="red")
+
+        return {
+            "Status": StrResolvedInstructionResult(result_name="Status", value=command_status),
+            "StandardOutputContent": StrResolvedInstructionResult(
+                result_name="StandardOutputContent", value=command_stdout
+            ),
+            "StandardErrorContent": StrResolvedInstructionResult(
+                result_name="StandardErrorContent",
+                value=command_stderr,
+            ),
+        }
+
     def _start_session(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
@@ -151,6 +213,11 @@ class AwsSsmRunner(InstructionRunner):
     ) -> dict[str, ResolvedInstructionResult]:
         # retrieve required parameters
         target_id_arg = require_arg(resolved_arguments, "target_id", StrResolvedInstructionArgument)
+
+        # retrieve optional parameters
+        document_name_arg = resolved_arguments.get("document_name")
+        if document_name_arg and not isinstance(document_name_arg, StrResolvedInstructionArgument):
+            raise TypeError(f"Expected StrResolvedInstructionArgument for document_name, got {type(document_name_arg)}")
 
         # verify installation
         console.rule()
@@ -183,6 +250,22 @@ class AwsSsmRunner(InstructionRunner):
         start_session_cmds = START_SESSION_CMD.copy()
         start_session_cmds.extend(["--target", target_id_arg.value])
 
+        # Add optional document name if provided
+        if document_name_arg:
+            start_session_cmds.extend(["--document-name", document_name_arg.value])
+
+            # Build parameters string from all remaining resolved arguments
+            # (excluding target_id and document_name which are handled separately)
+            parameters: list[str] = []
+            for arg_name, arg_value in resolved_arguments.items():
+                if arg_name not in ["target_id", "document_name"] and isinstance(
+                    arg_value, StrResolvedInstructionArgument
+                ):
+                    parameters.append(f"{arg_name}={arg_value.value}")
+
+            if parameters:
+                start_session_cmds.extend(["--parameters", ",".join(parameters)])
+
         session_shell_retcode, session_shell_timedout = cmd_utils.run_cmd_and_pipe_to_terminal(start_session_cmds)
 
         if session_shell_retcode:
@@ -202,6 +285,11 @@ class AwsSsmRunner(InstructionRunner):
     ) -> dict[str, ResolvedInstructionResult]:
         if instruction_name == AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC:
             return self._send_cmd_to_one_instance_and_wait_sync(
+                resolved_arguments=resolved_arguments,
+                console=console,
+            )
+        elif instruction_name == AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC:
+            return self._send_cmd_to_one_instance_using_default_shell_doc_and_wait_sync(
                 resolved_arguments=resolved_arguments,
                 console=console,
             )

--- a/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
@@ -378,3 +378,138 @@ class TestHostConnectCommand(unittest.TestCase):
 
         # Assert
         self.assertNotEqual(result.exit_code, 0)
+
+
+class TestHostExecCommand(unittest.TestCase):
+    def get_mock_host_handler(self) -> tuple[Mock, dict[str, Mock]]:
+        mock_exec_command = Mock()
+        mock_get_console = Mock()
+        mock_host_handler = Mock()
+
+        mock_host_handler.exec_command = mock_exec_command
+        mock_host_handler.get_console = mock_get_console
+
+        mock_exec_command.return_value = ("stdout output", "stderr output")
+        mock_get_console.return_value = Mock()
+
+        return mock_host_handler, {
+            "exec_command": mock_exec_command,
+            "get_console": mock_get_console,
+        }
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_help_includes_exec_command(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue("exec" in result.stdout, "exec command should appear in help")
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_instantiates_handler_and_calls_exec_command(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        # Setup
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["exec", "--", "df", "-h"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_host_handler_class.assert_called_once()
+        mock_handler_fns["exec_command"].assert_called_once_with(["df", "-h"])
+        mock_handler_fns["get_console"].assert_called_once()
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_command_args_to_handler(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        # Setup
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["exec", "--", "echo", "hello world"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["exec_command"].assert_called_once_with(["echo", "hello world"])
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_prints_stdout_and_stderr(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        # Setup
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+
+        mock_console = Mock()
+        mock_handler_fns["get_console"].return_value = mock_console
+        mock_handler_fns["exec_command"].return_value = ("test stdout", "test stderr")
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["exec", "--", "whoami"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_console.print.assert_called()
+        print_calls = [str(call) for call in mock_console.print.mock_calls]
+        self.assertTrue(any("test stdout" in call for call in print_calls))
+        self.assertTrue(any("test stderr" in call for call in print_calls))
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_switches_dir_when_passed_project_path(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        # Setup
+        mock_host_handler, _ = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["exec", "--path", "/test/project/path", "--", "whoami"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with("/test/project/path")
+
+    @patch("jupyter_deploy.cli.host_app.Console")
+    def test_fails_when_no_command_provided(self, mock_console_class: Mock) -> None:
+        # Setup
+        mock_console = Mock()
+        mock_console_class.return_value = mock_console
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["exec"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 1)
+        mock_console_class.assert_called_once()
+        mock_console.print.assert_called()
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_raises_when_handler_exec_command_raises(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        # Setup
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_handler_fns["exec_command"].side_effect = Exception("Test error")
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["exec", "--", "whoami"])
+
+        # Assert
+        self.assertNotEqual(result.exit_code, 0)

--- a/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
@@ -592,3 +592,261 @@ class TestServerLogsCmd(unittest.TestCase):
 
         # Assert
         self.assertNotEqual(result.exit_code, 0)
+
+
+class TestServerExecCmd(unittest.TestCase):
+    def get_mock_server_handler(self) -> tuple[Mock, dict[str, Mock]]:
+        """Return a mock server handler."""
+        mock_exec_command = Mock()
+        mock_get_console = Mock()
+        mock_server_handler = Mock()
+
+        mock_server_handler.exec_command = mock_exec_command
+        mock_server_handler.get_console = mock_get_console
+
+        mock_exec_command.return_value = ("stdout output", "stderr output")
+        mock_get_console.return_value = Mock()
+
+        return mock_server_handler, {
+            "exec_command": mock_exec_command,
+            "get_console": mock_get_console,
+        }
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_help_includes_exec_command(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue("exec" in result.stdout, "exec command should appear in help")
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_instantiates_handler_and_calls_exec_command(
+        self, mock_project_dir: Mock, mock_server_handler_class: Mock
+    ) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_console = Mock()
+        mock_handler_fns["get_console"].return_value = mock_console
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "pwd"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_server_handler_class.assert_called_once()
+        mock_handler_fns["exec_command"].assert_called_once_with(service="jupyter", command_args=["pwd"])
+        mock_handler_fns["get_console"].assert_called_once()
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_command_args_to_handler(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "ls", "-la"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["exec_command"].assert_called_once_with(service="jupyter", command_args=["ls", "-la"])
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_prints_stdout_and_stderr(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+
+        mock_console = Mock()
+        mock_handler_fns["get_console"].return_value = mock_console
+        mock_handler_fns["exec_command"].return_value = ("test stdout", "test stderr")
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "whoami"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_console.print.assert_called()
+        print_calls = [str(call) for call in mock_console.print.mock_calls]
+        self.assertTrue(any("test stdout" in call for call in print_calls))
+        self.assertTrue(any("test stderr" in call for call in print_calls))
+
+    @patch("jupyter_deploy.cli.servers_app.Console")
+    def test_fails_when_no_command_provided(self, mock_console_class: Mock) -> None:
+        # Setup
+        mock_console = Mock()
+        mock_console_class.return_value = mock_console
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["exec", "-s", "jupyter"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 1)
+        mock_console_class.assert_called_once()
+        mock_console.print.assert_called()
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_prints_error_when_invalid_service(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_handler_fns["exec_command"].side_effect = InvalidServiceError(
+            "Invalid service, use one of ['jupyter', 'traefik']"
+        )
+
+        mock_console = Mock()
+        mock_handler_fns["get_console"].return_value = mock_console
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["exec", "-s", "invalid_service", "--", "pwd"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 1)
+        mock_console.print.assert_called_once()
+        mock_call = mock_console.print.mock_calls[0]
+        self.assertTrue("Invalid service" in mock_call[1][0])
+        self.assertTrue("red" in mock_call[2]["style"])
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_raises_when_handler_exec_command_raises(
+        self, mock_project_dir: Mock, mock_server_handler_class: Mock
+    ) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_handler_fns["exec_command"].side_effect = Exception("Test error")
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "whoami"])
+
+        # Assert
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestServerConnectCmd(unittest.TestCase):
+    def get_mock_server_handler(self) -> tuple[Mock, dict[str, Mock]]:
+        """Return a mock server handler."""
+        mock_connect = Mock()
+        mock_get_console = Mock()
+        mock_server_handler = Mock()
+
+        mock_server_handler.connect = mock_connect
+        mock_server_handler.get_console = mock_get_console
+
+        mock_connect.return_value = None
+        mock_get_console.return_value = Mock()
+
+        return mock_server_handler, {
+            "connect": mock_connect,
+            "get_console": mock_get_console,
+        }
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_help_includes_connect_command(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue("connect" in result.stdout, "connect command should appear in help")
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_instantiates_handler_and_calls_connect(
+        self, mock_project_dir: Mock, mock_server_handler_class: Mock
+    ) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_console = Mock()
+        mock_handler_fns["get_console"].return_value = mock_console
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["connect", "-s", "jupyter"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_server_handler_class.assert_called_once()
+        mock_handler_fns["connect"].assert_called_once_with(service="jupyter")
+        mock_handler_fns["get_console"].assert_called_once()
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_defaults_to_default_service(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["connect"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["connect"].assert_called_once_with(service="default")
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_prints_error_when_invalid_service(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_handler_fns["connect"].side_effect = InvalidServiceError(
+            "Invalid service, use one of ['jupyter', 'traefik']"
+        )
+
+        mock_console = Mock()
+        mock_handler_fns["get_console"].return_value = mock_console
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["connect", "-s", "invalid_service"])
+
+        # Assert
+        self.assertEqual(result.exit_code, 1)
+        mock_console.print.assert_called_once()
+        mock_call = mock_console.print.mock_calls[0]
+        self.assertTrue("Invalid service" in mock_call[1][0])
+        self.assertTrue("red" in mock_call[2]["style"])
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_raises_when_handler_connect_raises(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        # Setup
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_handler_fns["connect"].side_effect = Exception("Test error")
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        # Execute
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["connect", "-s", "jupyter"])
+
+        # Assert
+        self.assertNotEqual(result.exit_code, 0)


### PR DESCRIPTION
This PR adds the following commands to the CLI and corresponding handling in base template:
- `jd host exec` --> execute a command in the host
- `jd server exec` --> execute a command in one of the service
- `jd server connect` --> start an interactive shell in one of the service

Implements 2/ of #113 

### User experience
- `jd host exec -- CMD`, for example `jd host exec -- df -h` shows the disk usage in the host
- `jd server exec -- CMD`, for example `jd server exec -- "ls -la" lists the file in the home dir of `jupyter` (default service)
- `jd server exec -s SERVICE -- CMD`, for example `jd server exec -s traefik -- "ps ls | grep traefik"` looks up the traefik process in the `traefik` image
- `jd server connect` starts an interactive shell to `jupyter` service (default service)
- `jd server connect -s SERVICE` targets a different service, for example `jd server connect -s traefik`

### Implementation
for the base template:
- `host exec` uses `SSM:SendCommand` with the default, AWS-provided SSM Shell document
- `server exec` uses `SSM:SendCommand` with a custom SSM document that runs `docker exec SERVICE CMD`
- `server connect` uses `SSM:StartSession` with a custom SSM document that runs `docker exec -it SERVICE SHELL`
Also added:
- unit tests
- e2e tests

### Testing
- run e2e tests
- updated existing deployment and tested manually 

### Screenshots
**host exec help**
<img width="911" height="218" alt="Screenshot 2026-01-13 at 1 57 11 PM" src="https://github.com/user-attachments/assets/d6c1f46e-655c-4f91-99aa-091e9315d40e" />

**server exec help**
<img width="917" height="259" alt="Screenshot 2026-01-13 at 1 57 45 PM" src="https://github.com/user-attachments/assets/44f18fee-092b-4520-91e6-1bf717bd2bb4" />

**server connect help**
<img width="905" height="258" alt="Screenshot 2026-01-13 at 1 58 11 PM" src="https://github.com/user-attachments/assets/b4aa20fd-38c8-4af8-8a59-30c77d12ebe5" />

**host exec example**
<img width="706" height="212" alt="Screenshot 2026-01-13 at 1 59 15 PM" src="https://github.com/user-attachments/assets/bf996067-b66b-455e-9d94-fc63a5c4320f" />

**server exec example**
<img width="1053" height="71" alt="Screenshot 2026-01-13 at 1 59 52 PM" src="https://github.com/user-attachments/assets/6a21681d-a51e-4867-88fa-006cd785ca35" />

**server connect example**
<img width="537" height="249" alt="Screenshot 2026-01-13 at 2 00 33 PM" src="https://github.com/user-attachments/assets/0c8f1f82-e8a3-40b5-ac84-25f21e2b3c17" />

