### PR TITLE
feat: history cmds

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_history.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_history.py
@@ -1,0 +1,216 @@
+"""E2E tests for jd history commands."""
+
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+
+
+def test_history_list_config_shows_existing_logs(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that jd history list config shows existing logs with expected format.
+
+    This test:
+    1. Ensures deployment exists with some history
+    2. Runs jd history list config (table format)
+    3. Verifies output is non-empty
+    4. Verifies table contains expected columns
+    5. Runs jd history list config --text
+    6. Verifies plain text output shows file paths
+    """
+    e2e_deployment.ensure_deployed()
+
+    # Run jd history list config (table format)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "list", "config"])
+
+    # Verify output is non-empty
+    assert result.stdout.strip(), "Expected non-empty output from jd history list config"
+
+    # Verify table headers are present
+    assert "Log Type" in result.stdout, "Expected 'Log Type' column in table output"
+    assert "Timestamp" in result.stdout, "Expected 'Timestamp' column in table output"
+    assert "Location" in result.stdout, "Expected 'Location' column in table output"
+
+    # Verify at least one log entry exists (should contain "file" as storage type)
+    assert "file" in result.stdout, "Expected at least one file-based log entry"
+
+    # Run jd history list config --text (plain text format)
+    result_text = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "list", "config", "--text"])
+
+    # Verify plain text output shows file paths
+    assert result_text.stdout.strip(), "Expected non-empty output from jd history list config --text"
+    # Should contain .log file paths
+    assert ".log" in result_text.stdout, "Expected .log file paths in plain text output"
+
+
+def test_history_list_up_shows_existing_logs(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that jd history list up shows existing logs with expected format.
+
+    This test:
+    1. Ensures deployment exists with some history
+    2. Runs jd history list up (table format)
+    3. Verifies output is non-empty
+    4. Verifies table contains expected columns
+    5. Runs jd history list up --text
+    6. Verifies plain text output shows file paths
+    """
+    e2e_deployment.ensure_deployed()
+
+    # Run jd history list up (table format)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "list", "up"])
+
+    # Verify output is non-empty
+    assert result.stdout.strip(), "Expected non-empty output from jd history list up"
+
+    # Verify table headers are present
+    assert "Log Type" in result.stdout, "Expected 'Log Type' column in table output"
+    assert "Timestamp" in result.stdout, "Expected 'Timestamp' column in table output"
+    assert "Location" in result.stdout, "Expected 'Location' column in table output"
+
+    # Verify at least one log entry exists (should contain "file" as storage type)
+    assert "file" in result.stdout, "Expected at least one file-based log entry"
+
+    # Run jd history list up --text (plain text format)
+    result_text = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "list", "up", "--text"])
+
+    # Verify plain text output shows file paths
+    assert result_text.stdout.strip(), "Expected non-empty output from jd history list up --text"
+    # Should contain .log file paths
+    assert ".log" in result_text.stdout, "Expected .log file paths in plain text output"
+
+
+def test_history_show_latest_without_command(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that jd history show displays most recent log across all commands.
+
+    This test:
+    1. Ensures deployment exists with execution history
+    2. Runs jd history show (no command argument)
+    3. Verifies command succeeds
+    4. Verifies output contains log content
+    """
+    e2e_deployment.ensure_deployed()
+
+    # Run jd history show (no command argument)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "show"])
+
+    # Verify command succeeded
+    assert result.returncode == 0, f"Expected jd history show to succeed, got returncode {result.returncode}"
+
+    # Verify output contains content (should be non-empty)
+    assert result.stdout.strip(), "Expected non-empty log content from jd history show"
+
+    # Should contain terraform-related content since last command was likely config or up
+    # At minimum, logs should contain some recognizable content
+    assert len(result.stdout) > 100, "Expected substantial log content (>100 chars)"
+
+
+def test_history_show_config_command(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that jd history show config displays latest config log.
+
+    This test:
+    1. Ensures deployment exists with config history
+    2. Runs jd history show config
+    3. Verifies output displays log content
+    4. Verifies content contains terraform-related keywords
+    """
+    e2e_deployment.ensure_deployed()
+
+    # Run jd history show config
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "show", "config"])
+
+    # Verify command succeeded
+    assert result.returncode == 0, f"Expected jd history show config to succeed, got returncode {result.returncode}"
+
+    # Verify output contains content
+    assert result.stdout.strip(), "Expected non-empty log content from jd history show config"
+
+    # Verify content contains terraform-related keywords
+    # Config logs should contain terraform plan output
+    stdout_lower = result.stdout.lower()
+    assert "terraform" in stdout_lower, "Expected 'terraform' keyword in config log"
+
+
+def test_history_show_up_command(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that jd history show up displays latest up log.
+
+    This test:
+    1. Ensures deployment exists with up history
+    2. Runs jd history show up
+    3. Verifies output displays log content
+    4. Verifies content contains terraform-related keywords
+    """
+    e2e_deployment.ensure_deployed()
+
+    # Run jd history show up
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "show", "up"])
+
+    # Verify command succeeded
+    assert result.returncode == 0, f"Expected jd history show up to succeed, got returncode {result.returncode}"
+
+    # Verify output contains content
+    assert result.stdout.strip(), "Expected non-empty log content from jd history show up"
+
+    # Verify content contains terraform-related keywords
+    # Up logs should contain terraform apply output
+    stdout_lower = result.stdout.lower()
+    assert "terraform" in stdout_lower, "Expected 'terraform' keyword in up log"
+
+
+def test_history_show_up_command_slice(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that jd history show up with -l and -s flags correctly slices log output.
+
+    This test:
+    1. Ensures deployment exists with up history
+    2. Runs jd history show up -l 20 -s 10
+    3. Verifies output displays sliced log content
+    4. Verifies output has expected line count (at most 20 lines)
+    """
+    e2e_deployment.ensure_deployed()
+
+    # Run jd history show up -l 20 -s 10
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "show", "up", "-l", "20", "-s", "10"])
+
+    # Verify command succeeded
+    assert result.returncode == 0, (
+        f"Expected jd history show up -l 20 -s 10 to succeed, got returncode {result.returncode}"
+    )
+
+    # Verify output contains content
+    assert result.stdout.strip(), "Expected non-empty log content from jd history show up -l 20 -s 10"
+
+    # Count lines in output
+    lines = result.stdout.splitlines()
+    assert len(lines) <= 20, f"Expected at most 20 lines, got {len(lines)}"
+
+    # Should have some content (assuming logs are long enough)
+    assert len(lines) > 0, "Expected at least some lines in sliced output"
+
+
+def test_history_clear_with_high_keep_value(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that jd history clear -k 100 succeeds without errors.
+
+    This test:
+    1. Ensures deployment exists with config history
+    2. Runs jd history clear config -k 100
+    3. Verifies command succeeds (exit code 0)
+    4. Verifies appropriate message is displayed
+
+    Note: Using -k 100 makes this effectively non-mutating since most
+    deployments won't have 100 logs to clean up.
+    """
+    e2e_deployment.ensure_deployed()
+
+    # Run jd history clear config -k 100
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "clear", "config", "-k", "100"])
+
+    # Verify command succeeded
+    assert result.returncode == 0, (
+        f"Expected jd history clear config -k 100 to succeed, got returncode {result.returncode}"
+    )
+
+    # Verify output contains an appropriate message
+    # Either "No stale log files to clear" or success message about cleared files
+    assert result.stdout.strip(), "Expected non-empty output from jd history clear"
+
+    # Should contain one of these patterns
+    stdout_lower = result.stdout.lower()
+    has_expected_message = (
+        "no stale log files to clear" in stdout_lower or "cleared" in stdout_lower or "kept" in stdout_lower
+    )
+    assert has_expected_message, f"Expected appropriate clear message, got: {result.stdout}"

--- a/libs/jupyter-deploy/jupyter_deploy/cli/history_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/history_app.py
@@ -15,7 +15,7 @@ from jupyter_deploy.handlers.command_history_handler import (
 )
 
 history_app = typer.Typer(
-    help=("View and manage logs emitted by the infrastructure-as-code engine as called by jupyter-deploy commands."),
+    help=("View and manage logs emitted by the infrastructure-as-code engine within jupyter-deploy commands."),
     no_args_is_help=True,
 )
 
@@ -24,7 +24,7 @@ history_app = typer.Typer(
 def list(
     command: Annotated[
         HistoryEnabledCommandType,
-        typer.Argument(help="Command type: config, up, or down."),
+        typer.Argument(help="Jupyter-deploy command that generated the logs."),
     ],
     project_dir: Annotated[
         str | None,
@@ -47,7 +47,7 @@ def list(
     with cmd_utils.project_dir(project_dir):
         project_path = Path.cwd()
         handler = CommandHistoryHandler(project_path)
-        logs = handler.list_logs(command.value, max_logs=n)
+        logs = handler.list_logs(command, max_logs=n)
 
         console = Console()
 
@@ -80,7 +80,7 @@ def show(
     command: Annotated[
         HistoryEnabledCommandType | None,
         typer.Argument(
-            help="Command type: config, up, or down. If omitted, show latest log from any command.",
+            help="Jupyter-deploy command that generated the log. If omitted, show latest log from any command.",
         ),
     ] = None,
     project_dir: Annotated[
@@ -119,7 +119,7 @@ def show(
 
         # Get log descriptor
         if command:
-            logs = handler.list_logs(command.value, max_logs=n)
+            logs = handler.list_logs(command, max_logs=n)
             if len(logs) < n:
                 if n == 1 or not logs:
                     console.print(
@@ -191,7 +191,7 @@ def clear(
     with cmd_utils.project_dir(project_dir):
         project_path = Path.cwd()
         handler = CommandHistoryHandler(project_path)
-        result = handler.clear_logs(command.value, keep=keep)
+        result = handler.clear_logs(command, keep=keep)
 
         if result.total_cleaned == 0 and result.total_failed == 0:
             console.print(":information: No stale log files to clear.")

--- a/libs/jupyter-deploy/jupyter_deploy/cli/history_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/history_app.py
@@ -1,0 +1,217 @@
+"""CLI commands for managing execution history and log files."""
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from jupyter_deploy import cmd_utils
+from jupyter_deploy.enum import HistoryEnabledCommandType
+from jupyter_deploy.handlers.command_history_handler import (
+    CommandHistoryHandler,
+    LogNotFound,
+)
+
+history_app = typer.Typer(
+    help=("View and manage logs emitted by the infrastructure-as-code engine as called by jupyter-deploy commands."),
+    no_args_is_help=True,
+)
+
+
+@history_app.command()
+def list(
+    command: Annotated[
+        HistoryEnabledCommandType,
+        typer.Argument(help="Command type: config, up, or down."),
+    ],
+    project_dir: Annotated[
+        str | None,
+        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+    ] = None,
+    n: Annotated[
+        int,
+        typer.Option("-n", help="Maximum number of logs to display", min=1),
+    ] = 20,
+    text: Annotated[
+        bool,
+        typer.Option("--text", help="Output plain text without Rich markup."),
+    ] = False,
+) -> None:
+    """Show the list of execution logs available in the project for a specific command.
+
+    Run either from a jupyter-deploy project directory that you created with `jd init`;
+    or pass a --path PATH to such a directory.
+    """
+    with cmd_utils.project_dir(project_dir):
+        project_path = Path.cwd()
+        handler = CommandHistoryHandler(project_path)
+        logs = handler.list_logs(command.value, max_logs=n)
+
+        console = Console()
+
+        if not logs:
+            console.print(f"No execution logs found for command: [bold cyan]{command.value}[/]")
+            return
+
+        if text:
+            # Plain text mode - just print __repr__ (file paths)
+            for log in logs:
+                console.print(repr(log))
+        else:
+            # Table mode - formatted display
+            table = Table(title="Execution History Logs", show_header=True, header_style="bold cyan")
+            table.add_column("Log Type", style="green")
+            table.add_column("Timestamp", style="blue")
+            table.add_column("Location", style="dim")
+
+            for log in logs:
+                table.add_row(
+                    log.storage_type,  # "file", "cloudwatch", etc.
+                    log.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+                    repr(log),  # File path or other representation
+                )
+            console.print(table)
+
+
+@history_app.command()
+def show(
+    command: Annotated[
+        HistoryEnabledCommandType | None,
+        typer.Argument(
+            help="Command type: config, up, or down. If omitted, show latest log from any command.",
+        ),
+    ] = None,
+    project_dir: Annotated[
+        str | None,
+        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+    ] = None,
+    n: Annotated[
+        int,
+        typer.Option("-n", help="Show Nth most recent log for the command.", min=1),
+    ] = 1,
+    lines: Annotated[
+        int | None,
+        typer.Option("-l", "--lines", help="Show only last L lines of the log content.", min=1),
+    ] = None,
+    skip: Annotated[
+        int,
+        typer.Option("-s", "--skip", help="Skip S lines from end (for pagination).", min=0),
+    ] = 0,
+) -> None:
+    """Display the content of a specific command execution log.
+
+    Run either from a jupyter-deploy project directory that you created with `jd init`;
+    or pass a --path PATH to such a directory.
+
+    By default, displays the content of the entire log.
+
+    Use --lines/-l to show only the last N lines.
+
+    Use --skip/-s to offset the first line returned (from the end of the content).
+    """
+    console = Console()
+
+    with cmd_utils.project_dir(project_dir):
+        project_path = Path.cwd()
+        handler = CommandHistoryHandler(project_path)
+
+        # Get log descriptor
+        if command:
+            logs = handler.list_logs(command.value, max_logs=n)
+            if len(logs) < n:
+                if n == 1 or not logs:
+                    console.print(
+                        f":x: No log found for command: [bold]{command.value}[/]",
+                        style="red",
+                    )
+                else:
+                    console.print(
+                        (
+                            f":x: [bold]{n}th[/] log not found for command: [bold]{command.value}[/]\n"
+                            f"Only {len(logs)} logs are available."
+                        ),
+                        style="red",
+                    )
+                raise typer.Exit(code=1)
+            log_descriptor = logs[n - 1]
+        else:
+            maybe_log_descriptor = handler.get_latest_log()
+            if not maybe_log_descriptor:
+                console.print(":information: No execution logs found.")
+                return
+            log_descriptor = maybe_log_descriptor
+
+        # Display log content
+        try:
+            if lines or skip:
+                # Tail/pagination mode - use get_log_lines with bounded memory
+                max_lines = lines or 1000  # Default to 1000 when skip is used without -l
+                log_lines = handler.get_log_lines(log_descriptor, max_lines=max_lines, skip=skip)
+                for line in log_lines:
+                    # use raw print as the engine may add formatting
+                    # end="" because line already includes \n from file
+                    print(line, end="")
+            else:
+                # Default streaming mode - memory-efficient iterator for entire log
+                for line in handler.stream_log_lines(log_descriptor):
+                    # use raw print as the engine may add formatting
+                    # end="" because line already includes \n from file
+                    print(line, end="")
+        except LogNotFound as e:
+            console.print(f":x: Failed to read log content: {e}", style="red")
+            raise typer.Exit(code=1) from None
+
+
+@history_app.command()
+def clear(
+    command: Annotated[
+        HistoryEnabledCommandType,
+        typer.Argument(
+            help="Command type to clear: config, up, or down.",
+        ),
+    ],
+    project_dir: Annotated[
+        str | None,
+        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+    ] = None,
+    keep: Annotated[
+        int,
+        typer.Option("--keep", "-k", help="Number of most recent logs to retain.", min=1),
+    ] = 20,
+) -> None:
+    """Delete execution logs for a specific command, keeping only the most recent N logs.
+
+    Run either from a jupyter-deploy project directory that you created with `jd init`;
+    or pass a --path PATH to such a directory.
+    """
+    console = Console()
+
+    with cmd_utils.project_dir(project_dir):
+        project_path = Path.cwd()
+        handler = CommandHistoryHandler(project_path)
+        result = handler.clear_logs(command.value, keep=keep)
+
+        if result.total_cleaned == 0 and result.total_failed == 0:
+            console.print(":information: No stale log files to clear.")
+        else:
+            # Report successful cleanups
+            if result.total_cleaned > 0:
+                console.print(
+                    f":white_check_mark: Cleared {result.total_cleaned} old log file(s) from '{command.value}' logs "
+                    f"(kept {result.total_kept} most recent).",
+                    style="green",
+                )
+
+            # Report failures if any
+            if result.has_failures:
+                console.print(
+                    f":error: Failed to delete {result.total_failed} log file(s):",
+                    style="red",
+                )
+                for failed_path, error in result.failed[:10]:
+                    console.print(f"  - {failed_path}: {error}", style="dim")
+
+                # Exit with non-zero code when there are failures
+                raise typer.Exit(code=1)

--- a/libs/jupyter-deploy/jupyter_deploy/cmd_history.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cmd_history.py
@@ -1,0 +1,85 @@
+"""Command history management - log descriptors and cleanup results."""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class LogDescriptor(BaseModel):
+    """Base class for log descriptors."""
+
+    id: str = Field(description="Unique identifier for this log")
+    command: str = Field(description="Command that generated this log (config/up/down)")
+    timestamp: datetime = Field(description="When the log was created")
+    storage_type: str = Field(description="Storage backend type (discriminator)")
+
+    class Config:
+        frozen = True
+
+    def __repr__(self) -> str:
+        """Return string representation for display.
+
+        Implemented by subclasses to return meaningful representation.
+        """
+        return f"{self.storage_type}:{self.id}"
+
+
+class LogFileDescriptor(LogDescriptor):
+    """Log stored as a local file."""
+
+    storage_type: Literal["file"] = "file"
+    path: Path = Field(description="Filesystem path to the log file")
+
+    def __repr__(self) -> str:
+        """Return file path as string representation."""
+        return str(self.path)
+
+
+# Discriminated union - Pydantic automatically selects the right type based on storage_type
+AnyLogDescriptor = LogFileDescriptor
+
+
+@dataclass
+class LogFilesCleanupResult:
+    """Result of a log files cleanup operation.
+
+    Attributes:
+        cleaned: List of file paths that were successfully deleted
+        kept: List of file paths that were kept (within keep limit)
+        failed: List of tuples containing (file_path, exception) for files that failed to delete
+    """
+
+    cleaned: list[Path] = field(default_factory=list)
+    kept: list[Path] = field(default_factory=list)
+    failed: list[tuple[Path, Exception]] = field(default_factory=list)
+
+    @property
+    def total_cleaned(self) -> int:
+        """Return the number of successfully cleaned files."""
+        return len(self.cleaned)
+
+    @property
+    def total_kept(self) -> int:
+        """Return the number of files kept."""
+        return len(self.kept)
+
+    @property
+    def total_failed(self) -> int:
+        """Return the number of files that failed to delete."""
+        return len(self.failed)
+
+    @property
+    def has_failures(self) -> bool:
+        """Return True if any deletions failed."""
+        return len(self.failed) > 0
+
+
+__all__ = [
+    "AnyLogDescriptor",
+    "LogDescriptor",
+    "LogFileDescriptor",
+    "LogFilesCleanupResult",
+]

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
@@ -189,6 +189,9 @@ class TerraformConfigHandler(EngineConfigHandler):
                 message="Error generating Terraform plan.",
             )
 
+        # Success - cleanup old logs
+        self.command_history_handler.clear_logs("config")
+
         # Return completion context from callback
         return plan_callback.get_completion_context()
 

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
@@ -38,6 +38,7 @@ from jupyter_deploy.engine.terraform.tf_supervised_execution_callback import (
     TerraformSupervisedExecutionCallback,
 )
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
+from jupyter_deploy.enum import HistoryEnabledCommandType
 from jupyter_deploy.handlers.command_history_handler import CommandHistoryHandler
 from jupyter_deploy.manifest import JupyterDeployManifest
 
@@ -103,7 +104,7 @@ class TerraformConfigHandler(EngineConfigHandler):
         self, preset_name: str | None = None, variable_overrides: dict[str, TemplateVariableDefinition] | None = None
     ) -> CompletionContext | None:
         # Create log file using command history handler
-        self._log_file = self.command_history_handler.create_log_file("config")
+        self._log_file = self.command_history_handler.create_log_file(HistoryEnabledCommandType.CONFIG)
 
         # 1/ run terraform init with supervised execution
         # Note that it is safe to run several times, see ``terraform init --help``:
@@ -190,7 +191,7 @@ class TerraformConfigHandler(EngineConfigHandler):
             )
 
         # Success - cleanup old logs
-        self.command_history_handler.clear_logs("config")
+        self.command_history_handler.clear_logs(HistoryEnabledCommandType.CONFIG)
 
         # Return completion context from callback
         return plan_callback.get_completion_context()

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_down.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_down.py
@@ -23,6 +23,7 @@ from jupyter_deploy.engine.terraform.tf_supervised_execution_callback import (
     TerraformNoopExecutionCallback,
     TerraformSupervisedExecutionCallback,
 )
+from jupyter_deploy.enum import HistoryEnabledCommandType
 from jupyter_deploy.handlers.command_history_handler import CommandHistoryHandler
 from jupyter_deploy.manifest import JupyterDeployManifest
 
@@ -61,7 +62,7 @@ class TerraformDownHandler(EngineDownHandler):
         verbose = self.terminal_handler is None
 
         # Create log file using command history handler
-        self._log_file = self.command_history_handler.create_log_file("down")
+        self._log_file = self.command_history_handler.create_log_file(HistoryEnabledCommandType.DOWN)
 
         # first handle persisting resources: attempt to remove them from state
         persisting_resources = self.get_persisting_resources()
@@ -164,4 +165,4 @@ class TerraformDownHandler(EngineDownHandler):
             )
 
         # Success - cleanup old logs
-        self.command_history_handler.clear_logs("down")
+        self.command_history_handler.clear_logs(HistoryEnabledCommandType.DOWN)

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_down.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_down.py
@@ -162,3 +162,6 @@ class TerraformDownHandler(EngineDownHandler):
                 retcode=destroy_retcode,
                 message="Error destroying Terraform infrastructure.",
             )
+
+        # Success - cleanup old logs
+        self.command_history_handler.clear_logs("down")

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_up.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_up.py
@@ -80,5 +80,8 @@ class TerraformUpHandler(EngineUpHandler):
                 message="Error applying Terraform plan.",
             )
 
+        # Success - cleanup old logs
+        self.command_history_handler.clear_logs("up")
+
         # Return completion context from callback
         return apply_callback.get_completion_context()

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_up.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_up.py
@@ -18,6 +18,7 @@ from jupyter_deploy.engine.terraform.tf_supervised_execution_callback import (
     TerraformNoopExecutionCallback,
     TerraformSupervisedExecutionCallback,
 )
+from jupyter_deploy.enum import HistoryEnabledCommandType
 from jupyter_deploy.handlers.command_history_handler import CommandHistoryHandler
 from jupyter_deploy.manifest import JupyterDeployManifest
 
@@ -44,7 +45,7 @@ class TerraformUpHandler(EngineUpHandler):
 
     def apply(self, config_file_path: Path, auto_approve: bool = False) -> CompletionContext | None:
         # Create log file using command history handler
-        self._log_file = self.command_history_handler.create_log_file("up")
+        self._log_file = self.command_history_handler.create_log_file(HistoryEnabledCommandType.UP)
 
         # Build terraform apply command
         apply_cmd = TF_APPLY_CMD.copy()
@@ -81,7 +82,7 @@ class TerraformUpHandler(EngineUpHandler):
             )
 
         # Success - cleanup old logs
-        self.command_history_handler.clear_logs("up")
+        self.command_history_handler.clear_logs(HistoryEnabledCommandType.UP)
 
         # Return completion context from callback
         return apply_callback.get_completion_context()

--- a/libs/jupyter-deploy/jupyter_deploy/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/enum.py
@@ -1,6 +1,14 @@
 from enum import Enum
 
 
+class HistoryEnabledCommandType(str, Enum):
+    """Command types for history tracking."""
+
+    CONFIG = "config"
+    UP = "up"
+    DOWN = "down"
+
+
 class InstructionArgumentSource(str, Enum):
     """Enum to list the possible sources for an instruction argument."""
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/command_history_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/command_history_handler.py
@@ -1,18 +1,37 @@
 """Handler for managing command execution history and log files."""
 
+from collections import deque
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 
+from jupyter_deploy.cmd_history import (
+    AnyLogDescriptor,
+    LogFileDescriptor,
+    LogFilesCleanupResult,
+)
 from jupyter_deploy.constants import HISTORY_DIR
+from jupyter_deploy.enum import HistoryEnabledCommandType
+from jupyter_deploy.fs_utils import list_files_sorted
+
+
+class LogNotFound(ValueError):
+    """Raised when a log file cannot be found."""
+
+    pass
+
+
+class LogCleanupError(Exception):
+    """Raised when log cleanup fails (non-critical, should warn user)."""
+
+    pass
 
 
 class CommandHistoryHandler:
     """Manages command execution history and log files.
 
-    This handler is responsible for:
-    - Creating log file paths for command execution
-    - Managing the history directory structure
-    - Providing access to historical logs (future: listing, reading, cleanup)
+    This handler abstracts log storage and provides methods for creating,
+    listing, reading, and cleaning up execution logs.
     """
 
     def __init__(self, project_path: Path) -> None:
@@ -27,8 +46,10 @@ class CommandHistoryHandler:
     def create_log_file(self, command: str) -> Path:
         """Create a log file for a command execution, return its path.
 
-        Generates a timestamped log file path organized by command in subdirectories,
-        ensures the necessary directories exist, and creates an empty log file.
+        Generates a timestamped log file path organized by command in subdirectories
+        and ensures the necessary directories exist.
+
+        Note: Does NOT auto-cleanup. Caller should explicitly call clear_logs() on success.
 
         Args:
             command: The command name (e.g., "config", "up", "down")
@@ -49,3 +70,172 @@ class CommandHistoryHandler:
         log_file_path.touch(exist_ok=True)
 
         return log_file_path
+
+    def list_logs(self, command: str, max_logs: int | None = None) -> list[AnyLogDescriptor]:
+        """Return a list of LogDescriptors for a specific command, newest first.
+
+        Log filenames (YYYYMMDD-HHMMSS.log) are lexicographically sortable, so we can use
+        string comparison to find the most recent logs without parsing all timestamps.
+
+        Args:
+            command: Command name (e.g., "config", "up", "down")
+            max_logs: Maximum number of logs to return (None = unlimited)
+
+        Returns:
+            List of log descriptors, sorted newest first
+        """
+        command_dir = self.history_dir / command
+
+        # Get log files sorted by filename (newest first)
+        # If directory doesn't exist, treat as "no logs" (not an error)
+        try:
+            log_files = list_files_sorted(command_dir, "*.log", max_files=max_logs, reverse=True)
+        except (FileNotFoundError, NotADirectoryError):
+            return []
+
+        # Convert to LogFileDescriptor objects
+        descriptors: list[AnyLogDescriptor] = []
+        for log_path in log_files:
+            # Parse timestamp from filename (YYYYMMDD-HHMMSS.log)
+            timestamp_str = log_path.stem
+            timestamp = datetime.strptime(timestamp_str, "%Y%m%d-%H%M%S").replace(tzinfo=UTC)
+
+            descriptor = LogFileDescriptor(
+                id=f"{command}/{log_path.name}",
+                command=command,
+                timestamp=timestamp,
+                path=log_path,
+            )
+            descriptors.append(descriptor)
+
+        return descriptors
+
+    def get_latest_log(self) -> AnyLogDescriptor | None:
+        """Return the LogDescriptor of the most recent log across ALL commands, or None."""
+        all_logs: list[AnyLogDescriptor] = []
+
+        # Iterate through known command types only (from enum)
+        # Only fetch the most recent log per command for efficiency
+        for command_type in HistoryEnabledCommandType:
+            logs = self.list_logs(command_type.value, max_logs=1)
+            all_logs.extend(logs)
+
+        if not all_logs:
+            return None
+
+        # Sort by timestamp, newest first
+        all_logs.sort(key=lambda log: log.timestamp, reverse=True)
+        return all_logs[0]
+
+    def get_log_lines(self, log_descriptor: AnyLogDescriptor, max_lines: int = 1000, skip: int = 0) -> list[str]:
+        """Return the requested log lines as a list (with newlines).
+
+        Args:
+            log_descriptor: Log descriptor identifying the log to read
+            max_lines: Maximum number of lines to return (from end of file, like tail -n).
+                      Defaults to 1000 for safety.
+            skip: Number of lines from end to skip before starting (default 0).
+                  Enables pagination through logs.
+
+        Returns:
+            List of log lines (with newlines). Returns last N lines, optionally skipping M from end.
+
+        Examples:
+            max_lines=1000, skip=0    → Last 1000 lines ([-1000:])
+            max_lines=1000, skip=1000 → Lines [-2000:-1000]
+
+        Raises:
+            LogNotFound: If the log file does not exist
+            NotImplementedError: If the log type is not supported
+        """
+        if isinstance(log_descriptor, LogFileDescriptor):
+            try:
+                with open(log_descriptor.path) as f:
+                    # Use deque with maxlen for efficient tail-like behavior
+                    # Read (skip + max_lines) to get our window
+                    total_lines = skip + max_lines
+                    all_lines = list(deque(f, maxlen=total_lines))
+
+                    # Return the first max_lines (skipping the last `skip` lines)
+                    return all_lines[:max_lines] if skip > 0 else all_lines
+            except FileNotFoundError as e:
+                raise LogNotFound(f"Log file not found: {log_descriptor.path}") from e
+        else:
+            raise NotImplementedError(f"Unknown log type: {log_descriptor.__class__}")
+
+    def stream_log_lines(self, log_descriptor: AnyLogDescriptor) -> Iterator[str]:
+        """Return iterator yielding log lines (with newlines).
+
+        Raises:
+            LogNotFound: If the log file does not exist
+            NotImplementedError: If the log type is not supported
+        """
+        if isinstance(log_descriptor, LogFileDescriptor):
+            try:
+                with open(log_descriptor.path) as f:
+                    yield from f
+            except FileNotFoundError as e:
+                raise LogNotFound(f"Log file not found: {log_descriptor.path}") from e
+        else:
+            raise NotImplementedError(f"Unknown log type: {log_descriptor.__class__}")
+
+    def clear_logs(self, command: str, keep: int = 20) -> LogFilesCleanupResult:
+        """Clear old logs for a specific command, keeping only the most recent N logs.
+
+        Args:
+            command: Command name to clear logs for (e.g., "config", "up", "down") - REQUIRED
+            keep: Number of most recent logs to keep per command (default: 20)
+
+        Returns:
+            LogFilesCleanupResult with details about cleaned, kept, and failed files
+
+        Raises:
+            LogCleanupError: If any log files failed to be deleted
+        """
+        result = self._cleanup_log_files(command, keep=keep)
+
+        # Raise exception if any deletions failed
+        if result.has_failures:
+            error_summary = f"Failed to delete {result.total_failed} log file(s)"
+            raise LogCleanupError(error_summary)
+
+        return result
+
+    def _cleanup_log_files(self, command: str, keep: int = 20) -> LogFilesCleanupResult:
+        """Clean up log files for a specific command, keeping only the most recent N.
+
+        Uses lexicographic ordering (filename-based) for performance.
+
+        Args:
+            command: The command name (e.g., "config", "up", "down")
+            keep: Number of most recent logs to keep (default: 20)
+
+        Returns:
+            LogFilesCleanupResult with details about cleaned, kept, and failed files
+        """
+        result = LogFilesCleanupResult()
+        command_dir = self.history_dir / command
+
+        # Get all log files sorted by filename (newest first)
+        # If directory doesn't exist, treat as "no logs to clean" (not an error)
+        try:
+            log_files = list_files_sorted(command_dir, "*.log", max_files=None, reverse=True)
+        except (FileNotFoundError, NotADirectoryError):
+            return result
+
+        if not log_files:
+            return result
+
+        # Track files to keep (within the keep limit)
+        result.kept = list(log_files[:keep])
+
+        # Delete old logs beyond the keep limit
+        for old_path in log_files[keep:]:
+            try:
+                old_path.unlink()
+                result.cleaned.append(old_path)
+            except Exception as e:
+                # Track errors during cleanup (e.g., permission issues)
+                result.failed.append((old_path, e))
+
+        return result

--- a/libs/jupyter-deploy/tests/unit/cli/test_history_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_history_app.py
@@ -1,0 +1,548 @@
+"""Tests for history CLI commands."""
+
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from typer.testing import CliRunner
+
+from jupyter_deploy.cli.history_app import history_app
+from jupyter_deploy.cmd_history import LogFileDescriptor, LogFilesCleanupResult
+from jupyter_deploy.handlers.command_history_handler import LogNotFound
+
+runner = CliRunner()
+
+
+def get_mock_history_handler() -> tuple[Mock, dict[str, Mock]]:
+    """Create a mock CommandHistoryHandler with all methods mocked.
+
+    Returns:
+        Tuple of (mock_handler, mock_methods_dict)
+    """
+    mock_handler = Mock()
+    mock_list_logs = Mock()
+    mock_get_latest_log = Mock()
+    mock_get_log_lines = Mock()
+    mock_stream_log_lines = Mock()
+    mock_clear_logs = Mock()
+
+    mock_handler.list_logs = mock_list_logs
+    mock_handler.get_latest_log = mock_get_latest_log
+    mock_handler.get_log_lines = mock_get_log_lines
+    mock_handler.stream_log_lines = mock_stream_log_lines
+    mock_handler.clear_logs = mock_clear_logs
+
+    # Default return values
+    mock_list_logs.return_value = []
+    mock_get_latest_log.return_value = None
+    mock_get_log_lines.return_value = []
+    mock_clear_logs.return_value = LogFilesCleanupResult()
+
+    return mock_handler, {
+        "list_logs": mock_list_logs,
+        "get_latest_log": mock_get_latest_log,
+        "get_log_lines": mock_get_log_lines,
+        "stream_log_lines": mock_stream_log_lines,
+        "clear_logs": mock_clear_logs,
+    }
+
+
+class TestHistoryListCommand(unittest.TestCase):
+    """Test cases for 'jd history list' command."""
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    def test_list_shows_no_logs_message_when_empty(self, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that list command shows message when no logs exist."""
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["list", "config"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No execution logs found", result.stdout)
+        mock_methods["list_logs"].assert_called_once_with("config", max_logs=20)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_list_displays_logs_in_table(
+        self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock
+    ) -> None:
+        """Test that list command displays logs in a formatted table."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log1 = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143022.log"),
+        )
+        log2 = LogFileDescriptor(
+            id="config/20260129-143023.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 23, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143023.log"),
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["list_logs"].return_value = [log2, log1]
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["list", "config"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Execution History Logs", result.stdout)
+        self.assertIn("config", result.stdout)
+        self.assertIn("file", result.stdout)
+        mock_methods["list_logs"].assert_called_once_with("config", max_logs=20)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_list_with_text_flag_shows_plain_output(
+        self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock
+    ) -> None:
+        """Test that list command with --text shows plain repr output."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log1 = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143022.log"),
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["list_logs"].return_value = [log1]
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["list", "config", "--text"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(".jd-history/config/20260129-143022.log", result.stdout)
+        mock_methods["list_logs"].assert_called_once_with("config", max_logs=20)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    def test_list_requires_command_argument(self, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that list command requires command argument."""
+        result = runner.invoke(history_app, ["list"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    def test_list_validates_command_type_via_enum(self, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that list command validates command type through enum."""
+        result = runner.invoke(history_app, ["list", "invalid_command"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    def test_list_accepts_n_option(self, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that list command accepts -n option and passes it to handler."""
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["list", "config", "-n", "10"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_methods["list_logs"].assert_called_once_with("config", max_logs=10)
+
+
+class TestHistoryShowCommand(unittest.TestCase):
+    """Test cases for 'jd history show' command."""
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_show_displays_log_content(self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that show command displays log content."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143022.log"),
+        )
+
+        log_lines = ["Terraform initialized\n", "Plan: 65 to add, 0 to change, 0 to destroy\n"]
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["list_logs"].return_value = [log_descriptor]
+        mock_methods["stream_log_lines"].return_value = iter(log_lines)
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["show", "config"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Terraform initialized", result.stdout)
+        mock_methods["list_logs"].assert_called_once_with("config", max_logs=1)
+        mock_methods["stream_log_lines"].assert_called_once_with(log_descriptor)
+        mock_methods["get_log_lines"].assert_not_called()
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_show_accepts_n_option(self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that show command accepts -n option to show Nth most recent log."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log1 = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143022.log"),
+        )
+        log2 = LogFileDescriptor(
+            id="config/20260129-143023.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 23, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143023.log"),
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["list_logs"].return_value = [log2, log1]
+        mock_methods["stream_log_lines"].return_value = iter(["log content\n"])
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["show", "config", "-n", "2"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_methods["list_logs"].assert_called_once_with("config", max_logs=2)
+        mock_methods["stream_log_lines"].assert_called_once_with(log1)
+        mock_methods["get_log_lines"].assert_not_called()
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_show_accepts_lines_option(self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that show command accepts -l option to limit output lines."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143022.log"),
+        )
+
+        log_lines = [f"Line {i}\n" for i in range(100)]
+        last_10_lines = log_lines[-10:]
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["list_logs"].return_value = [log_descriptor]
+        mock_methods["get_log_lines"].return_value = last_10_lines
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["show", "config", "-l", "10"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Line 99", result.stdout)
+        self.assertNotIn("Line 0", result.stdout)
+        mock_methods["get_log_lines"].assert_called_once_with(log_descriptor, max_lines=10, skip=0)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_show_accepts_skip_option(self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that show command accepts -s/--skip option for pagination."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143022.log"),
+        )
+
+        log_lines = [f"Line {i}\n" for i in range(100)]
+        middle_lines = log_lines[40:50]
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["list_logs"].return_value = [log_descriptor]
+        mock_methods["get_log_lines"].return_value = middle_lines
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["show", "config", "-l", "10", "-s", "50"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Line 40", result.stdout)
+        self.assertIn("Line 49", result.stdout)
+        self.assertNotIn("Line 50", result.stdout)
+        mock_methods["get_log_lines"].assert_called_once_with(log_descriptor, max_lines=10, skip=50)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    def test_show_displays_message_when_no_log_found(self, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that show command displays error when no log is found."""
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["show", "config"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("No log found", result.stdout)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_show_handles_log_not_found_exception(
+        self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock
+    ) -> None:
+        """Test that show command handles LogNotFound exception gracefully."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143022.log"),
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["list_logs"].return_value = [log_descriptor]
+        mock_methods["stream_log_lines"].side_effect = LogNotFound("Log file not found")
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["show", "config"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Failed to read log content", result.stdout)
+        mock_methods["stream_log_lines"].assert_called_once_with(log_descriptor)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_show_without_command_shows_latest_from_any(
+        self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock
+    ) -> None:
+        """Test that show command without command arg shows latest log from any command."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log_descriptor = LogFileDescriptor(
+            id="up/20260129-150000.log",
+            command="up",
+            timestamp=datetime(2026, 1, 29, 15, 0, 0, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/up/20260129-150000.log"),
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["get_latest_log"].return_value = log_descriptor
+        mock_methods["stream_log_lines"].return_value = iter(["log content\n"])
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["show"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_methods["get_latest_log"].assert_called_once()
+        mock_methods["stream_log_lines"].assert_called_once_with(log_descriptor)
+        mock_methods["get_log_lines"].assert_not_called()
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_show_uses_streaming_by_default(
+        self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock
+    ) -> None:
+        """Test that show command uses streaming mode by default (no -l or -s)."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/project/.jd-history/config/20260129-143022.log"),
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["list_logs"].return_value = [log_descriptor]
+        mock_methods["stream_log_lines"].return_value = iter(["line 1\n", "line 2\n"])
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["show", "config"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("line 1", result.stdout)
+        self.assertIn("line 2", result.stdout)
+        mock_methods["stream_log_lines"].assert_called_once_with(log_descriptor)
+        mock_methods["get_log_lines"].assert_not_called()
+
+
+class TestHistoryClearCommand(unittest.TestCase):
+    """Test cases for 'jd history clear' command."""
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_clear_displays_success_message_for_specific_command(
+        self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock
+    ) -> None:
+        """Test that clear command displays success message."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        cleanup_result = LogFilesCleanupResult(
+            cleaned=[Path("/fake/log1.log"), Path("/fake/log2.log")],
+            kept=[Path("/fake/log3.log")],
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["clear_logs"].return_value = cleanup_result
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["clear", "config"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Cleared 2 old log file(s)", result.stdout)
+        self.assertIn("kept 1 most recent", result.stdout)
+        mock_methods["clear_logs"].assert_called_once_with("config", keep=20)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    def test_clear_displays_message_when_no_logs_to_clear(
+        self, mock_handler_class: Mock, mock_project_dir: Mock
+    ) -> None:
+        """Test that clear command displays message when no logs need clearing."""
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["clear", "config"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("No stale log files to clear", result.stdout)
+        mock_methods["clear_logs"].assert_called_once_with("config", keep=20)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_clear_accepts_keep_option(self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that clear command accepts --keep option."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        cleanup_result = LogFilesCleanupResult(
+            cleaned=[Path("/fake/log1.log")],
+            kept=[Path("/fake/log2.log")],
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["clear_logs"].return_value = cleanup_result
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["clear", "config", "--keep", "10"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_methods["clear_logs"].assert_called_once_with("config", keep=10)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    @patch("pathlib.Path.cwd")
+    def test_clear_displays_failures_when_present(
+        self, mock_cwd: Mock, mock_handler_class: Mock, mock_project_dir: Mock
+    ) -> None:
+        """Test that clear command displays failures when some deletions fail."""
+        mock_cwd.return_value = Path("/fake/project")
+
+        cleanup_result = LogFilesCleanupResult(
+            cleaned=[Path("/fake/log1.log")],
+            kept=[Path("/fake/log2.log")],
+            failed=[(Path("/fake/log3.log"), OSError("Permission denied"))],
+        )
+
+        mock_handler, mock_methods = get_mock_history_handler()
+        mock_methods["clear_logs"].return_value = cleanup_result
+        mock_handler_class.return_value = mock_handler
+
+        result = runner.invoke(history_app, ["clear", "config"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Failed to delete 1 log file(s)", result.stdout)
+        mock_methods["clear_logs"].assert_called_once_with("config", keep=20)
+
+    @patch("jupyter_deploy.cli.history_app.cmd_utils.project_dir")
+    @patch("jupyter_deploy.cli.history_app.CommandHistoryHandler")
+    def test_clear_requires_command_argument(self, mock_handler_class: Mock, mock_project_dir: Mock) -> None:
+        """Test that clear command requires command argument."""
+        result = runner.invoke(history_app, ["clear"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestParameterValidation(unittest.TestCase):
+    """Test parameter validation for history commands."""
+
+    def test_list_rejects_n_zero(self) -> None:
+        """Test that list command rejects n=0."""
+        result = runner.invoke(history_app, ["list", "config", "-n", "0"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    def test_list_rejects_n_negative(self) -> None:
+        """Test that list command rejects negative n."""
+        result = runner.invoke(history_app, ["list", "config", "-n", "-1"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    def test_show_rejects_n_zero(self) -> None:
+        """Test that show command rejects n=0."""
+        result = runner.invoke(history_app, ["show", "config", "-n", "0"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    def test_show_rejects_n_negative(self) -> None:
+        """Test that show command rejects negative n."""
+        result = runner.invoke(history_app, ["show", "config", "-n", "-1"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    def test_show_rejects_lines_zero(self) -> None:
+        """Test that show command rejects lines=0."""
+        result = runner.invoke(history_app, ["show", "config", "-l", "0"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    def test_show_rejects_lines_negative(self) -> None:
+        """Test that show command rejects negative lines."""
+        result = runner.invoke(history_app, ["show", "config", "-l", "-1"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    def test_show_rejects_skip_negative(self) -> None:
+        """Test that show command rejects negative skip."""
+        result = runner.invoke(history_app, ["show", "config", "-s", "-1"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    def test_show_accepts_skip_zero(self) -> None:
+        """Test that show command accepts skip=0 (valid value)."""
+        # Note: This will fail due to missing logs, but validates skip=0 is accepted
+        result = runner.invoke(history_app, ["show", "config", "-s", "0"])
+
+        # Should fail on no logs found, NOT on parameter validation
+        # If it were parameter validation error, output would mention "Invalid value"
+        self.assertNotIn("Invalid value", result.stdout)
+
+    def test_clear_rejects_keep_zero(self) -> None:
+        """Test that clear command rejects keep=0."""
+        result = runner.invoke(history_app, ["clear", "config", "--keep", "0"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)
+
+    def test_clear_rejects_keep_negative(self) -> None:
+        """Test that clear command rejects negative keep."""
+        result = runner.invoke(history_app, ["clear", "config", "--keep", "-1"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Invalid value", result.stdout)

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_up.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_up.py
@@ -6,6 +6,7 @@ from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.engine.supervised_execution import ExecutionError
 from jupyter_deploy.engine.terraform.tf_enums import TerraformSequenceId
 from jupyter_deploy.engine.terraform.tf_up import TerraformUpHandler
+from jupyter_deploy.handlers.command_history_handler import LogCleanupError
 
 
 class TestTerraformUpHandler(unittest.TestCase):
@@ -206,3 +207,86 @@ class TestTerraformUpHandler(unittest.TestCase):
         # Verify executor was created and executed
         mock_create_executor.assert_called_once()
         mock_executor.execute.assert_called_once()
+
+    @patch("jupyter_deploy.engine.terraform.tf_up.tf_supervised_executor_factory.create_terraform_executor")
+    def test_apply_clears_old_logs_on_success(self, mock_create_executor: Mock) -> None:
+        """Test that apply calls clear_logs on successful execution."""
+        path = Path("/mock/path")
+        project_path = Path("/mock/project")
+        mock_manifest = Mock()
+        mock_history_handler = Mock()
+        mock_history_handler.create_log_file.return_value = Path("/mock/log.log")
+        mock_history_handler.clear_logs.return_value = Mock()
+
+        # Mock executor - success
+        mock_executor = Mock()
+        mock_executor.execute.return_value = 0
+        mock_create_executor.return_value = mock_executor
+
+        handler = TerraformUpHandler(
+            project_path=project_path,
+            project_manifest=mock_manifest,
+            command_history_handler=mock_history_handler,
+        )
+
+        # Act
+        handler.apply(path)
+
+        # Assert - clear_logs should be called after successful execution
+        mock_history_handler.clear_logs.assert_called_once_with("up")
+
+    @patch("jupyter_deploy.engine.terraform.tf_up.tf_supervised_executor_factory.create_terraform_executor")
+    def test_apply_does_not_clear_logs_on_failure(self, mock_create_executor: Mock) -> None:
+        """Test that apply does NOT call clear_logs when execution fails."""
+        path = Path("/mock/path")
+        project_path = Path("/mock/project")
+        mock_manifest = Mock()
+        mock_history_handler = Mock()
+        mock_history_handler.create_log_file.return_value = Path("/mock/log.log")
+        mock_history_handler.clear_logs.return_value = Mock()
+
+        # Mock executor - failure
+        mock_executor = Mock()
+        mock_executor.execute.return_value = 1
+        mock_create_executor.return_value = mock_executor
+
+        handler = TerraformUpHandler(
+            project_path=project_path,
+            project_manifest=mock_manifest,
+            command_history_handler=mock_history_handler,
+        )
+
+        # Act & Assert - should raise ExecutionError
+        with self.assertRaises(ExecutionError):
+            handler.apply(path)
+
+        # Assert - clear_logs should NOT be called on failure
+        mock_history_handler.clear_logs.assert_not_called()
+
+    @patch("jupyter_deploy.engine.terraform.tf_up.tf_supervised_executor_factory.create_terraform_executor")
+    def test_apply_bubbles_up_clear_logs_exception(self, mock_create_executor: Mock) -> None:
+        """Test that apply bubbles up LogCleanupError from clear_logs."""
+        path = Path("/mock/path")
+        project_path = Path("/mock/project")
+        mock_manifest = Mock()
+        mock_history_handler = Mock()
+        mock_history_handler.create_log_file.return_value = Path("/mock/log.log")
+        mock_history_handler.clear_logs.side_effect = LogCleanupError("Failed to delete 2 log file(s)")
+
+        # Mock executor - success
+        mock_executor = Mock()
+        mock_executor.execute.return_value = 0
+        mock_create_executor.return_value = mock_executor
+
+        handler = TerraformUpHandler(
+            project_path=project_path,
+            project_manifest=mock_manifest,
+            command_history_handler=mock_history_handler,
+        )
+
+        # Act & Assert - should raise LogCleanupError from clear_logs
+        with self.assertRaises(LogCleanupError) as context:
+            handler.apply(path)
+
+        self.assertEqual(str(context.exception), "Failed to delete 2 log file(s)")
+        mock_history_handler.clear_logs.assert_called_once_with("up")

--- a/libs/jupyter-deploy/tests/unit/handlers/test_command_history_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_command_history_handler.py
@@ -1,12 +1,17 @@
 """Tests for CommandHistoryHandler."""
 
 import unittest
-from datetime import UTC
+from datetime import UTC, datetime
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, mock_open, patch
 
+from jupyter_deploy.cmd_history import LogFileDescriptor, LogFilesCleanupResult
 from jupyter_deploy.constants import HISTORY_DIR
-from jupyter_deploy.handlers.command_history_handler import CommandHistoryHandler
+from jupyter_deploy.handlers.command_history_handler import (
+    CommandHistoryHandler,
+    LogCleanupError,
+    LogNotFound,
+)
 
 
 class TestCommandHistoryHandler(unittest.TestCase):
@@ -52,90 +57,314 @@ class TestCommandHistoryHandler(unittest.TestCase):
 
     @patch("pathlib.Path.touch")
     @patch("pathlib.Path.mkdir")
-    def test_create_log_file_ensures_directory_and_file_exist(self, mock_mkdir: Mock, mock_touch: Mock) -> None:
-        """Test that create_log_file ensures command subdirectory and file exist."""
+    def test_create_log_file_does_not_auto_cleanup(self, _mock_mkdir: Mock, _mock_touch: Mock) -> None:
+        """Test that create_log_file does NOT auto-cleanup (caller must explicitly cleanup)."""
+        with patch.object(self.handler, "_cleanup_log_files") as mock_cleanup:
+            self.handler.create_log_file("config")
+            mock_cleanup.assert_not_called()
+
+    @patch("jupyter_deploy.handlers.command_history_handler.list_files_sorted")
+    def test_list_logs_returns_empty_when_dir_not_exists(self, mock_list_files: Mock) -> None:
+        """Test that list_logs returns empty list when command directory doesn't exist."""
+        mock_list_files.side_effect = FileNotFoundError("Directory does not exist")
+
+        result = self.handler.list_logs(command="config")
+
+        self.assertEqual(result, [])
+
+    @patch("jupyter_deploy.handlers.command_history_handler.list_files_sorted")
+    def test_list_logs_returns_descriptors_for_valid_logs(self, mock_list_files: Mock) -> None:
+        """Test that list_logs returns LogFileDescriptor objects for valid log files."""
+        # Mock list_files_sorted to return paths in sorted order (newest first)
+        mock_list_files.return_value = [
+            Path("/fake/path/.jd-history/config/20260129-143023.log"),
+            Path("/fake/path/.jd-history/config/20260129-143022.log"),
+        ]
+
         # Act
-        self.handler.create_log_file("up")
+        result = self.handler.list_logs(command="config")
 
         # Assert
-        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
-        mock_touch.assert_called_once_with(exist_ok=True)
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], LogFileDescriptor)
+        self.assertEqual(result[0].command, "config")
+        self.assertEqual(result[0].storage_type, "file")
+        # Most recent (20260129-143023) should be first
+        self.assertEqual(result[0].id, "config/20260129-143023.log")
+        mock_list_files.assert_called_once_with(
+            self.project_path / HISTORY_DIR / "config", "*.log", max_files=None, reverse=True
+        )
 
-    @patch("pathlib.Path.touch")
-    @patch("pathlib.Path.mkdir")
-    def test_create_log_file_works_with_different_commands(self, _mock_mkdir: Mock, mock_touch: Mock) -> None:
-        """Test that create_log_file works with different command names."""
-        # Act
-        config_log = self.handler.create_log_file("config")
-        up_log = self.handler.create_log_file("up")
-        down_log = self.handler.create_log_file("down")
+    @patch("jupyter_deploy.handlers.command_history_handler.list_files_sorted")
+    def test_list_logs_raises_on_malformed_filenames(self, mock_list_files: Mock) -> None:
+        """Test that list_logs raises ValueError for malformed log filenames."""
+        # Mock list_files_sorted to return a path with invalid timestamp format
+        mock_list_files.return_value = [
+            Path("/fake/path/.jd-history/config/invalid-timestamp.log"),
+        ]
 
-        # Assert
-        self.assertTrue(str(config_log).endswith(".log"))
-        self.assertIn(f"{HISTORY_DIR}/config/", str(config_log))
-        self.assertTrue(str(up_log).endswith(".log"))
-        self.assertIn(f"{HISTORY_DIR}/up/", str(up_log))
-        self.assertTrue(str(down_log).endswith(".log"))
-        self.assertIn(f"{HISTORY_DIR}/down/", str(down_log))
-        # Verify touch was called for each log file
-        self.assertEqual(mock_touch.call_count, 3)
+        # Act & Assert - should raise ValueError from strptime
+        with self.assertRaises(ValueError):
+            self.handler.list_logs(command="config")
 
-    @patch("pathlib.Path.touch")
-    @patch("pathlib.Path.mkdir")
-    @patch("jupyter_deploy.handlers.command_history_handler.datetime")
-    def test_create_log_file_uses_utc_timezone(
-        self, mock_datetime_module: Mock, _mock_mkdir: Mock, _mock_touch: Mock
-    ) -> None:
-        """Test that create_log_file uses UTC timezone for timestamps."""
-        # Mock datetime
-        mock_now = Mock()
-        mock_now.strftime.return_value = "20260129-143022"
-        mock_datetime_module.now.return_value = mock_now
+    @patch("pathlib.Path.exists")
+    def test_get_latest_log_returns_none_when_no_logs(self, mock_exists: Mock) -> None:
+        """Test that get_latest_log returns None when no logs exist."""
+        mock_exists.return_value = False
 
-        # Act
-        self.handler.create_log_file("config")
+        result = self.handler.get_latest_log()
 
-        # Assert
-        mock_datetime_module.now.assert_called_once_with(UTC)
+        self.assertIsNone(result)
 
-    @patch("pathlib.Path.touch")
-    @patch("pathlib.Path.mkdir")
-    @patch("jupyter_deploy.handlers.command_history_handler.datetime")
-    def test_create_log_file_timestamp_format(
-        self, mock_datetime_module: Mock, _mock_mkdir: Mock, _mock_touch: Mock
-    ) -> None:
-        """Test that create_log_file formats timestamp as YYYYMMDD-HHMMSS."""
-        # Mock datetime
-        mock_now = Mock()
-        mock_now.strftime.return_value = "20260129-143022"
-        mock_datetime_module.now.return_value = mock_now
+    @patch("pathlib.Path.exists")
+    @patch("pathlib.Path.iterdir")
+    def test_get_latest_log_returns_most_recent_across_commands(self, mock_iterdir: Mock, mock_exists: Mock) -> None:
+        """Test that get_latest_log returns most recent log across all commands."""
+        mock_exists.return_value = True
 
-        # Act
-        self.handler.create_log_file("config")
+        # Mock command directories
+        config_dir = Mock(spec=Path)
+        config_dir.name = "config"
+        config_dir.is_dir.return_value = True
 
-        # Assert - verify strftime was called with correct format
-        mock_now.strftime.assert_called_once_with("%Y%m%d-%H%M%S")
+        up_dir = Mock(spec=Path)
+        up_dir.name = "up"
+        up_dir.is_dir.return_value = True
 
-    @patch("pathlib.Path.touch")
-    @patch("pathlib.Path.mkdir")
-    @patch("jupyter_deploy.handlers.command_history_handler.datetime")
-    def test_create_log_file_multiple_calls_different_timestamps(
-        self, mock_datetime_module: Mock, _mock_mkdir: Mock, _mock_touch: Mock
-    ) -> None:
-        """Test that multiple calls generate different timestamps."""
-        # Mock datetime to return different timestamps
-        mock_now1 = Mock()
-        mock_now1.strftime.return_value = "20260129-143022"
-        mock_now2 = Mock()
-        mock_now2.strftime.return_value = "20260129-143023"
+        mock_iterdir.return_value = [config_dir, up_dir]
 
-        mock_datetime_module.now.side_effect = [mock_now1, mock_now2]
+        # Mock list_logs to return descriptors with different timestamps
+        config_log = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/path/.jd-history/config/20260129-143022.log"),
+        )
 
-        # Act
-        log_file1 = self.handler.create_log_file("config")
-        log_file2 = self.handler.create_log_file("config")
+        up_log = LogFileDescriptor(
+            id="up/20260129-150000.log",
+            command="up",
+            timestamp=datetime(2026, 1, 29, 15, 0, 0, tzinfo=UTC),  # Most recent
+            path=Path("/fake/path/.jd-history/up/20260129-150000.log"),
+        )
 
-        # Assert
-        self.assertNotEqual(log_file1, log_file2)
-        self.assertEqual(log_file1.name, "20260129-143022.log")
-        self.assertEqual(log_file2.name, "20260129-143023.log")
+        def mock_list_logs_side_effect(command: str, max_logs: int | None = None) -> list[LogFileDescriptor]:
+            if command == "config":
+                return [config_log]
+            elif command == "up":
+                return [up_log]
+            return []
+
+        with patch.object(self.handler, "list_logs", side_effect=mock_list_logs_side_effect):
+            result = self.handler.get_latest_log()
+
+            self.assertIsNotNone(result)
+            assert result is not None  # Type narrowing for mypy
+            self.assertEqual(result.command, "up")
+            self.assertEqual(result.timestamp, up_log.timestamp)
+
+    def test_get_log_lines_raises_for_missing_file(self) -> None:
+        """Test that get_log_lines raises LogNotFound when file doesn't exist."""
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/nonexistent/file.log"),
+        )
+
+        with self.assertRaises(LogNotFound):
+            self.handler.get_log_lines(log_descriptor)
+
+    def test_get_log_lines_returns_all_lines(self) -> None:
+        """Test that get_log_lines returns all lines from the log file (up to 1000 default)."""
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/file.log"),
+        )
+
+        log_content = "Line 1\nLine 2\nLine 3\n"
+        m_open = mock_open(read_data=log_content)
+
+        with patch("builtins.open", m_open):
+            result = self.handler.get_log_lines(log_descriptor)
+
+            self.assertIsNotNone(result)
+            self.assertEqual(result, ["Line 1\n", "Line 2\n", "Line 3\n"])
+
+    def test_get_log_lines_respects_max_lines(self) -> None:
+        """Test that get_log_lines returns only last N lines when max_lines is specified."""
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/file.log"),
+        )
+
+        log_content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
+        m_open = mock_open(read_data=log_content)
+
+        with patch("builtins.open", m_open):
+            result = self.handler.get_log_lines(log_descriptor, max_lines=2)
+
+            self.assertIsNotNone(result)
+            self.assertEqual(result, ["Line 4\n", "Line 5\n"])
+
+    def test_get_log_lines_respects_skip(self) -> None:
+        """Test that get_log_lines skips lines from end when skip is specified."""
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/file.log"),
+        )
+
+        log_content = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
+        m_open = mock_open(read_data=log_content)
+
+        with patch("builtins.open", m_open):
+            # Get 2 lines, skipping the last 2 (should get lines 2 and 3)
+            result = self.handler.get_log_lines(log_descriptor, max_lines=2, skip=2)
+
+            self.assertIsNotNone(result)
+            self.assertEqual(result, ["Line 2\n", "Line 3\n"])
+
+    def test_stream_log_lines_yields_lines(self) -> None:
+        """Test that stream_log_lines yields lines from the log file."""
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/fake/file.log"),
+        )
+
+        log_content = "Line 1\nLine 2\nLine 3\n"
+        m_open = mock_open(read_data=log_content)
+
+        with patch("builtins.open", m_open):
+            result = list(self.handler.stream_log_lines(log_descriptor))
+
+            self.assertEqual(result, ["Line 1\n", "Line 2\n", "Line 3\n"])
+
+    def test_stream_log_lines_raises_for_missing_file(self) -> None:
+        """Test that stream_log_lines raises LogNotFound when file doesn't exist."""
+        log_descriptor = LogFileDescriptor(
+            id="config/20260129-143022.log",
+            command="config",
+            timestamp=datetime(2026, 1, 29, 14, 30, 22, tzinfo=UTC),
+            path=Path("/nonexistent/file.log"),
+        )
+
+        with self.assertRaises(LogNotFound):
+            list(self.handler.stream_log_lines(log_descriptor))
+
+    @patch("jupyter_deploy.handlers.command_history_handler.list_files_sorted")
+    def test_cleanup_log_files_returns_empty_result_when_dir_not_exists(self, mock_list_files: Mock) -> None:
+        """Test that _cleanup_log_files returns empty result when directory doesn't exist."""
+        mock_list_files.side_effect = FileNotFoundError("Directory does not exist")
+
+        result = self.handler._cleanup_log_files("config", keep=5)
+
+        self.assertIsInstance(result, LogFilesCleanupResult)
+        self.assertEqual(result.total_cleaned, 0)
+        self.assertEqual(result.total_kept, 0)
+        self.assertEqual(result.total_failed, 0)
+
+    @patch("jupyter_deploy.handlers.command_history_handler.list_files_sorted")
+    def test_cleanup_log_files_deletes_old_logs_beyond_keep_limit(self, mock_list_files: Mock) -> None:
+        """Test that _cleanup_log_files deletes logs beyond the keep limit."""
+        # Create 8 mock log paths (already in sorted order, newest first)
+        logs = []
+        for _ in range(8):
+            log = Mock(spec=Path)
+            log.unlink = Mock()
+            logs.append(log)
+
+        mock_list_files.return_value = logs
+
+        # Act - keep only 5 most recent
+        result = self.handler._cleanup_log_files("config", keep=5)
+
+        # Assert - should delete 3 oldest logs
+        self.assertIsInstance(result, LogFilesCleanupResult)
+        self.assertEqual(result.total_cleaned, 3)
+        self.assertEqual(result.total_kept, 5)
+        self.assertEqual(result.total_failed, 0)
+        self.assertEqual(result.cleaned, logs[5:])
+        self.assertEqual(result.kept, logs[:5])
+        # Verify unlink was called on the 3 oldest logs (indices 5, 6, 7)
+        for log in logs[5:]:
+            log.unlink.assert_called_once()
+        # Verify unlink was NOT called on the 5 newest logs (indices 0-4)
+        for log in logs[:5]:
+            log.unlink.assert_not_called()
+
+    @patch("jupyter_deploy.handlers.command_history_handler.list_files_sorted")
+    def test_cleanup_log_files_handles_unlink_errors_gracefully(self, mock_list_files: Mock) -> None:
+        """Test that _cleanup_log_files handles unlink errors gracefully."""
+        # Create 7 mock log paths (already in sorted order, newest first)
+        logs = []
+        for i in range(7):
+            log = Mock(spec=Path)
+            if i == 5:
+                # First old log (index 5 after keep=5) fails to delete
+                log.unlink.side_effect = OSError("Permission denied")
+            else:
+                log.unlink = Mock()
+            logs.append(log)
+
+        mock_list_files.return_value = logs
+
+        # Act - keep only 5 most recent
+        result = self.handler._cleanup_log_files("config", keep=5)
+
+        # Assert - should delete only 1 (the second old log at index 6), track failure on the first (index 5)
+        self.assertIsInstance(result, LogFilesCleanupResult)
+        self.assertEqual(result.total_cleaned, 1)
+        self.assertEqual(result.total_kept, 5)
+        self.assertEqual(result.total_failed, 1)
+        self.assertEqual(result.cleaned, [logs[6]])
+        self.assertEqual(result.kept, logs[:5])
+        self.assertEqual(len(result.failed), 1)
+        self.assertEqual(result.failed[0][0], logs[5])
+        self.assertIsInstance(result.failed[0][1], OSError)
+
+    def test_clear_logs_clears_specific_command(self) -> None:
+        """Test that clear_logs clears logs for a specific command."""
+        mock_result = LogFilesCleanupResult(
+            cleaned=[Path("/fake/log1.log"), Path("/fake/log2.log"), Path("/fake/log3.log")],
+            kept=[Path("/fake/log4.log"), Path("/fake/log5.log")],
+        )
+        with patch.object(self.handler, "_cleanup_log_files", return_value=mock_result) as mock_cleanup:
+            result = self.handler.clear_logs(command="config", keep=20)
+
+            self.assertIsInstance(result, LogFilesCleanupResult)
+            self.assertEqual(result.total_cleaned, 3)
+            mock_cleanup.assert_called_once_with("config", keep=20)
+
+    def test_clear_logs_uses_default_keep_value(self) -> None:
+        """Test that clear_logs uses default keep value of 20."""
+        mock_result = LogFilesCleanupResult(
+            cleaned=[Path("/fake/log1.log"), Path("/fake/log2.log")],
+            kept=[Path("/fake/log3.log")],
+        )
+        with patch.object(self.handler, "_cleanup_log_files", return_value=mock_result) as mock_cleanup:
+            result = self.handler.clear_logs(command="config")
+
+            self.assertIsInstance(result, LogFilesCleanupResult)
+            self.assertEqual(result.total_cleaned, 2)
+            mock_cleanup.assert_called_once_with("config", keep=20)
+
+    def test_clear_logs_raises_exception_on_failures(self) -> None:
+        """Test that clear_logs raises LogCleanupError when deletions fail."""
+        mock_result = LogFilesCleanupResult(
+            cleaned=[Path("/fake/log1.log")],
+            kept=[Path("/fake/log2.log")],
+            failed=[(Path("/fake/log3.log"), OSError("Permission denied"))],
+        )
+        with patch.object(self.handler, "_cleanup_log_files", return_value=mock_result):
+            with self.assertRaises(LogCleanupError) as context:
+                self.handler.clear_logs(command="config", keep=20)
+
+            self.assertEqual(str(context.exception), "Failed to delete 1 log file(s)")


