### PR TITLE
fix: surface underlying cmd retcode in exec cmds

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -93,6 +93,9 @@ commands:
   - result-name: host.exec.stderr
     source: result
     source-key: '[0].StandardErrorContent'
+  - result-name: host.exec.returncode
+    source: result
+    source-key: '[0].ResponseCode'
 - cmd: server.status
   sequence:
   - api-name: aws.ssm.wait-command-sync
@@ -201,6 +204,9 @@ commands:
   - result-name: server.exec.stderr
     source: result
     source-key: '[0].StandardErrorContent'
+  - result-name: server.exec.returncode
+    source: result
+    source-key: '[0].ResponseCode'
 - cmd: server.connect
   sequence:
   - api-name: aws.ssm.start-session

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -132,7 +132,7 @@ def exec(
         handler = host_handler.HostHandler()
         console = handler.get_console()
 
-        stdout, stderr = handler.exec_command(command_args)
+        stdout, stderr, returncode = handler.exec_command(command_args)
 
         if stdout:
             console.rule("stdout")
@@ -144,3 +144,6 @@ def exec(
             console.rule("stderr")
             console.print(stderr)
             console.rule()
+
+        if returncode != 0:
+            raise typer.Exit(code=returncode)

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -229,7 +229,7 @@ def exec(
         console = handler.get_console()
 
         try:
-            stdout, stderr = handler.exec_command(service=service, command_args=command_args)
+            stdout, stderr, returncode = handler.exec_command(service=service, command_args=command_args)
         except InvalidServiceError as e:
             console.print(f":x: {e}", style="red")
             raise typer.Exit(code=1) from e
@@ -244,6 +244,9 @@ def exec(
             console.rule("stderr")
             console.print(stderr)
             console.rule()
+
+        if returncode != 0:
+            raise typer.Exit(code=returncode)
 
 
 @servers_app.command()

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
@@ -80,8 +80,8 @@ class HostHandler(BaseProjectHandler):
             cli_paramdefs={},
         )
 
-    def exec_command(self, command_args: list[str]) -> tuple[str, str]:
-        """Execute a command on the host, return the stdout and stderr."""
+    def exec_command(self, command_args: list[str]) -> tuple[str, str, int]:
+        """Execute a command on the host, return the stdout, stderr, and exit code."""
         command = self.project_manifest.get_command("host.exec")
         console = self.get_console()
         runner = cmd_runner.ManifestCommandRunner(
@@ -97,4 +97,5 @@ class HostHandler(BaseProjectHandler):
         )
         stdout = runner.get_result_value(command, "host.exec.stdout", str)
         stderr = runner.get_result_value(command, "host.exec.stderr", str)
-        return stdout, stderr
+        returncode = runner.get_result_value_with_fallback(command, "host.exec.returncode", int, 0)
+        return stdout, stderr, returncode

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
@@ -103,8 +103,8 @@ class ServerHandler(BaseProjectHandler):
         stderr = runner.get_result_value(command, "server.errors", str)
         return stdout, stderr
 
-    def exec_command(self, service: str, command_args: list[str]) -> tuple[str, str]:
-        """Execute a command inside a service container, return the stdout and stderr."""
+    def exec_command(self, service: str, command_args: list[str]) -> tuple[str, str, int]:
+        """Execute a command inside a service container, return the stdout, stderr, and exit code."""
         command = self.project_manifest.get_command("server.exec")
         validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
         console = self.get_console()
@@ -124,7 +124,8 @@ class ServerHandler(BaseProjectHandler):
         )
         stdout = runner.get_result_value(command, "server.exec.stdout", str)
         stderr = runner.get_result_value(command, "server.exec.stderr", str)
-        return stdout, stderr
+        returncode = runner.get_result_value_with_fallback(command, "server.exec.returncode", int, 0)
+        return stdout, stderr, returncode
 
     def connect(self, service: str) -> None:
         """Start an interactive shell session inside a service container."""

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
@@ -17,7 +17,11 @@ from jupyter_deploy.provider.resolved_argdefs import (
     require_arg,
     retrieve_optional_arg,
 )
-from jupyter_deploy.provider.resolved_resultdefs import ResolvedInstructionResult, StrResolvedInstructionResult
+from jupyter_deploy.provider.resolved_resultdefs import (
+    IntResolvedInstructionResult,
+    ResolvedInstructionResult,
+    StrResolvedInstructionResult,
+)
 
 START_SESSION_CMD = ["aws", "ssm", "start-session"]
 
@@ -121,6 +125,7 @@ class AwsSsmRunner(InstructionRunner):
         command_status = response["Status"]
         command_stdout = response.get("StandardOutputContent", "").rstrip()
         command_stderr = response.get("StandardErrorContent", "").rstrip()
+        command_response_code = response.get("ResponseCode", 0)
 
         if command_status == "Failed":
             console.print(f":x: command {doc_name_arg.value} failed.", style="red")
@@ -143,6 +148,7 @@ class AwsSsmRunner(InstructionRunner):
                 result_name="StandardErrorContent",
                 value=command_stderr,
             ),
+            "ResponseCode": IntResolvedInstructionResult(result_name="ResponseCode", value=command_response_code),
         }
 
     def _send_cmd_to_one_instance_using_default_shell_doc_and_wait_sync(
@@ -182,6 +188,7 @@ class AwsSsmRunner(InstructionRunner):
         command_status = response["Status"]
         command_stdout = response.get("StandardOutputContent", "").rstrip()
         command_stderr = response.get("StandardErrorContent", "").rstrip()
+        command_response_code = response.get("ResponseCode", 0)
 
         if command_status == "Failed":
             console.print(":x: command execution failed.", style="red")
@@ -204,6 +211,7 @@ class AwsSsmRunner(InstructionRunner):
                 result_name="StandardErrorContent",
                 value=command_stderr,
             ),
