### PR TITLE
fix: harden base template, notebook runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ The E2E tests run in a local container using `pytest` where `playwright` and web
 Look at `./justfile` for more details.
 IMPORTANT: you CANNOT run any e2e directly with `uv run pytest E2E-TEST-SELECTOR`, you MUST use a `just` command.
 
+**IMPORTANT**: Deployment directories contain their own copy of template files.
+When testing template changes in an existing deployment (e.g., sandbox-e2e),
+you must manually copy the modified template files from `libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/`
+to the deployment directory BEFORE running configuration tests or deploying.
+
 ## Prerequisites
 1. A deployed project to test against located in a dir relative to the workspace root (e.g., `./sandbox`)
 2. Some E2E tests require environment variables to be set:
@@ -89,9 +94,14 @@ IMPORTANT: you CANNOT run any e2e directly with `uv run pytest E2E-TEST-SELECTOR
 The configuration test verifies a template project is correctly wired up.
 In the case of the base template, this corresponds to the `terraform plan` operation succeeding.
 
+**Before running configuration tests on modified template files**:
+- Copy changed template files from base template to the test deployment directory
+- The configuration test validates the LOCAL files in the deployment directory, not the installed package
+
 To run the configuration test:
 1. ask the user for the `<project-dir>` to use
-2. run `just test-e2e <project-dir> test_configuration`
+2. if testing modified template files, ensure they've been copied to `<project-dir>`
+3. run `just test-e2e <project-dir> test_configuration`
 
 ## Authentication Setup for the base template
 Before running E2E tests, ask the user to run GitHub OAuth authentication: `just auth-setup <project-dir>`.

--- a/justfile
+++ b/justfile
@@ -185,7 +185,7 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="":
     fi
 
     # Default log level
-    LOG_LEVEL="WARNING"
+    LOG_LEVEL="INFO"
 
     # Parse options (comma-separated key=value pairs)
     OPTIONS_STR="{{options}}"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/services.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/services.tf
@@ -325,6 +325,7 @@ mainSteps:
   - action: aws:runShellScript
     name: DownloadUtilityScripts
     inputs:
+      onFailure: exit
       runCommand:
         - |
           mkdir -p /usr/local/bin
@@ -338,6 +339,7 @@ mainSteps:
   - action: aws:runShellScript
     name: CloudInit
     inputs:
+      onFailure: exit
       runCommand:
         - |
           ${local.cloud_init_indented}
@@ -345,6 +347,7 @@ mainSteps:
   - action: aws:runShellScript
     name: MountAdditionalVolumes
     inputs:
+      onFailure: exit
       runCommand:
         - |
           ${local.cloudinit_volumes_indented}
@@ -352,6 +355,7 @@ mainSteps:
   - action: aws:runShellScript
     name: DownloadDockerFiles
     inputs:
+      onFailure: exit
       runCommand:
         - |
           BUCKET="${module.s3_bucket.bucket_name}"
@@ -371,6 +375,7 @@ mainSteps:
   - action: aws:runShellScript
     name: SyncCertificates
     inputs:
+      onFailure: exit
       runCommand:
         - |
           sh /usr/local/bin/sync-acme.sh
@@ -378,6 +383,7 @@ mainSteps:
   - action: aws:runShellScript
     name: StartDockerServices
     inputs:
+      onFailure: exit
       runCommand:
         - |
           sh /opt/docker/docker-startup.sh

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit-volumes.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit-volumes.sh.tftpl
@@ -59,7 +59,29 @@ setup_ebs "${ebs.mount_point}" "${ebs.device_name}"
 install_efs_utils() {
     if ! rpm -q amazon-efs-utils &> /dev/null; then
         echo "Installing amazon-efs-utils..."
-        yum install -y amazon-efs-utils
+
+        # Retry configuration
+        # https://github.com/jupyter-infra/jupyter-deploy/issues/130
+        MAX_RETRIES=2
+        RETRY_COUNT=0
+        RETRY_DELAY=2
+
+        while [ $RETRY_COUNT -le $MAX_RETRIES ]; do
+            if yum install -y amazon-efs-utils; then
+                echo "Successfully installed amazon-efs-utils"
+                break
+            else
+                RETRY_COUNT=$((RETRY_COUNT + 1))
+                if [ $RETRY_COUNT -le $MAX_RETRIES ]; then
+                    echo "Failed to install amazon-efs-utils (attempt $RETRY_COUNT/$((MAX_RETRIES + 1))), retrying in $${RETRY_DELAY}s..."
+                    sleep $RETRY_DELAY
+                    RETRY_DELAY=$((RETRY_DELAY * 2))
+                else
+                    echo "Failed to install amazon-efs-utils after $((MAX_RETRIES + 1)) attempts"
+                    exit 1
+                fi
+            fi
+        done
     else
         echo "amazon-efs-utils is already installed"
     fi

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/jupyter_server_config_pixi.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/jupyter_server_config_pixi.py
@@ -8,6 +8,6 @@ c.ServerApp.terminado_settings = {
     "shell_command": [
         "bash",
         "-c",
-        "echo \"This is a pixi-managed shell, use 'pixi add' instead of 'pip'!\"; bash",
+        "echo \"This is a pixi-managed environment, use 'pixi add --pypi' or 'pixi add' instead of 'pip'!\"; bash",
     ]
 }

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/jupyter_server_config.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/jupyter_server_config.py
@@ -8,6 +8,6 @@ c.ServerApp.terminado_settings = {
     "shell_command": [
         "bash",
         "-c",
-        "echo \"This is a UV-managed shell, use 'uv add' or 'uv pip' instead of 'pip'!\"; bash",
+        "echo \"This is a UV-managed environment, use 'uv add' or 'uv pip' instead of 'pip'!\"; bash",
     ]
 }

--- a/libs/pytest-jupyter-deploy/pyproject.toml
+++ b/libs/pytest-jupyter-deploy/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = [
     "pyyaml>=6.0.2",
     "pexpect>=4.9.0",
     "types-pexpect>=4.9.0",
+    "requests>=2.32.0",
+    "types-requests>=2.32.0",
 ]
 
 [project.optional-dependencies]

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebook.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebook.py
@@ -208,7 +208,7 @@ def run_notebook_in_jupyterlab(
                 # No more strategies, fail with detailed error
                 raise RuntimeError(
                     f"Notebook execution stuck: {executed_count}/{total_count} cells executed. "
-                    f"All remediation strategies exhausted."
+                    f"All remediation strategies exhausted or none specified."
                 )
 
         # Not done yet, wait and check again

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebook.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebook.py
@@ -9,6 +9,21 @@ from pathlib import Path
 from playwright.sync_api import Page
 
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.notebooks import (
+    CloseReopenStrategy,
+    CopyCleanStrategy,
+    PageRefreshStrategy,
+    RemediationStrategy,
+)
+from pytest_jupyter_deploy.notebooks.notebook_utils import (
+    close_all_tabs_and_stop_sessions,
+    dismiss_document_session_error_if_present,
+    extract_cell_outputs,
+    is_cell_executed,
+    prepare_jupyterlab_to_run_notebook,
+    reload_on_server_connection_error,
+    verify_executed_and_no_cell_error,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,227 +64,14 @@ def upload_notebook(deployment: EndToEndDeployment, src_path: str | Path, target
     deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", python_cmd])
 
 
-def _extract_cell_outputs(page: Page, cells_info: list[dict[str, str]]) -> list[dict[str, str]]:
-    """Extract cell execution information from the current notebook.
-
-    Note: this method swallows exceptions to ensure we gather as much cell
-    information as possible.
-
-    Args:
-        page: Playwright Page instance
-        cells_info: Cell info from previous poll (to avoid expensive re-extraction
-            for cells that were already fully executed and captured)
-
-    Returns:
-        Updated list of cell information with keys:
-        - cell_number: Execution count (e.g., "[1]", "[2]") or "[-1]" when not-executed
-        - has_error: Boolean indicating if cell has error output
-        - error_output: Error traceback text if present, empty string otherwise
-    """
-    # Progressively scroll to ensure all cells are rendered
-    # JupyterLab uses virtualization - cells outside viewport aren't in DOM
-    # Get final cell list after scrolling
-    code_cells = page.locator(".jp-CodeCell").all()
-    logger.debug(f"Found {len(code_cells)} cells.")
-
-    # Create a new list to avoid mutating the input
-    updated_cells_info: list[dict[str, str]] = []
-
-    # Ensure we have entries for all cells
-    for i in range(len(code_cells)):
-        if i < len(cells_info):
-            # Copy existing cell info
-            updated_cells_info.append(cells_info[i].copy())
-        else:
-            # Create new cell info entry
-            updated_cells_info.append(
-                {
-                    "cell_index": str(i),
-                    "cell_number": "[-1]",
-                    "has_error": "False",
-                    "error_output": "",
-                }
-            )
-
-    for i, cell in enumerate(code_cells):
-        # Skip cells that were already fully executed and captured
-        if _is_cell_executed(updated_cells_info[i]["cell_number"]):
-            continue
-
-        # Update execution count
-        cell.scroll_into_view_if_needed()
-        try:
-            input_prompt = cell.locator(".jp-InputArea-prompt")
-            prompt_text = input_prompt.inner_text(timeout=1000)
-            updated_cells_info[i]["cell_number"] = prompt_text.strip()
-        except Exception as e:
-            updated_cells_info[i]["cell_number"] = "[-1]"
-            logger.warning(f"Exception when attempting to retrieve cell number: {e}")
-            # do NOT raise here, keep gathering cell information
-
-        logger.debug(f"Updated cell {i} to {updated_cells_info[i]['cell_number']}")
-
-        # Stop iteration if we encounter a cell that's not executed yet (empty or [*]:)
-        # Since cells execute sequentially, all cells below this haven't started
-        cell_num = updated_cells_info[i]["cell_number"]
-        if not cell_num or cell_num.strip() == "" or "[*]" in cell_num:
-            logger.debug(f"Cell {i} not yet executed ({cell_num}), stopping iteration to avoid virtualization")
-            break
-
-        # Check for error outputs (expensive operation) only if cell is now executed
-        if _is_cell_executed(updated_cells_info[i]["cell_number"]):
-            try:
-                # JupyterLab displays errors in output area with specific classes
-                output_area = cell.locator(".jp-OutputArea-output")
-                if output_area.count() > 0:
-                    # Get all output text and check if it contains error indicators
-                    all_output_text = output_area.first.inner_text(timeout=1000)
-
-                    # Check for common error patterns
-                    if any(pattern in all_output_text for pattern in ["Traceback", "Error:", "Exception:", "error:"]):
-                        updated_cells_info[i]["has_error"] = "True"
-                        updated_cells_info[i]["error_output"] = all_output_text[:500]  # Limit to first 500 chars
-                        logger.warning(f"Detected error for cell {i}: {all_output_text[:50]}.")
-            except Exception as e:
-                updated_cells_info[i]["has_error"] = "Possibly"
-                updated_cells_info[i]["error_output"] = "Failed to retrieve cell output"
-                updated_cells_info[i]["cell_number"] = "[*]"
-
-                logger.warning(f"Exception when attempting to retrieve cell output: {e}")
-                # do NOT raise here, keep gathering cell information
-
-    return updated_cells_info
-
-
-def _close_all_tabs_and_stop_sessions(page: Page, extra_sleep_after_close_tabs_seconds: float = 0.0) -> None:
-    """Close all open tabs and shut down all kernel sessions in JupyterLab.
-
-    Uses the View > Sessions and Tabs menu to cleanly close all tabs and shutdown all kernels.
-    This helps avoid strict mode violations when multiple notebooks are open.
-
-    Args:
-        page: Playwright Page instance
-        extra_wait_after_close_all: Additional seconds to wait after closing tabs
-            (useful when cleaning up after error dialogs)
-    """
-    try:
-        logger.debug("Attempting to close all tabs and shutdown all kernels...")
-
-        # Close any open dialogs first
-        page.keyboard.press("Escape")
-        time.sleep(0.2)
-
-        # Click View menu in top menu bar
-        logger.debug("Opening View menu...")
-        view_menu = page.get_by_role("menuitem", name="View")
-        view_menu.click()
-        time.sleep(0.3)
-
-        # Click "Sessions and Tabs" submenu item
-        logger.debug("Clicking 'Sessions and Tabs'...")
-        sessions_and_tabs = page.get_by_text("Sessions and Tabs", exact=True)
-        sessions_and_tabs.wait_for(state="visible", timeout=1000)
-        sessions_and_tabs.click()
-        time.sleep(0.5)
-    except Exception as e:
-        # Error accessing session and tabs
-        logger.warning(f"Could not access Sessions and Tabs left panel: {e}")
-        return
-
-    # Scope searches to the left panel to avoid strict mode violations
-    left_panel = page.locator("#jp-running-sessions")
-
-    # Click "Close All" button in OPEN TABS section
-    try:
-        # Target the specific toolbar first, then find the button within it
-        open_tabs_toolbar = left_panel.locator('jp-toolbar[aria-label="Open Tabs toolbar"]')
-        close_all_button = open_tabs_toolbar.locator('jp-button[aria-label="Close All"]')
-        close_all_button.wait_for(state="visible", timeout=1000)
-
-        logger.debug("Clicking 'Close All' button...")
-        close_all_button.click()
-        time.sleep(0.3)
-
-        # JupyterLab displays a dialog box with a confirm button at a hard-to-find place in the DOM
-        # use the keyboard to go around the issue of finding it!
-        logger.debug("Confirming 'Close All' with Enter key...")
-        page.keyboard.press("Enter")
-        time.sleep(0.5)
-
-        # Wait for tabs to actually close (with extra wait if needed for error cleanup)
-        base_sleep_seconds = 1.0
-        total_sleep = base_sleep_seconds + extra_sleep_after_close_tabs_seconds
-        logger.debug(f"Waiting {total_sleep}s for tabs to close...")
-        time.sleep(total_sleep)
-    except Exception as e:
-        logger.debug(f"No 'Close All' button found or already closed: {e}")
-
-    # Click "Shut Down All" button in KERNELS section if present and enabled
-    # COMMENTED OUT: This may prevent kernels from auto-starting for subsequent notebooks
-    # try:
-    #     # Target the specific toolbar first, then find the button within it
-    #     kernels_toolbar = left_panel.locator('jp-toolbar[aria-label="Kernels toolbar"]')
-    #     shutdown_all_button = kernels_toolbar.locator('jp-button[aria-label="Shut Down All"]')
-    #     shutdown_all_button.wait_for(state="visible", timeout=1000)
-    #
-    #     logger.debug("Clicking 'Shut Down All' button...")
-    #     shutdown_all_button.click()
-    #     time.sleep(0.3)
-    #
-    #     # JupyterLab displays a dialog box with a confirm button at a hard-to-find place in the DOM
-    #     # use the keyboard to go around the issue of finding it!
-    #     logger.debug("Confirming 'Shut Down All' with Enter key...")
-    #     page.keyboard.press("Enter")
-    #     time.sleep(0.5)
-    # except Exception as e:
-    #     logger.debug(f"No 'Shut Down All' button found or already shut down: {e}")
-
-    # Close the Sessions and Tabs panel
-    page.keyboard.press("Escape")
-    time.sleep(0.2)
-
-    logger.debug("Successfully closed all tabs and shut down all kernels")
-
-
-def _dismiss_document_session_error_if_present(page: Page) -> bool:
-    """Dismiss any lingering 'Document session error' dialog if present.
-
-    This dialog can appear when JupyterLab tries to restore a session for a notebook
-    that was previously open but has since been deleted from the filesystem.
-
-    Dismissing with Enter will unblock the UI (though it may leave a spinner),
-    which allows the subsequent close all tabs operation to clean up properly.
-
-    Args:
-        page: Playwright Page instance
-
-    Returns:
-        True if a dialog was dismissed, False otherwise
-    """
-    logger.debug("Checking for 'Document session error' dialog...")
-    try:
-        # Look for the dialog element with aria-label containing "Document session error"
-        error_dialog = page.locator('dialog[aria-label*="Document session error"]')
-
-        # Check if the dialog is visible with a short timeout
-        if error_dialog.is_visible(timeout=1000):
-            logger.debug("Found 'Document session error' dialog, dismissing with Enter key...")
-            # Press Enter to dismiss the dialog (may leave a spinner but unblocks the UI)
-            page.keyboard.press("Enter")
-            time.sleep(0.5)
-            logger.debug("Successfully dismissed 'Document session error' dialog")
-            return True
-        else:
-            logger.debug("No 'Document session error' dialog present")
-            return False
-    except Exception as e:
-        # No error dialog present or already dismissed
-        logger.debug(f"No 'Document session error' dialog found: {e}")
-        return False
-
-
 def run_notebook_in_jupyterlab(
-    page: Page, notebook_path: str, timeout_ms: int = 120000, poll_interval_ms: int = 2000
+    page: Page,
+    notebook_path: str,
+    timeout_ms: int = 120000,
+    poll_interval_ms: int = 2000,
+    remediation_strategies: list[RemediationStrategy] | None = None,
+    stuck_poll_threshold: int = 10,
+    skip_initial_setup: bool = False,
 ) -> None:
     """Run a notebook in JupyterLab and wait for completion.
 
@@ -278,59 +80,33 @@ def run_notebook_in_jupyterlab(
         notebook_path: Path to the notebook relative to /home/jovyan (e.g., "work/test.ipynb")
         timeout_ms: Maximum time to wait for notebook execution in milliseconds (default: 120000)
         poll_interval_ms: Interval between cell execution checks in milliseconds (default: 2000)
+        remediation_strategies: List of remediation strategies to apply if execution gets stuck.
+            Defaults to [PageRefreshStrategy, CloseReopenStrategy, CopyCleanStrategy]
+        stuck_poll_threshold: Number of consecutive stuck polls before triggering remediation (default: 10)
+        skip_initial_setup: If True, skip the initial setup (close tabs, open notebook, click Run All).
+            Used when remediation strategies have already performed the setup. (default: False)
 
     Raises:
         RuntimeError: If notebook execution fails or times out, includes cell execution details
     """
-    # Check for server connection errors
-    _reload_on_server_connection_error(page)
+    # Initialize default remediation strategies if none provided
+    if remediation_strategies is None:
+        remediation_strategies = [PageRefreshStrategy(), CloseReopenStrategy(), CopyCleanStrategy()]
 
-    # Dismiss any "Document session error" dialog first (unblocks UI so we can close tabs)
-    dismissed_error_dialog = _dismiss_document_session_error_if_present(page)
+    if not skip_initial_setup:
+        # Check for server connection errors
+        reload_on_server_connection_error(page)
 
-    # Close all open notebook tabs and shut down all kernels to avoid strict mode violations
-    # If we dismissed an error dialog, wait longer for tabs to close (spinner cleanup)
-    extra_sleep_seconds = 1.5 if dismissed_error_dialog else 0.0
-    _close_all_tabs_and_stop_sessions(page, extra_sleep_after_close_tabs_seconds=extra_sleep_seconds)
+        # Dismiss any "Document session error" dialog first (unblocks UI so we can close tabs)
+        dismissed_error_dialog = dismiss_document_session_error_if_present(page)
 
-    # Open the notebook directly via URL to bypass file browser caching issues
-    # JupyterLab uses URLs like /lab/tree/path/to/notebook.ipynb
-    current_url = page.url
-    base_url = current_url.split("/lab")[0] if "/lab" in current_url else current_url.rstrip("/")
-    notebook_url = f"{base_url}/lab/tree/{notebook_path}"
+        # Close all open notebook tabs and shut down all kernels to avoid strict mode violations
+        # If we dismissed an error dialog, wait longer for tabs to close (spinner cleanup)
+        extra_sleep_seconds = 1.5 if dismissed_error_dialog else 0.0
+        close_all_tabs_and_stop_sessions(page, extra_sleep_after_close_tabs_seconds=extra_sleep_seconds)
 
-    logger.debug(f"Opening notebook at: {notebook_url}...")
-    page.goto(notebook_url)
-    time.sleep(2)  # Give JupyterLab time to load the notebook
-
-    # Wait for the notebook to load - check for the notebook toolbar
-    # Strict mode will enforce that only one notebook is visible
-    # do NOT add .first as it would mess up cell selection later
-    logger.debug("Looking for notebook toolbar...")
-    notebook_toolbar = page.locator(".jp-NotebookPanel-toolbar")
-    notebook_toolbar.wait_for(state="visible", timeout=10000)
-
-    # Wait for the kernel to be ready before executing cells
-    # The kernel status is shown in the status bar (e.g., "Python 3 (ipykernel) | Idle")
-    logger.debug("Waiting for kernel to be ready...")
-    try:
-        # Target the visible status bar element specifically to avoid strict mode violation
-        kernel_status_idle = page.locator(".jp-StatusBar-TextItem").filter(has_text="Idle")
-        kernel_status_idle.wait_for(state="visible", timeout=10000)
-        logger.debug("Kernel is idle and ready")
-    except Exception as e:
-        logger.warning(f"Could not detect idle kernel status, proceeding anyway: {e}")
-
-    # Click "Run" option in JupyterLab top menu and then "Run All Cells" option
-    logger.debug("Clicking 'Run' option in JupyterLab top menu...")
-    run_menu = page.get_by_role("menuitem", name="Run")
-    run_menu.click()
-
-    logger.debug("Clicking 'Run All Cells' option...")
-    run_all_item = page.get_by_text("Run All Cells", exact=True)
-    run_all_item.wait_for(state="visible", timeout=1000)
-    run_all_item.click()
-    logger.debug("Clicked 'Run All Cells'")
+        # Navigate to notebook, wait for it to load, and click Run All Cells
+        prepare_jupyterlab_to_run_notebook(page, notebook_path)
 
     # Wait for execution to complete by polling cell execution counts
     # This is more reliable than watching kernel status indicators, which can be affected by WebSocket issues
@@ -340,13 +116,17 @@ def run_notebook_in_jupyterlab(
     poll_iteration = 0  # Track poll iteration for logging
     cells_info: list[dict[str, str]] = []  # Track previous poll to avoid re-extraction
 
+    # Stuck detection variables
+    stuck_poll_count = 0  # Count consecutive polls without progress
+    previous_executed_count = 0  # Track progress between polls
+
     logger.debug(f"Waiting for notebook execution to complete (timeout: {timeout_ms}ms)...")
     while time.time() - start_time < max_wait:
         poll_iteration += 1
         logger.debug(f"[Poll {poll_iteration}] Checking cell execution states...")
 
         # Extract current cell execution states (reuse info from previous poll for executed cells)
-        cells_info = _extract_cell_outputs(page, cells_info=cells_info)
+        cells_info = extract_cell_outputs(page, cells_info=cells_info)
 
         if not cells_info:
             # No cells found yet, notebook may still be loading
@@ -355,7 +135,7 @@ def run_notebook_in_jupyterlab(
             continue
 
         # Count how many cells have executed
-        executed_count = len([cell for cell in cells_info if _is_cell_executed(cell["cell_number"])])
+        executed_count = len([cell for cell in cells_info if is_cell_executed(cell["cell_number"])])
         total_count = len(cells_info)
 
         logger.debug(f"[Poll {poll_iteration}] Execution progress: {executed_count}/{total_count} cells completed")
@@ -363,9 +143,73 @@ def run_notebook_in_jupyterlab(
         # Check if all cells have executed
         if executed_count == total_count:
             # All cells executed - verify no errors
-            _verify_executed_and_no_cell_error(cells_info, notebook_path)
-            logger.info(f"Notebook execution completed successfully: all {total_count} cells executed without errors")
+            verify_executed_and_no_cell_error(cells_info, notebook_path)
+            logger.debug(f"Notebook execution completed successfully: all {total_count} cells executed without errors")
             return
+
+        # Detect stuck state: no progress and at least one cell is stuck at [*]:
+        has_stuck_cell = any("[*]" in cell["cell_number"] for cell in cells_info)
+        made_progress = executed_count > previous_executed_count
+
+        if not made_progress and has_stuck_cell:
+            stuck_poll_count += 1
+            logger.debug(f"[Poll {poll_iteration}] No progress detected, stuck_poll_count={stuck_poll_count}")
+        else:
+            # Reset counter if progress was made
+            if made_progress:
+                logger.debug(f"[Poll {poll_iteration}] Progress made, resetting stuck counter")
+            stuck_poll_count = 0
+
+        # Update previous count for next iteration
+        previous_executed_count = executed_count
+
+        # Trigger remediation if stuck threshold reached
+        if stuck_poll_count >= stuck_poll_threshold:
+            if remediation_strategies:
+                strategy = remediation_strategies[0]
+                logger.warning(
+                    f"Notebook execution stuck after {stuck_poll_count} polls. "
+                    f"Attempting remediation: {strategy.description()}"
+                )
+
+                # Apply the strategy - it may return a new notebook path (e.g., if it copied the notebook)
+                new_path = strategy.apply(page, notebook_path)
+                updated_notebook_path = new_path if new_path is not None else notebook_path
+
+                if new_path is not None:
+                    logger.info(f"Strategy changed notebook path from {notebook_path} to {new_path}")
+
+                # Calculate remaining timeout for recursive call
+                elapsed_ms = int((time.time() - start_time) * 1000)
+                remaining_timeout_ms = timeout_ms - elapsed_ms
+
+                if remaining_timeout_ms <= 0:
+                    raise RuntimeError(
+                        f"Notebook execution timed out after {timeout_ms}ms during remediation. "
+                        f"{executed_count}/{total_count} cells executed."
+                    )
+
+                # Recursive call with remaining strategies and timeout
+                # Skip initial setup since the strategy has already performed necessary actions
+                # Use the updated notebook path (which may be different if strategy copied the notebook)
+                remaining_strategies = remediation_strategies[1:]
+                logger.info(f"Retrying execution with {len(remaining_strategies)} remaining strategies")
+
+                return run_notebook_in_jupyterlab(
+                    page=page,
+                    notebook_path=updated_notebook_path,
+                    timeout_ms=remaining_timeout_ms,
+                    poll_interval_ms=poll_interval_ms,
+                    remediation_strategies=remaining_strategies,
+                    stuck_poll_threshold=stuck_poll_threshold,
+                    skip_initial_setup=True,
+                )
+            else:
+                # No more strategies, fail with detailed error
+                raise RuntimeError(
+                    f"Notebook execution stuck: {executed_count}/{total_count} cells executed. "
+                    f"All remediation strategies exhausted."
+                )
 
         # Not done yet, wait and check again
         time.sleep(poll_interval)
@@ -373,15 +217,15 @@ def run_notebook_in_jupyterlab(
     # Timeout - perform final check to see if cells actually completed
     poll_iteration += 1
     logger.warning(f"[Poll {poll_iteration}] Timeout reached, performing final cell extraction...")
-    cells_info = _extract_cell_outputs(page, cells_info=cells_info)
-    executed_count = len([cell for cell in cells_info if _is_cell_executed(cell["cell_number"])])
+    cells_info = extract_cell_outputs(page, cells_info=cells_info)
+    executed_count = len([cell for cell in cells_info if is_cell_executed(cell["cell_number"])])
     total_count = len(cells_info)
 
     # Check if all cells actually executed (might have finished just after timeout)
     if executed_count == total_count and total_count > 0:
         # All cells executed - verify no errors
-        _verify_executed_and_no_cell_error(cells_info, notebook_path)
-        logger.info(
+        verify_executed_and_no_cell_error(cells_info, notebook_path)
+        logger.debug(
             f"Notebook execution completed successfully (caught on final check after timeout): "
             f"all {total_count} cells executed without errors"
         )

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/__init__.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/__init__.py
@@ -1,0 +1,17 @@
+"""Notebook testing utilities and remediation strategies."""
+
+from pytest_jupyter_deploy.notebooks.notebook_utils import prepare_jupyterlab_to_run_notebook
+from pytest_jupyter_deploy.notebooks.remediation_strategy import (
+    CloseReopenStrategy,
+    CopyCleanStrategy,
+    PageRefreshStrategy,
+    RemediationStrategy,
+)
+
+__all__ = [
+    "RemediationStrategy",
+    "PageRefreshStrategy",
+    "CloseReopenStrategy",
+    "CopyCleanStrategy",
+    "prepare_jupyterlab_to_run_notebook",
+]

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
@@ -1,0 +1,417 @@
+"""Utility functions for notebook testing in JupyterLab."""
+
+import logging
+import time
+
+import requests
+from playwright.sync_api import Page
+
+logger = logging.getLogger(__name__)
+
+
+def prepare_jupyterlab_to_run_notebook(page: Page, notebook_path: str) -> None:
+    """Navigate to notebook, wait for it to load, and click Run All Cells.
+
+    Args:
+        page: Playwright Page instance
+        notebook_path: Path to the notebook relative to /home/jovyan (e.g., "work/test.ipynb")
+    """
+    # Open the notebook directly via URL to bypass file browser caching issues
+    # JupyterLab uses URLs like /lab/tree/path/to/notebook.ipynb
+    current_url = page.url
+    base_url = current_url.split("/lab")[0] if "/lab" in current_url else current_url.rstrip("/")
+    notebook_url = f"{base_url}/lab/tree/{notebook_path}"
+
+    logger.debug(f"Opening notebook at: {notebook_url}...")
+    page.goto(notebook_url)
+    time.sleep(2)  # Give JupyterLab time to load the notebook
+
+    # Wait for the notebook to load - check for the notebook toolbar
+    # Strict mode will enforce that only one notebook is visible
+    # do NOT add .first as it would mess up cell selection later
+    logger.debug("Looking for notebook toolbar...")
+    notebook_toolbar = page.locator(".jp-NotebookPanel-toolbar")
+    notebook_toolbar.wait_for(state="visible", timeout=10000)
+
+    # Wait for the kernel to be ready before executing cells
+    # The kernel status is shown in the status bar (e.g., "Python 3 (ipykernel) | Idle")
+    logger.debug("Waiting for kernel to be ready...")
+    try:
+        # Target the visible status bar element specifically to avoid strict mode violation
+        kernel_status_idle = page.locator(".jp-StatusBar-TextItem").filter(has_text="Idle")
+        kernel_status_idle.wait_for(state="visible", timeout=10000)
+        logger.debug("Kernel is idle and ready")
+    except Exception as e:
+        logger.warning(f"Could not detect idle kernel status, proceeding anyway: {e}")
+
+    # Click "Run" option in JupyterLab top menu and then "Run All Cells" option
+    logger.debug("Clicking 'Run' option in JupyterLab top menu...")
+    run_menu = page.get_by_role("menuitem", name="Run")
+    run_menu.click()
+
+    logger.debug("Clicking 'Run All Cells' option...")
+    run_all_item = page.get_by_text("Run All Cells", exact=True)
+    run_all_item.wait_for(state="visible", timeout=1000)
+    run_all_item.click()
+    logger.debug("Clicked 'Run All Cells'")
+
+
+def extract_cell_outputs(page: Page, cells_info: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Extract cell execution information from the current notebook.
+
+    Note: this method swallows exceptions to ensure we gather as much cell
+    information as possible.
+
+    Args:
+        page: Playwright Page instance
+        cells_info: Cell info from previous poll (to avoid expensive re-extraction
+            for cells that were already fully executed and captured)
+
+    Returns:
+        Updated list of cell information with keys:
+        - cell_number: Execution count (e.g., "[1]", "[2]") or "[-1]" when not-executed
+        - has_error: Boolean indicating if cell has error output
+        - error_output: Error traceback text if present, empty string otherwise
+    """
+    # Progressively scroll to ensure all cells are rendered
+    # JupyterLab uses virtualization - cells outside viewport aren't in DOM
+    # Get final cell list after scrolling
+    code_cells = page.locator(".jp-CodeCell").all()
+    logger.debug(f"Found {len(code_cells)} cells.")
+
+    # Create a new list to avoid mutating the input
+    updated_cells_info: list[dict[str, str]] = []
+
+    # Ensure we have entries for all cells
+    for i in range(len(code_cells)):
+        if i < len(cells_info):
+            # Copy existing cell info
+            updated_cells_info.append(cells_info[i].copy())
+        else:
+            # Create new cell info entry
+            updated_cells_info.append(
+                {
+                    "cell_index": str(i),
+                    "cell_number": "[-1]",
+                    "has_error": "False",
+                    "error_output": "",
+                }
+            )
+
+    for i, cell in enumerate(code_cells):
+        # Skip cells that were already fully executed and captured
+        if is_cell_executed(updated_cells_info[i]["cell_number"]):
+            continue
+
+        # Update execution count
+        cell.scroll_into_view_if_needed()
+        try:
+            input_prompt = cell.locator(".jp-InputArea-prompt")
+            prompt_text = input_prompt.inner_text(timeout=1000)
+            updated_cells_info[i]["cell_number"] = prompt_text.strip()
+        except Exception as e:
+            updated_cells_info[i]["cell_number"] = "[-1]"
+            logger.warning(f"Exception when attempting to retrieve cell number: {e}")
+            # do NOT raise here, keep gathering cell information
+
+        logger.debug(f"Updated cell {i} to {updated_cells_info[i]['cell_number']}")
+
+        # Stop iteration if we encounter a cell that's not executed yet (empty or [*]:)
+        # Since cells execute sequentially, all cells below this haven't started
+        cell_num = updated_cells_info[i]["cell_number"]
+        if not cell_num or cell_num.strip() == "" or "[*]" in cell_num:
+            logger.debug(f"Cell {i} not yet executed ({cell_num}), stopping iteration to avoid virtualization")
+            break
+
+        # Check for error outputs (expensive operation) only if cell is now executed
+        if is_cell_executed(updated_cells_info[i]["cell_number"]):
+            try:
+                # JupyterLab displays errors in output area with specific classes
+                output_area = cell.locator(".jp-OutputArea-output")
+                if output_area.count() > 0:
+                    # Get all output text and check if it contains error indicators
+                    all_output_text = output_area.first.inner_text(timeout=1000)
+
+                    # Check for common error patterns
+                    if any(pattern in all_output_text for pattern in ["Traceback", "Error:", "Exception:", "error:"]):
+                        updated_cells_info[i]["has_error"] = "True"
+                        updated_cells_info[i]["error_output"] = all_output_text[:500]  # Limit to first 500 chars
+                        logger.warning(f"Detected error for cell {i}: {all_output_text[:50]}.")
+            except Exception as e:
+                updated_cells_info[i]["has_error"] = "Possibly"
+                updated_cells_info[i]["error_output"] = "Failed to retrieve cell output"
+                updated_cells_info[i]["cell_number"] = "[*]"
+
+                logger.warning(f"Exception when attempting to retrieve cell output: {e}")
+                # do NOT raise here, keep gathering cell information
+
+    return updated_cells_info
+
+
+def close_all_tabs_and_stop_sessions(page: Page, extra_sleep_after_close_tabs_seconds: float = 0.0) -> None:
+    """Close all open tabs and shut down all kernel sessions in JupyterLab.
+
+    Uses the View > Sessions and Tabs menu to cleanly close all tabs and shutdown all kernels.
+    This helps avoid strict mode violations when multiple notebooks are open.
+
+    Args:
+        page: Playwright Page instance
+        extra_sleep_after_close_tabs_seconds: Additional seconds to wait after closing tabs
+            (useful when cleaning up after error dialogs)
+    """
+    try:
+        logger.debug("Attempting to close all tabs and shutdown all kernels...")
+
+        # Close any open dialogs first
+        page.keyboard.press("Escape")
+        time.sleep(0.2)
+
+        # Click View menu in top menu bar
+        logger.debug("Opening View menu...")
+        view_menu = page.get_by_role("menuitem", name="View")
+        view_menu.click()
+        time.sleep(0.3)
+
+        # Click "Sessions and Tabs" submenu item
+        logger.debug("Clicking 'Sessions and Tabs'...")
+        sessions_and_tabs = page.get_by_text("Sessions and Tabs", exact=True)
+        sessions_and_tabs.wait_for(state="visible", timeout=1000)
+        sessions_and_tabs.click()
+        time.sleep(0.5)
+    except Exception as e:
+        # Error accessing session and tabs
+        logger.warning(f"Could not access Sessions and Tabs left panel: {e}")
+        return
+
+    # Scope searches to the left panel to avoid strict mode violations
+    left_panel = page.locator("#jp-running-sessions")
+
+    # Click "Close All" button in OPEN TABS section
+    try:
+        # Target the specific toolbar first, then find the button within it
+        open_tabs_toolbar = left_panel.locator('jp-toolbar[aria-label="Open Tabs toolbar"]')
+        close_all_button = open_tabs_toolbar.locator('jp-button[aria-label="Close All"]')
+        close_all_button.wait_for(state="visible", timeout=1000)
+
+        logger.debug("Clicking 'Close All' button...")
+        close_all_button.click()
+        time.sleep(0.3)
+
+        # JupyterLab displays a dialog box with a confirm button at a hard-to-find place in the DOM
+        # use the keyboard to go around the issue of finding it!
+        logger.debug("Confirming 'Close All' with Enter key...")
+        page.keyboard.press("Enter")
+        time.sleep(0.5)
+
+        # Wait for tabs to actually close (with extra wait if needed for error cleanup)
+        base_sleep_seconds = 1.0
+        total_sleep = base_sleep_seconds + extra_sleep_after_close_tabs_seconds
+        logger.debug(f"Waiting {total_sleep}s for tabs to close...")
+        time.sleep(total_sleep)
+    except Exception as e:
+        logger.debug(f"No 'Close All' button found or already closed: {e}")
+
+    # Close the Sessions and Tabs panel
+    page.keyboard.press("Escape")
+    time.sleep(0.2)
+
+    logger.debug("Successfully closed all tabs and shut down all kernels")
+
+
+def dismiss_document_session_error_if_present(page: Page) -> bool:
+    """Dismiss any lingering 'Document session error' dialog if present.
+
+    This dialog can appear when JupyterLab tries to restore a session for a notebook
+    that was previously open but has since been deleted from the filesystem.
+
+    Dismissing with Enter will unblock the UI (though it may leave a spinner),
+    which allows the subsequent close all tabs operation to clean up properly.
+
+    Args:
+        page: Playwright Page instance
+
+    Returns:
+        True if a dialog was dismissed, False otherwise
+    """
+    logger.debug("Checking for 'Document session error' dialog...")
+    try:
+        # Look for the dialog element with aria-label containing "Document session error"
+        error_dialog = page.locator('dialog[aria-label*="Document session error"]')
+
+        # Check if the dialog is visible with a short timeout
+        if error_dialog.is_visible(timeout=1000):
+            logger.debug("Found 'Document session error' dialog, dismissing with Enter key...")
+            # Press Enter to dismiss the dialog (may leave a spinner but unblocks the UI)
+            page.keyboard.press("Enter")
+            time.sleep(0.5)
+            logger.debug("Successfully dismissed 'Document session error' dialog")
+            return True
+        else:
+            logger.debug("No 'Document session error' dialog present")
+            return False
+    except Exception as e:
+        # No error dialog present or already dismissed
+        logger.debug(f"No 'Document session error' dialog found: {e}")
+        return False
+
+
+def reload_on_server_connection_error(page: Page, pop_up_visible_timeout_ms: int = 500) -> bool:
+    """Check for server connection error and reload page if detected.
+
+    Args:
+        page: Playwright Page instance
+        pop_up_visible_timeout_ms: Timeout in ms to check if connection error popup is visible
+
+    Returns:
+        True if connection error was detected and page was reloaded, False otherwise
+    """
+    connection_error = page.get_by_text("Server Connection Error")
+    if connection_error.is_visible(timeout=pop_up_visible_timeout_ms):
+        logger.warning("Connection error detected, waiting 2s and refreshing page...")
+        time.sleep(2)
+        page.reload()
+        logger.info("Page reloaded after connection error")
+        return True
+    return False
+
+
+def is_cell_executed(cell_number: str) -> bool:
+    """Return True if a cell has been executed based on its execution count.
+
+    Args:
+        cell_number: The execution count text from the cell prompt (e.g., "[1]", "[ ]:", "[*]", "[-1]")
+
+    Returns:
+        True if the cell has a numeric execution count (indicating it executed successfully),
+        False if the cell is unexecuted or still executing
+    """
+    # Cell is executed if it contains a digit (e.g., "[1]", "[2]", etc.)
+    # Not executed if it's "[ ]:", "[ ]", "[]", "[-1]", "[*]", or any variation without digits
+    return any(char.isdigit() for char in cell_number) and "*" not in cell_number and "-" not in cell_number
+
+
+def verify_executed_and_no_cell_error(cells_info: list[dict[str, str]], notebook_path: str) -> None:
+    """Check if any cells have errors and raise RuntimeError if found.
+
+    Args:
+        cells_info: List of cell information dictionaries
+        notebook_path: Path to the notebook for error message
+
+    Raises:
+        RuntimeError: If any cell has an error or if no cells executed
+    """
+    # Log cell states for debugging
+    logger.debug(f"Verifying {len(cells_info)} cells from {notebook_path}")
+    for cell in cells_info:
+        logger.debug(
+            f"  Cell {cell['cell_index']}: execution_count={cell['cell_number']}, has_error={cell['has_error']}"
+        )
+
+    # Verify we found at least one cell
+    if not cells_info:
+        raise RuntimeError(
+            f"Notebook {notebook_path} validation failed: no cells found. The notebook may not have loaded properly."
+        )
+
+    # Verify all cells have execution counts (actually executed)
+    unexecuted_cells = [cell for cell in cells_info if not is_cell_executed(cell["cell_number"])]
+    if unexecuted_cells:
+        unexecuted_indices = [cell["cell_index"] for cell in unexecuted_cells]
+        unexecuted_numbers = [cell["cell_number"] for cell in unexecuted_cells]
+        raise RuntimeError(
+            f"Notebook {notebook_path} validation failed.\n"
+            f"{len(unexecuted_cells)} cell(s) did not execute completely.\n"
+            f"Cell indices: {unexecuted_indices}\n"
+            f"Cell execution states: {unexecuted_numbers}\n"
+            "The notebook may have failed to execute or is still executing."
+        )
+
+    errors_found = [cell for cell in cells_info if cell["has_error"] in ["True", "Possibly"]]
+    if errors_found:
+        raise RuntimeError(f"Notebook {notebook_path} execution failed with errors.")
+
+
+def delete_notebook_via_api(base_url: str, notebook_path: str) -> None:
+    """Delete a notebook using the Jupyter Contents API.
+
+    Args:
+        base_url: The base URL of the Jupyter server
+        notebook_path: Path to the notebook relative to /home/jovyan (e.g., "e2e-test/application_simple.ipynb")
+
+    Raises:
+        requests.HTTPError: If the delete request fails
+    """
+    delete_url = f"{base_url}/api/contents/{notebook_path}"
+    logger.debug(f"Deleting notebook via API: {delete_url}")
+
+    response = requests.delete(delete_url)
+    response.raise_for_status()
+
+    logger.debug(f"Successfully deleted notebook: {notebook_path}")
+
+
+def copy_and_clean_notebook(base_url: str, notebook_path: str, suffix: str = "-clean") -> str:
+    """Copy a notebook and clean its execution state using the Jupyter Contents API.
+
+    This creates a fresh copy of the notebook with:
+    - All cell outputs cleared
+    - All execution counts reset to None
+    - Execution metadata removed
+
+    By using a different path, this ensures jupyter-server-documents creates a new Y-doc room,
+    avoiding any corrupted session state from the original file's room.
+
+    Args:
+        base_url: The base URL of the Jupyter server
+        notebook_path: Path to the notebook relative to /home/jovyan (e.g., "e2e-test/application_simple.ipynb")
+        suffix: Suffix to append to the filename before the extension (default: "-clean")
+
+    Returns:
+        The path to the cleaned copy (e.g., "e2e-test/application_simple-clean.ipynb")
+
+    Raises:
+        requests.HTTPError: If the GET or PUT request fails
+    """
+    # 1. GET the original notebook
+    get_url = f"{base_url}/api/contents/{notebook_path}"
+    logger.info(f"Fetching notebook via API: {get_url}")
+
+    response = requests.get(get_url)
+    response.raise_for_status()
+
+    notebook_data = response.json()
+    content = notebook_data["content"]
+
+    # 2. Clean the execution state
+    logger.info(f"Cleaning execution state for {len(content['cells'])} cells")
+
+    for cell in content["cells"]:
+        # Clear outputs
+        if "outputs" in cell:
+            cell["outputs"] = []
+
+        # Clear execution count
+        if "execution_count" in cell:
+            cell["execution_count"] = None
+
+    # Clear notebook-level execution metadata if present
+    if "execution" in content.get("metadata", {}):
+        del content["metadata"]["execution"]
+
+    # 3. Create new path for the clean copy
+    # e.g., "e2e-test/application_simple.ipynb" -> "e2e-test/application_simple-clean.ipynb"
+    path_parts = notebook_path.rsplit(".", 1)
+    clean_path = f"{path_parts[0]}{suffix}.{path_parts[1]}"
+
+    # 4. PUT the cleaned notebook to the new path
+    put_url = f"{base_url}/api/contents/{clean_path}"
+    logger.info(f"Saving cleaned notebook to: {put_url}")
+
+    put_body = {"type": "notebook", "format": "json", "content": content}
+
+    put_response = requests.put(put_url, json=put_body)
+    put_response.raise_for_status()
+
+    logger.info(f"Successfully created cleaned notebook copy: {clean_path}")
+
+    return clean_path

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
@@ -331,25 +331,6 @@ def verify_executed_and_no_cell_error(cells_info: list[dict[str, str]], notebook
         raise RuntimeError(f"Notebook {notebook_path} execution failed with errors.")
 
 
-def delete_notebook_via_api(base_url: str, notebook_path: str) -> None:
-    """Delete a notebook using the Jupyter Contents API.
-
-    Args:
-        base_url: The base URL of the Jupyter server
-        notebook_path: Path to the notebook relative to /home/jovyan (e.g., "e2e-test/application_simple.ipynb")
-
-    Raises:
-        requests.HTTPError: If the delete request fails
-    """
-    delete_url = f"{base_url}/api/contents/{notebook_path}"
-    logger.debug(f"Deleting notebook via API: {delete_url}")
-
-    response = requests.delete(delete_url)
-    response.raise_for_status()
-
-    logger.debug(f"Successfully deleted notebook: {notebook_path}")
-
-
 def copy_and_clean_notebook(base_url: str, notebook_path: str, suffix: str = "-clean") -> str:
     """Copy a notebook and clean its execution state using the Jupyter Contents API.
 

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/remediation_strategy.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/remediation_strategy.py
@@ -1,0 +1,132 @@
+"""Remediation strategies for stuck notebook execution."""
+
+import logging
+import time
+from abc import ABC, abstractmethod
+
+from playwright.sync_api import Page
+
+from pytest_jupyter_deploy.notebooks.notebook_utils import (
+    close_all_tabs_and_stop_sessions,
+    copy_and_clean_notebook,
+    delete_notebook_via_api,
+    dismiss_document_session_error_if_present,
+    prepare_jupyterlab_to_run_notebook,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RemediationStrategy(ABC):
+    """Base class for notebook execution remediation strategies."""
+
+    @abstractmethod
+    def apply(self, page: Page, notebook_path: str) -> str | None:
+        """Apply the remediation strategy.
+
+        Args:
+            page: Playwright Page instance
+            notebook_path: Path to the notebook relative to /home/jovyan
+
+        Returns:
+            New notebook path if the strategy changed it (e.g., by copying to a new file),
+            None otherwise
+        """
+        pass
+
+    @abstractmethod
+    def description(self) -> str:
+        """Return a human-readable description of this strategy."""
+        pass
+
+
+class PageRefreshStrategy(RemediationStrategy):
+    """Refresh the page to reset websocket connections.
+
+    After refresh, the notebook should still be open and the recursive call
+    will continue polling without redoing the initial setup.
+    """
+
+    def apply(self, page: Page, notebook_path: str) -> str | None:
+        logger.info("Applying remediation: page refresh...")
+        page.reload()
+        time.sleep(2)  # Wait for page to reload
+        logger.info("Page refresh complete")
+        return None  # Path unchanged
+
+    def description(self) -> str:
+        return "page refresh"
+
+
+class CloseReopenStrategy(RemediationStrategy):
+    """Close all tabs and reopen the notebook.
+
+    This strategy performs a full setup: closes all tabs, reopens the notebook,
+    waits for kernel to be ready, and clicks Run All Cells. The recursive call
+    will then continue polling without redoing the setup.
+    """
+
+    def apply(self, page: Page, notebook_path: str) -> str | None:
+        logger.info("Applying remediation: close/reopen tabs...")
+
+        # Dismiss any "Document session error" dialog first (unblocks UI so we can close tabs)
+        dismissed_error_dialog = dismiss_document_session_error_if_present(page)
+
+        # Close all tabs using utility function
+        # If we dismissed an error dialog, wait longer for tabs to close (spinner cleanup)
+        extra_sleep_seconds = 1.5 if dismissed_error_dialog else 0.0
+        close_all_tabs_and_stop_sessions(page, extra_sleep_after_close_tabs_seconds=extra_sleep_seconds)
+
+        # Navigate to notebook, wait for it to load, and click Run All Cells
+        prepare_jupyterlab_to_run_notebook(page, notebook_path)
+
+        logger.info("Close/reopen complete, execution restarted")
+        return None  # Path unchanged
+
+    def description(self) -> str:
+        return "close/reopen tabs and restart execution"
+
+
+class CopyCleanStrategy(RemediationStrategy):
+    """Copy notebook to a new path, clean execution state, and delete the original.
+
+    This creates a fresh Y-doc room in jupyter-server-documents, avoiding any
+    corrupted session state from the original file's room. The strategy:
+    1. Copies the notebook to a new path with cleaned execution state
+    2. Deletes the original notebook
+    3. Closes all tabs and reopens the clean copy
+    4. Returns the new path for the recursive call to use
+    """
+
+    def apply(self, page: Page, notebook_path: str) -> str | None:
+        logger.info("Applying remediation: copy/clean/delete notebook...")
+
+        # Extract base URL from current page
+        # At this point we're on the notebook page (e.g., https://host/lab/tree/work/test.ipynb)
+        # so splitting on /lab will reliably give us the base URL (e.g., https://host)
+        current_url = page.url
+        base_url = current_url.split("/lab")[0] if "/lab" in current_url else current_url.rstrip("/")
+        logger.debug(f"Using base URL: {base_url}")
+
+        # Copy notebook to new path with cleaned execution state
+        # This creates a new Y-doc room, avoiding corrupted session state
+        clean_path = copy_and_clean_notebook(base_url, notebook_path)
+        logger.info(f"Created clean copy: {clean_path}")
+
+        # Delete the original notebook to avoid confusion
+        delete_notebook_via_api(base_url, notebook_path)
+        logger.info(f"Deleted original notebook: {notebook_path}")
+
+        # Dismiss any error dialogs and close all tabs
+        dismissed_error_dialog = dismiss_document_session_error_if_present(page)
+        extra_sleep_seconds = 1.5 if dismissed_error_dialog else 0.0
+        close_all_tabs_and_stop_sessions(page, extra_sleep_after_close_tabs_seconds=extra_sleep_seconds)
+
+        # Navigate to the clean copy, wait for it to load, and click Run All Cells
+        prepare_jupyterlab_to_run_notebook(page, clean_path)
+
+        logger.info(f"Copy/clean/delete complete, execution restarted with new path: {clean_path}")
+        return clean_path  # Return new path for recursive call
+
+    def description(self) -> str:
+        return "copy/clean/delete notebook and restart execution"

--- a/uv.lock
+++ b/uv.lock
@@ -724,7 +724,9 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-order" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "types-pexpect" },
+    { name = "types-requests" },
 ]
 
 [package.optional-dependencies]
@@ -739,7 +741,9 @@ requires-dist = [
     { name = "pytest-order", specifier = ">=1.3.0" },
     { name = "pytest-playwright", marker = "extra == 'ui'", specifier = ">=0.7.2" },
     { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "requests", specifier = ">=2.32.0" },
     { name = "types-pexpect", specifier = ">=4.9.0" },
+    { name = "types-requests", specifier = ">=2.32.0" },
 ]
 provides-extras = ["ui"]
 
@@ -995,6 +999,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload-time = "2025-05-16T03:08:04.019Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.4.20260107"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/f3/a0663907082280664d745929205a89d41dffb29e89a50f753af7d57d0a96/types_requests-2.32.4.20260107.tar.gz", hash = "sha256:018a11ac158f801bfa84857ddec1650750e393df8a004a8a9ae2a9bec6fcb24f", size = 23165, upload-time = "2026-01-07T03:20:54.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/12/709ea261f2bf91ef0a26a9eed20f2623227a8ed85610c1e54c5805692ecb/types_requests-2.32.4.20260107-py3-none-any.whl", hash = "sha256:b703fe72f8ce5b31ef031264fe9395cac8f46a04661a79f7ed31a80fb308730d", size = 20676, upload-time = "2026-01-07T03:20:52.929Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR hardens the base template and plugin notebook runner logic:
1. adds `onFailure: exit` to cloudinit SSM Document steps so that it has a change to restart instead of failing silently (#128)
2. retries installing efs utils in `volumes-init` script (#130)
3. adds remediation logic to notebook runner in plugin to a/ reload pages, b/ reload notebook, c/ re-upload and reload notebook (#131) - also refactor the notebook runner into utilities

### Customer experience
- no change

### Implementation
- create abstract class `RemediationStrategy` with an `apply()` method
- add child classes `PageRefreshStrategy`, `CloseReopenStrategy`, `CopyCleanStrategy`
- update `run_notebook_in_jupyterlab` to:
    - interrupt the notebook runner loop if it detects it's stuck (see #131)
    - call first `RediationStrategy.apply()` method
    - call itself recursively without the `RediationStrategy` that was just used by passing `rediation_strategies[1:]`

### Testing
- run E2E tests