### PR DESCRIPTION
This PR adds jupyter-deploy commands to display (and manage) logs that the underlying infrastructure-as-code engine has output when wrapped within a `jupyter-deploy` command such as `jd config`, `jd up` or `jd down`.

Addresses #141 

Also in this PR:
- add auto-clear mechanism (w/ warning level failure) for `config`, `up` and `down` commands
- add a print statement to `config`, `up`, `down` command explaining how to access the logs

### User experience
- `jd history show` --> displays the latest command run logs (full)
- `jd history show up` --> displays the latest `up` command logs
- `jd history show config -n 2` --> displays the second-to-latest `config` command logs
- `jd history show config -l 200` --> displays the last 200 lines of the latest config command logs
- `jd history show config -l 300 -s 100` --> displays the line[-300:-100]
- `jd history list config` --> display the available `config` log runs for the project
- `jd history clear config --keep 20` --> deletes the log records (in `<project>/.jd-history`), except the 20 latest

### Implementation
- add `cli/history_app`, register w/ main app
- add methods to `handlers/command_history_handler`
- add a method `list_files_sorted` to `fs_utils` to a/ do a simple `os.scan` (non-recursive), b/ efficiently retrieve the latest n files (sort), to protect against very large dirs
- add error handling for fs operation in history (throws predictable error)
- catch the clear errors in `config`, `up`, `down`, display a warning but do not fail (side-effect operation)