+            "ResponseCode": IntResolvedInstructionResult(result_name="ResponseCode", value=command_response_code),
         }
 
     def _start_session(

--- a/libs/jupyter-deploy/jupyter_deploy/provider/manifest_command_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/manifest_command_runner.py
@@ -119,6 +119,19 @@ class ManifestCommandRunner:
             )
         return value  # type: ignore
 
+    def get_result_value_with_fallback(
+        self, cmd_def: JupyterDeployCommandV1, result_name: str, expect_type: type[R], fallback: R
+    ) -> R:
+        """Return the transformed result value, or fallback if not found.
+
+        This method provides backward compatibility when results may not be defined
+        in older manifest versions.
+        """
+        try:
+            return self.get_result_value(cmd_def, result_name, expect_type)
+        except (StopIteration, KeyError):
+            return fallback
+
     def update_variables(self, cmd_def: JupyterDeployCommandV1) -> None:
         """Update the project variables based on the results."""
         updates = cmd_def.updates

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
@@ -44,15 +44,18 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_handler = Mock()
         mock_run_command_sequence = Mock()
         mock_get_result_value = Mock()
+        mock_get_result_value_with_fallback = Mock()
 
         mock_cmd_runner_handler.run_command_sequence = mock_run_command_sequence
         mock_cmd_runner_handler.get_result_value = mock_get_result_value
