### PR TITLE
fix: harden ebs mount, instance restart

### DIFF
--- a/env.example
+++ b/env.example
@@ -3,7 +3,16 @@
 # The docker-compose will automatically load .env from the repository root
 
 # ==============================================================================
-# DEPLOYMENT CONFIGURATION
+# TEST CONTAINER BUILD CONFIGURATION
+# ==============================================================================
+
+# Leave blank the host settings, the justfile methods will populate them
+HOST_UID=
+HOST_GID=
+
+
+# ==============================================================================
+# JUPYTER DEPLOYMENT CONFIGURATION
 # ==============================================================================
 
 # Domain configuration

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/local-await-server.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/local-await-server.sh.tftpl
@@ -11,8 +11,11 @@ wait_for_instance(){
     local SLEEP_INTERVAL_SECONDS=10
     local total_wait_seconds=0
 
+    # pass include-all-instances is necessary to ensure
+    # EC2:DescribeInstanceStatus returns stopped instance
     INSTANCE_STATE=$(aws ec2 describe-instance-status \
         --instance-ids "$INSTANCE_ID" \
+        --include-all-instances \
         --query "InstanceStatuses[0].InstanceState.Name" \
         --output text)
 
@@ -22,6 +25,17 @@ wait_for_instance(){
         # shorter sleep here: the instance may have been running for a while
         sleep 15
         return 0
+    fi
+
+    # If the instance is stopped, start it
+    if [ "$INSTANCE_STATE" = "stopped" ]; then
+        echo "Instance is stopped, starting it..."
+        aws ec2 start-instances --instance-ids "$INSTANCE_ID" > /dev/null
+        # Update state to pending so the loop below will wait for it
+        INSTANCE_STATE="pending"
+
+        # sleep SLEEP_INTERVAL_SECONDS in the while loop gives
+        # enough time to aws describe-instances to update.
     fi
 
     while [ "$INSTANCE_STATE" = "pending" ] || [ "$INSTANCE_STATE" = "rebooting" ]; do
@@ -35,6 +49,7 @@ wait_for_instance(){
 
         INSTANCE_STATE=$(aws ec2 describe-instance-status \
             --instance-ids "$INSTANCE_ID" \
+            --include-all-instances \
             --query "InstanceStatuses[0].InstanceState.Name" \
             --output text)
     done

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/services.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/services.tf
@@ -518,6 +518,7 @@ resource "aws_ssm_association" "instance_startup_with_secret" {
 
   depends_on = [
     module.secret,
-    module.ec2_instance
+    module.ec2_instance,
+    module.volumes
   ]
 }

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit-volumes.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit-volumes.sh.tftpl
@@ -18,36 +18,54 @@ setup_ebs() {
 
     mkdir -p "$FULL_MOUNT_POINT"
 
-    # Check if device exists and is a block device
-    if [ -b "$device_name" ]; then
-        if ! blkid "$device_name" > /dev/null; then
-            echo "Formatting $device_name with ext4..."
-            mkfs -t ext4 "$device_name"
-        else
-            echo "Device $device_name already formatted"
-        fi
+    # Wait for device to become available with retry
+    MAX_RETRIES=2
+    RETRY_COUNT=0
+    RETRY_DELAY=2
 
-        if ! grep -q "$FULL_MOUNT_POINT" /etc/fstab; then
-            echo "Adding to fstab: $device_name $FULL_MOUNT_POINT ext4 defaults 0 2"
-            echo "$device_name $FULL_MOUNT_POINT ext4 defaults,nofail 0 2" | tee -a /etc/fstab
+    while [ $RETRY_COUNT -le $MAX_RETRIES ]; do
+        if [ -b "$device_name" ]; then
+            echo "Device $device_name is available"
+            break
         else
-            echo "fstab entry for $FULL_MOUNT_POINT already exists"
+            RETRY_COUNT=$((RETRY_COUNT + 1))
+            if [ $RETRY_COUNT -le $MAX_RETRIES ]; then
+                echo "Device $device_name not yet available (attempt $RETRY_COUNT/$((MAX_RETRIES + 1))), waiting $${RETRY_DELAY}s..."
+                sleep $RETRY_DELAY
+                RETRY_DELAY=$((RETRY_DELAY * 2))
+            else
+                echo "Error: Device $device_name not found after $((MAX_RETRIES + 1)) attempts"
+                exit 1
+            fi
         fi
+    done
 
-        if ! mountpoint -q "$FULL_MOUNT_POINT"; then
-            echo "Mounting $device_name to $FULL_MOUNT_POINT"
-            mount "$FULL_MOUNT_POINT"
-        else
-            echo "$FULL_MOUNT_POINT is already mounted"
-        fi
-
-        echo "Setting permissions on $FULL_MOUNT_POINT"
-        chown -R service-user:service-user "$FULL_MOUNT_POINT"
-        chmod 750 "$FULL_MOUNT_POINT"
-        echo "EBS volume for $mount_point initialization complete"
+    # Device is available, proceed with setup
+    if ! blkid "$device_name" > /dev/null; then
+        echo "Formatting $device_name with ext4..."
+        mkfs -t ext4 "$device_name"
     else
-        echo "Error: Device $device_name not found for mounting to $FULL_MOUNT_POINT"
+        echo "Device $device_name already formatted"
     fi
+
+    if ! grep -q "$FULL_MOUNT_POINT" /etc/fstab; then
+        echo "Adding to fstab: $device_name $FULL_MOUNT_POINT ext4 defaults 0 2"
+        echo "$device_name $FULL_MOUNT_POINT ext4 defaults,nofail 0 2" | tee -a /etc/fstab
+    else
+        echo "fstab entry for $FULL_MOUNT_POINT already exists"
+    fi
+
+    if ! mountpoint -q "$FULL_MOUNT_POINT"; then
+        echo "Mounting $device_name to $FULL_MOUNT_POINT"
+        mount "$FULL_MOUNT_POINT"
+    else
+        echo "$FULL_MOUNT_POINT is already mounted"
+    fi
+
+    echo "Setting permissions on $FULL_MOUNT_POINT"
+    chown -R service-user:service-user "$FULL_MOUNT_POINT"
+    chmod 750 "$FULL_MOUNT_POINT"
+    echo "EBS volume for $mount_point initialization complete"
 }
 %{ for ebs in ebs_volumes ~}
 setup_ebs "${ebs.mount_point}" "${ebs.device_name}"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/image/docker-compose.yml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/image/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - ~/.aws:/home/testuser/.aws:ro
       # Mount X11 socket for GUI applications
       - /tmp/.X11-unix:/tmp/.X11-unix
+      # Mount test-results directory for test artifacts (screenshots, logs)
+      - ./test-results:/workspace/test-results
       # Project directory will be mounted dynamically via override file in justfile
     environment:
       - DISPLAY=${DISPLAY}

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/image/docker-compose.yml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/image/docker-compose.yml
@@ -18,8 +18,6 @@ services:
       - ~/.aws:/home/testuser/.aws:ro
       # Mount X11 socket for GUI applications
       - /tmp/.X11-unix:/tmp/.X11-unix
-      # Mount test-results directory for test artifacts (screenshots, logs)
-      - ./test-results:/workspace/test-results
       # Project directory will be mounted dynamically via override file in justfile
     environment:
       - DISPLAY=${DISPLAY}

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/image/docker-compose.yml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/image/docker-compose.yml
@@ -8,7 +8,6 @@ services:
         USER_GID: ${HOST_GID:-1000}
     image: jupyter-deploy-e2e-aws-ec2-base:latest
     container_name: jupyter-deploy-e2e-aws-ec2-base
-    hostname: ${HOSTNAME:-localhost}
     working_dir: /workspace
     # User is set in Dockerfile based on build args
     volumes:


### PR DESCRIPTION
This PR a/ adds retry logic in volume initialization script responsible to configure external mount on the host, b/ make the ssm-association dependent on the completion of ebs creation and mount (as in, the aws operation), c/ add handling for stopped instances in waiter script.

Addresses #138 

### Customer experience
- no change

### Implementation
- add retries to `volume-init`
- add `module.volumes` as dependency of SSM Association
- update waiter script

### Testing
- run E2E test
- run `jd config & jd up` from stopped instance --> verified restart