### Testing
- tested manually against deployed project
- add E2E test `test_history` (mostly non-mutating)

### Screenshot
**jd history --help**
<img width="1043" height="219" alt="Screenshot 2026-02-04 at 4 10 29 PM" src="https://github.com/user-attachments/assets/5c877f40-e077-42e0-8621-ec17eb0f88c6" />

**jd history list --help**
<img width="1046" height="246" alt="Screenshot 2026-02-04 at 4 10 52 PM" src="https://github.com/user-attachments/assets/f31f8b43-3cec-462a-aa26-0d2b3da96e6c" />

**jd history show --help**
<img width="1045" height="296" alt="Screenshot 2026-02-04 at 4 11 13 PM" src="https://github.com/user-attachments/assets/17d39bfe-79d7-422e-85bd-5b5536352693" />

**jd history clear --help**
<img width="1044" height="230" alt="Screenshot 2026-02-04 at 4 11 43 PM" src="https://github.com/user-attachments/assets/3b9954dc-b679-4f9f-b877-e0a45f833adc" />

**jd history list config**
<img width="857" height="197" alt="Screenshot 2026-02-04 at 4 12 55 PM" src="https://github.com/user-attachments/assets/78a7f187-beb8-4451-9a07-81a230ef130c" />

**jd history show**
<img width="615" height="394" alt="Screenshot 2026-02-04 at 4 13 43 PM" src="https://github.com/user-attachments/assets/b970f1f8-ad1b-43fe-98cc-ffeba7342c21" />

**jd history show -l 10**
<img width="801" height="157" alt="Screenshot 2026-02-04 at 4 14 23 PM" src="https://github.com/user-attachments/assets/acf2058b-e940-4a16-8eda-a7f17a1a3af3" />