+        mock_cmd_runner_handler.get_result_value_with_fallback = mock_get_result_value_with_fallback
 
         mock_get_result_value.return_value = "running"
 
         return mock_cmd_runner_handler, {
             "run_command_sequence": mock_run_command_sequence,
             "get_result_value": mock_get_result_value,
+            "get_result_value_with_fallback": mock_get_result_value_with_fallback,
         }
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
@@ -126,6 +129,9 @@ class TestHostHandler(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             handler.connect()
 
+        with self.assertRaises(NotImplementedError):
+            handler.exec_command(["echo", "hello"])
+
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
@@ -166,6 +172,13 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_fns["run_command_sequence"].reset_mock()
         handler.restart_host()
         mock_cmd_runner_fns["run_command_sequence"].assert_called_with(mock.ANY, cli_paramdefs={})
+
+        # Test exec_command
+        mock_cmd_runner_fns["run_command_sequence"].reset_mock()
+        handler.exec_command(["echo", "hello"])
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("commands", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["commands"].value, ["echo hello"])
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
@@ -422,3 +435,108 @@ class TestHostHandler(unittest.TestCase):
         self.assertEqual(mock_cmd_runner_class.call_args[1]["output_handler"], mock_output_handler)
         self.assertEqual(mock_cmd_runner_class.call_args[1]["variable_handler"], mock_variable_handler)
         mock_cmd_runner_fns["run_command_sequence"].assert_called_once_with(mock_cmd, cli_paramdefs={})
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_exec_command_calls_run_command_and_returns_stdout_stderr_returncode(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        # Setup
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_output_handler, _ = self.get_mock_outputs_handler_and_fns()
+
+        mock_tf_outputs_handler.return_value = mock_output_handler
+        mock_variable_handler = Mock()
+        mock_tf_variables_handler.return_value = mock_variable_handler
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        # Setup get_result_value and get_result_value_with_fallback behavior
+        mock_cmd_runner_fns["get_result_value"].side_effect = ["test stdout", "test stderr"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 0
+
+        # Act
+        handler = HostHandler()
+        stdout, stderr, returncode = handler.exec_command(["echo", "hello"])
+
+        # Verify
+        self.assertEqual(stdout, "test stdout")
+        self.assertEqual(stderr, "test stderr")
+        self.assertEqual(returncode, 0)
+
+        mock_cmd_runner_class.assert_called_once()
+        mock_manifest_fns["get_command"].assert_called_once_with("host.exec")
+        self.assertEqual(mock_cmd_runner_class.call_args[1]["output_handler"], mock_output_handler)
+        self.assertEqual(mock_cmd_runner_class.call_args[1]["variable_handler"], mock_variable_handler)
+
+        # Check CLI parameters
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertEqual(len(cli_paramdefs), 1)
+        self.assertIn("commands", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["commands"].parameter_name, "commands")
+        self.assertEqual(cli_paramdefs["commands"].value, ["echo hello"])
+
+        # Verify get_result_value was called for stdout and stderr
+        self.assertEqual(mock_cmd_runner_fns["get_result_value"].call_count, 2)
+        self.assertEqual(mock_cmd_runner_fns["get_result_value"].mock_calls[0][1][1], "host.exec.stdout")
+        self.assertEqual(mock_cmd_runner_fns["get_result_value"].mock_calls[1][1][1], "host.exec.stderr")
+
+        # Verify get_result_value_with_fallback was called for returncode
+        mock_cmd_runner_fns["get_result_value_with_fallback"].assert_called_once_with(
+            mock_cmd, "host.exec.returncode", int, 0
+        )
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_exec_command_returns_non_zero_returncode_on_failure(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        # Setup
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_output_handler, _ = self.get_mock_outputs_handler_and_fns()
+
+        mock_tf_outputs_handler.return_value = mock_output_handler
+        mock_variable_handler = Mock()
+        mock_tf_variables_handler.return_value = mock_variable_handler
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        # Setup get_result_value and get_result_value_with_fallback behavior
+        mock_cmd_runner_fns["get_result_value"].side_effect = ["", "command not found"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 127
+
+        # Act
+        handler = HostHandler()
+        stdout, stderr, returncode = handler.exec_command(["command_that_does_not_exist"])
+
+        # Verify
+        self.assertEqual(stdout, "")
+        self.assertEqual(stderr, "command not found")
+        self.assertEqual(returncode, 127)
+
+        # Verify get_result_value_with_fallback was called for returncode
+        mock_cmd_runner_fns["get_result_value_with_fallback"].assert_called_once_with(
+            mock_cmd, "host.exec.returncode", int, 0
+        )

--- a/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
+++ b/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
@@ -65,6 +65,26 @@ commands:
           - api-attribute: "instance_id"
             source: "output"
             source-key: "instance_id"
+  - cmd: "host.exec"
+    sequence:
+      - api-name: "aws.ssm.wait-default-shell-command-sync"
+        arguments:
+          - api-attribute: "instance_id"
+            source: "output"
+            source-key: "instance_id"
+          - api-attribute: "commands"
+            source: "cli"
+            source-key: "commands"
+    results:
+      - result-name: "host.exec.stdout"
+        source: "result"
+        source-key: "[0].StandardOutputContent"
+      - result-name: "host.exec.stderr"
+        source: "result"
+        source-key: "[0].StandardErrorContent"
+      - result-name: "host.exec.returncode"
+        source: "result"
+        source-key: "[0].ResponseCode"
   - cmd: "server.status"
     sequence:
       - api-name: "aws.ssm.wait-command-sync"
@@ -150,6 +170,32 @@ commands:
     - result-name: server.errors
       source: result
       source-key: '[0].StandardErrorContent'
+  - cmd: "server.exec"
+    sequence:
+      - api-name: "aws.ssm.wait-command-sync"
+        arguments:
+          - api-attribute: "document_name"
+            source: "output"
+            source-key: "server_exec_document"
+          - api-attribute: "instance_id"
+            source: "output"
+            source-key: "instance_id"
+          - api-attribute: "service"
+            source: "cli"
+            source-key: "service"
+          - api-attribute: "commands"
+            source: "cli"
+            source-key: "commands"
+    results:
+      - result-name: "server.exec.stdout"
+        source: "result"
+        source-key: "[0].StandardOutputContent"
+      - result-name: "server.exec.stderr"
+        source: "result"
+        source-key: "[0].StandardErrorContent"
+      - result-name: "server.exec.returncode"
+        source: "result"
+        source-key: "[0].ResponseCode"
   - cmd: "users.add"
     sequence:
       - api-name: "aws.ssm.wait-command-sync"

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/commands.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/commands.py
@@ -1,0 +1,45 @@
+"""Command execution utilities for E2E tests."""
+
+import subprocess
+
+from pytest_jupyter_deploy.cli import JDCliError
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+
+
+def verify_server_command_fails(
+    e2e_deployment: EndToEndDeployment,
+    command_args: list[str],
+    expected_returncode: int,
+    stderr_contains: str,
+) -> None:
+    """Verify that a server command fails with expected error.
+
+    Args:
+        e2e_deployment: The deployment instance
+        command_args: Full command arguments (e.g., ["jupyter-deploy", "server", "exec", "--", "false"])
+        expected_returncode: Expected return code (e.g., 1, 126, 127)
+        stderr_contains: Substring that should appear in stderr (case-insensitive)
+
+    Raises:
+        AssertionError: If command succeeds or fails with unexpected error
+    """
+    try:
+        result = e2e_deployment.cli.run_command(command_args)
+        # If we reach here, the command succeeded unexpectedly
+        raise AssertionError(f"Expected command {command_args} to fail, but it succeeded with output: {result.stdout}")
+    except JDCliError as e:
+        # Command failed as expected - now verify it failed for the right reason
+        if not (e.__cause__ and isinstance(e.__cause__, subprocess.CalledProcessError)):
+            raise AssertionError(f"Expected CalledProcessError, but got unexpected error type: {e}") from e
+
+        # Check return code
+        actual_returncode = e.__cause__.returncode
+        if actual_returncode != expected_returncode:
+            raise AssertionError(
+                f"Expected return code {expected_returncode}, but got {actual_returncode}. Error: {e}"
+            ) from e
+
+        # Check error message in stderr
+        error_output = str(e).lower()
+        if stderr_contains.lower() not in error_output:
+            raise AssertionError(f"Expected stderr to contain '{stderr_contains}', but got: {e}") from e

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/files.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/files.py
@@ -1,37 +1,64 @@
 """File operation utilities for E2E tests."""
 
 import base64
+import subprocess
 from pathlib import Path
 
+from pytest_jupyter_deploy.cli import JDCliError
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 
 
 def verify_file_exists_on_server(e2e_deployment: EndToEndDeployment, file_path: str) -> None:
     """Verify that a file exists on the server."""
-    result = e2e_deployment.cli.run_command(
-        ["jupyter-deploy", "server", "exec", "--", "stat", "--format=%F", file_path]
-    )
-    assert "No such file or directory" not in result.stdout, f"Expected file {file_path} to exist on server"
+    try:
+        result = e2e_deployment.cli.run_command(
+            ["jupyter-deploy", "server", "exec", "--", "stat", "--format=%F", file_path]
+        )
+    except JDCliError as e:
+        raise AssertionError(f"Expected file {file_path} to exist on server, but stat failed: {e}") from e
+
     assert "file" in result.stdout, f"Expected file {file_path} to be of type file: {result.stdout}"
 
 
 def verify_dir_exists_on_server(e2e_deployment: EndToEndDeployment, dir_path: str) -> None:
-    """Verify that a file exists on the server."""
-    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", "stat", "--format=%F", dir_path])
-    assert "No such file or directory" not in result.stdout, f"Expected dir {dir_path} to exist on server"
+    """Verify that a directory exists on the server."""
+    try:
+        result = e2e_deployment.cli.run_command(
+            ["jupyter-deploy", "server", "exec", "--", "stat", "--format=%F", dir_path]
+        )
+    except JDCliError as e:
+        raise AssertionError(f"Expected directory {dir_path} to exist on server, but stat failed: {e}") from e
+
     assert "directory" in result.stdout, f"Expected directory {dir_path} to be of type dir: {result.stdout}"
 
 
 def verify_file_or_dir_does_not_exist_on_server(e2e_deployment: EndToEndDeployment, file_path: str) -> None:
-    """Verify that a file does not exist on the server."""
-    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", "stat", file_path])
-    # When stat fails, the error message appears in stdout (captured by the CLI wrapper)
-    # The message may be split across lines, so normalize whitespace before checking
-    stdout_normalized = " ".join(result.stdout.split())
-    stderr_normalized = " ".join(result.stderr.split())
-    assert "No such file or directory" in stdout_normalized or "No such file or directory" in stderr_normalized, (
-        f"Expected file {file_path} to not exist on server"
-    )
+    """Verify that a file or directory does not exist on the server."""
+    try:
+        result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", "stat", file_path])
+        # If stat succeeded, the file exists - this is unexpected
+        raise AssertionError(
+            f"Expected file {file_path} to not exist on server, but stat succeeded with output: {result.stdout}"
+        )
+    except JDCliError as e:
+        # Verify it failed because the file doesn't exist, not some other error
+        if e.__cause__ and isinstance(e.__cause__, subprocess.CalledProcessError):
+            # Verify exit code is 1 (stat returns 1 for "No such file or directory")
+            actual_returncode = e.__cause__.returncode
+            if actual_returncode != 1:
+                raise AssertionError(
+                    f"Expected exit code 1 for non-existent file {file_path}, but got {actual_returncode}. Error: {e}"
+                ) from e
+
+            # Normalize whitespace to handle error messages split across lines
+            error_output_normalized = " ".join(str(e).split())
+            if "No such file or directory" not in error_output_normalized:
+                raise AssertionError(
+                    f"Expected file {file_path} to not exist, but stat failed for a different reason: {e}"
+                ) from e
+            # File doesn't exist as expected
+        else:
+            raise AssertionError(f"Unexpected error type when checking if {file_path} exists: {e}") from e
 
 
 def upload_file_on_server(e2e_deployment: EndToEndDeployment, src_path: str | Path, target_path: str) -> None:


### PR DESCRIPTION
This PR update `jd host exec` and `jd server exec` logic to look through the command executed on the host or server and surface its return code. Previously, the exec commands returned `0` as return code if the `SSM:SendCommand` API call succeeded (for the base template), irrespective of whether the underlying command failed or succeeded. This behavior was counter-intuitive for users.

Addresses #129 

### User experience
- `jd server exec -- whoami` --> `jovyan`, retcode=0
- `jd server exec -- unknown-cmd` --> <error msg>, retcode=126 (docker)
- `jd host exec -- pwd` --> `/`, retcode = 0
- `jd host exec -- unknown-cmd` --> <error msg>, retcode=127

### Implementation
- update `HostHandler.exec()` and `ServerHandler.exec()` to return the retcode
- update `host`/`server` cli to return the underlying retcode from handler
- update the base template `manifest.yaml` to add the retcode to the `exec` cmds results
- update e2e tests and plugin to take into account this new behavior

### Testing
- unit tests (updated)
- ran e2e tests