### PR TITLE
test: e2e interactive config tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,10 +46,8 @@ Always run from the root of the repository:
    - Runs `uv run pytest`
 
 ## General coding rules
-1. **IMPORTANT**: Always place imports at the TOP of Python files. DO NOT use lazy imports (imports inside functions) except  
-  in `<cli>/provider/instruction_runner_factory` which handles optional dependencies.
-2. you MUST NOT silence linters without the user's permission
-3. you MUST NOT write docstrings that merely repeat a method name
+1. you MUST NOT silence linters without the user's permission
+2. you MUST NOT write docstrings that merely repeat a method name
 
 ## Writing unit tests
 Unit tests are located in `libs/<package-name>/tests/unit`
@@ -140,6 +138,8 @@ Essential commands for debugging a deployed instance that uses the base template
 - `jd show --outputs --list` - Display list of available outputs
 - `jd show -v VARIABLE-NAME --text` - Display the variable value (careful: it does not guarantee it was applied with `jd up`)
 - `jd show -o OUTPUT-NAME --text` - Display the output value
+- `jd history show CMD` - Display the content of the latest CMD (`config` or `up`) run (pass `-n 2` for the second-to-latest, etc)
+- `jd history show up -n 100 -s 100` - Display lines [-200:-100] of the latest `up` run
 - `jd --help` or `jd CMD SUB-CMD --help` - Find out about API shapes 
 
 ## Key file locations on instance in the base template

--- a/env.example
+++ b/env.example
@@ -30,7 +30,8 @@ JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET=00000aaaaa11111bbbbb22222ccccc
 #   - Single item: ["username1"]
 #   - Multiple items: ["username1", "username2"]
 JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES=["username1", "username2"]
-JD_E2E_VAR_OAUTH_ALLOWED_ORG=
+# Required when JD_E2E_VAR_OAUTH_ALLOWED_TEAMS is not []
+JD_E2E_VAR_OAUTH_ALLOWED_ORG=your-org-name
 # Array variables use YAML list syntax:
 #   - Empty list: []
 #   - Single item: ["team1"]

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_interactive.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_interactive.py
@@ -1,0 +1,275 @@
+"""E2E tests for supervised execution interactive config prompts."""
+
+import ast
+import os
+
+import pexpect
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+from pytest_jupyter_deploy.undeployed_project import undeployed_project
+
+# All required deployment configuration variables from .env
+REQUIRED_DEPLOYMENT_VARS = [
+    "JD_E2E_VAR_DOMAIN",
+    "JD_E2E_VAR_SUBDOMAIN",
+    "JD_E2E_VAR_EMAIL",
+    "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+    "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES",
+    "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+    "JD_E2E_VAR_OAUTH_ALLOWED_ORG",
+]
+
+
+@skip_if_testvars_not_set(REQUIRED_DEPLOYMENT_VARS)
+def test_config_interactive(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that terraform prompts work correctly in interactive mode.
+
+    This test verifies that:
+    1. Progress bar pauses when terraform prompts for input
+    2. User can provide input via stdin
+    3. Command completes successfully after receiving all inputs
+    4. Values are correctly set and can be retrieved via jd show
+    """
+    # Get deployment config values from environment
+    domain = os.environ["JD_E2E_VAR_DOMAIN"]
+    subdomain = os.environ["JD_E2E_VAR_SUBDOMAIN"]
+    letsencrypt_email = os.environ["JD_E2E_VAR_EMAIL"]
+    oauth_client_id = os.environ["JD_E2E_VAR_OAUTH_APP_CLIENT_ID"]
+    oauth_client_secret = os.environ["JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET"]
+    oauth_allowed_usernames = os.environ["JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES"]
+    oauth_allowed_teams = os.environ["JD_E2E_VAR_OAUTH_ALLOWED_TEAMS"]
+    oauth_allowed_org = os.environ["JD_E2E_VAR_OAUTH_ALLOWED_ORG"]
+
+    with undeployed_project(e2e_deployment.suite_config) as (_, cli):
+        # Run interactive config session (non-verbose)
+        with cli.spawn_interactive_session("jupyter-deploy config", timeout=120) as session:
+            # Terraform prompts for required variables in lexicographic order:
+            # 1. domain
+            # 2. letsencrypt_email
+            # 3. oauth_allowed_org (nullable - send empty string)
+            # 4. oauth_allowed_teams (nullable - send empty string)
+            # 5. oauth_allowed_usernames
+            # 6. oauth_app_client_id
+            # 7. oauth_app_client_secret
+            # 8. subdomain
+
+            # 1. Domain prompt
+            session.expect(r"var\.domain", timeout=60)
+            session.sendline(domain)
+
+            # 2. Letsencrypt email prompt
+            session.expect(r"var\.letsencrypt_email", timeout=10)
+            session.sendline(letsencrypt_email)
+
+            # 3. OAuth allowed org prompt (nullable string - send value from env)
+            session.expect(r"var\.oauth_allowed_org", timeout=10)
+            session.sendline(oauth_allowed_org)
+
+            # 4. OAuth allowed teams prompt (list - send value from env)
+            session.expect(r"var\.oauth_allowed_teams", timeout=10)
+            session.sendline(oauth_allowed_teams)
+
+            # 5. OAuth allowed usernames prompt (list)
+            session.expect(r"var\.oauth_allowed_usernames", timeout=10)
+            session.sendline(oauth_allowed_usernames)
+
+            # 6. OAuth app client ID prompt
+            session.expect(r"var\.oauth_app_client_id", timeout=10)
+            session.sendline(oauth_client_id)
+
+            # 7. OAuth app client secret prompt (sensitive)
+            session.expect(r"var\.oauth_app_client_secret", timeout=10)
+            session.sendline(oauth_client_secret)
+
+            # 8. Subdomain prompt
+            session.expect(r"var\.subdomain", timeout=10)
+            session.sendline(subdomain)
+
+            # Wait for command completion
+            session.expect(pexpect.EOF, timeout=90)
+
+            # Check exit status
+            session.close()
+
+            # Capture output for debugging
+            output = session.before if hasattr(session, "before") else ""
+
+            assert session.exitstatus == 0, (
+                f"Expected config to complete successfully (exit 0), got exit status {session.exitstatus}\n"
+                f"Session output: {output}"
+            )
+
+        # Verify values were correctly set using jd show
+        # Domain
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "domain", "--text"])
+        assert domain in result.stdout, f"Expected domain '{domain}' in output, got: {result.stdout}"
+
+        # Subdomain
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "subdomain", "--text"])
+        assert subdomain in result.stdout, f"Expected subdomain '{subdomain}' in output, got: {result.stdout}"
+
+        # Letsencrypt email
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "letsencrypt_email", "--text"])
+        assert letsencrypt_email in result.stdout, (
+            f"Expected letsencrypt_email '{letsencrypt_email}' in output, got: {result.stdout}"
+        )
+
+        # OAuth app client ID
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_app_client_id", "--text"])
+        assert oauth_client_id in result.stdout, (
+            f"Expected oauth_client_id '{oauth_client_id}' in output, got: {result.stdout}"
+        )
+
+        # OAuth app client secret (sensitive - should be masked)
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_app_client_secret", "--text"])
+        assert result.stdout.strip() == "****", (
+            f"Expected oauth_app_client_secret to be masked as '****', got: {result.stdout.strip()}"
+        )
+
+        # OAuth allowed org
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_allowed_org", "--text"])
+        assert oauth_allowed_org in result.stdout, (
+            f"Expected oauth_allowed_org '{oauth_allowed_org}' in output, got: {result.stdout}"
+        )
+
+        # OAuth allowed teams (list variable)
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_allowed_teams", "--text"])
+        # Parse the list from the output
+        teams_list = ast.literal_eval(result.stdout.strip())
+        assert isinstance(teams_list, list), f"Expected list, got {type(teams_list)}"
+        # Parse expected value from env var (it's already in JSON format like [])
+        expected_teams = ast.literal_eval(oauth_allowed_teams)
+        assert teams_list == expected_teams, f"Expected oauth_allowed_teams to be {expected_teams}, got {teams_list}"
+
+        # OAuth allowed usernames (list variable)
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_allowed_usernames", "--text"])
+        # Parse the list from the output
+        users_list = ast.literal_eval(result.stdout.strip())
+        assert isinstance(users_list, list), f"Expected list, got {type(users_list)}"
+        # Parse expected value from env var (it's already in JSON format like ["user1"])
+        expected_users = ast.literal_eval(oauth_allowed_usernames)
+        assert users_list == expected_users, (
+            f"Expected oauth_allowed_usernames to be {expected_users}, got {users_list}"
+        )
+
+
+@skip_if_testvars_not_set(REQUIRED_DEPLOYMENT_VARS)
+def test_config_interactive_verbose(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that terraform prompts work correctly in interactive mode with --verbose flag.
+
+    This test verifies the same behavior as test_config_interactive but with verbose output.
+    """
+    # Get deployment config values from environment
+    domain = os.environ["JD_E2E_VAR_DOMAIN"]
+    subdomain = os.environ["JD_E2E_VAR_SUBDOMAIN"]
+    letsencrypt_email = os.environ["JD_E2E_VAR_EMAIL"]
+    oauth_client_id = os.environ["JD_E2E_VAR_OAUTH_APP_CLIENT_ID"]
+    oauth_client_secret = os.environ["JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET"]
+    oauth_allowed_usernames = os.environ["JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES"]
+    oauth_allowed_teams = os.environ["JD_E2E_VAR_OAUTH_ALLOWED_TEAMS"]
+    oauth_allowed_org = os.environ["JD_E2E_VAR_OAUTH_ALLOWED_ORG"]
+
+    with undeployed_project(e2e_deployment.suite_config) as (_, cli):
+        # Run interactive config session (verbose mode)
+        with cli.spawn_interactive_session("jupyter-deploy config --verbose", timeout=120) as session:
+            # Terraform prompts for required variables in lexicographic order
+
+            # 1. Domain prompt
+            session.expect(r"var\.domain", timeout=90)
+            session.sendline(domain)
+
+            # 2. Letsencrypt email prompt
+            session.expect(r"var\.letsencrypt_email", timeout=10)
+            session.sendline(letsencrypt_email)
+
+            # 3. OAuth allowed org prompt (nullable string - send value from env)
+            session.expect(r"var\.oauth_allowed_org", timeout=10)
+            session.sendline(oauth_allowed_org)
+
+            # 4. OAuth allowed teams prompt (list - send value from env)
+            session.expect(r"var\.oauth_allowed_teams", timeout=10)
+            session.sendline(oauth_allowed_teams)
+
+            # 5. OAuth allowed usernames prompt (list)
+            session.expect(r"var\.oauth_allowed_usernames", timeout=10)
+            session.sendline(oauth_allowed_usernames)
+
+            # 6. OAuth app client ID prompt
+            session.expect(r"var\.oauth_app_client_id", timeout=10)
+            session.sendline(oauth_client_id)
+
+            # 7. OAuth app client secret prompt (sensitive)
+            session.expect(r"var\.oauth_app_client_secret", timeout=10)
+            session.sendline(oauth_client_secret)
+
+            # 8. Subdomain prompt
+            session.expect(r"var\.subdomain", timeout=10)
+            session.sendline(subdomain)
+
+            # Wait for command completion
+            session.expect(pexpect.EOF, timeout=90)
+
+            # Check exit status
+            session.close()
+
+            # Capture output for debugging
+            output = session.before if hasattr(session, "before") else ""
+
+            assert session.exitstatus == 0, (
+                f"Expected config --verbose to complete successfully (exit 0), got exit status {session.exitstatus}\n"
+                f"Session output: {output}"
+            )
+
+        # Verify values were correctly set (same as non-verbose test)
+        # Domain
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "domain", "--text"])
+        assert domain in result.stdout, f"Expected domain '{domain}' in output, got: {result.stdout}"
+
+        # Subdomain
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "subdomain", "--text"])
+        assert subdomain in result.stdout, f"Expected subdomain '{subdomain}' in output, got: {result.stdout}"
+
+        # Letsencrypt email
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "letsencrypt_email", "--text"])
+        assert letsencrypt_email in result.stdout, (
+            f"Expected letsencrypt_email '{letsencrypt_email}' in output, got: {result.stdout}"
+        )
+
+        # OAuth app client ID
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_app_client_id", "--text"])
+        assert oauth_client_id in result.stdout, (
+            f"Expected oauth_client_id '{oauth_client_id}' in output, got: {result.stdout}"
+        )
+
+        # OAuth app client secret (sensitive - should be masked)
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_app_client_secret", "--text"])
+        assert result.stdout.strip() == "****", (
+            f"Expected oauth_app_client_secret to be masked as '****', got: {result.stdout.strip()}"
+        )
+
+        # OAuth allowed org
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_allowed_org", "--text"])
+        assert oauth_allowed_org in result.stdout, (
+            f"Expected oauth_allowed_org '{oauth_allowed_org}' in output, got: {result.stdout}"
+        )
+
+        # OAuth allowed teams (list variable)
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_allowed_teams", "--text"])
+        # Parse the list from the output
+        teams_list = ast.literal_eval(result.stdout.strip())
+        assert isinstance(teams_list, list), f"Expected list, got {type(teams_list)}"
+        # Parse expected value from env var (it's already in JSON format like [])
+        expected_teams = ast.literal_eval(oauth_allowed_teams)
+        assert teams_list == expected_teams, f"Expected oauth_allowed_teams to be {expected_teams}, got {teams_list}"
+
+        # OAuth allowed usernames (list variable)
+        result = cli.run_command(["jupyter-deploy", "show", "--variable", "oauth_allowed_usernames", "--text"])
+        # Parse the list from the output
+        users_list = ast.literal_eval(result.stdout.strip())
+        assert isinstance(users_list, list), f"Expected list, got {type(users_list)}"
+        # Parse expected value from env var (it's already in JSON format like ["user1"])
+        expected_users = ast.literal_eval(oauth_allowed_usernames)
+        assert users_list == expected_users, (
+            f"Expected oauth_allowed_usernames to be {expected_users}, got {users_list}"
+        )

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_set.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_set.py
@@ -199,3 +199,25 @@ def test_config_set_list_of_dict_variable(e2e_deployment: EndToEndDeployment) ->
     assert reverted_mounts == current_mounts, (
         f"Expected additional_ebs_mounts to be reverted to {current_mounts}, but got {reverted_mounts}"
     )
+
+
+def test_config_set_string_variable_with_verbose(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that config --verbose shows full terraform output without progress bar artifacts."""
+    e2e_deployment.ensure_deployed()
+
+    # Run jd config --verbose to verify it shows full terraform output
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "config", "--verbose"])
+
+    # Verify command succeeded
+    assert result.returncode == 0, f"Expected config --verbose to succeed, got returncode {result.returncode}"
+
+    # Check for terraform init success message
+    assert "Terraform has been successfully initialized!" in result.stdout, (
+        "Expected 'Terraform has been successfully initialized!' in verbose output"
+    )
+
+    # Verify no progress bar artifacts (spinners, live box remnants)
+    # Progress bar typically uses ANSI escape codes or special characters
+    # Check that output doesn't contain common progress indicators
+    assert "⠋" not in result.stdout, "Found spinner character in verbose output (should not have progress bar)"
+    assert "⠙" not in result.stdout, "Found spinner character in verbose output (should not have progress bar)"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_deployment.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_deployment.py
@@ -1,6 +1,7 @@
 """E2E test for full deployment lifecycle from scratch."""
 
 import pytest
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.oauth2_proxy.github import GitHubOAuth2ProxyApplication
 
 from .constants import ORDER_DEPLOYMENT
@@ -28,3 +29,38 @@ def test_immediately_available_after_deployment(
     # Now authenticate and verify full JupyterLab access
     github_oauth_app.ensure_authenticated()
     github_oauth_app.verify_jupyterlab_accessible()
+
+
+@pytest.mark.order(ORDER_DEPLOYMENT + 1)
+@pytest.mark.full_deployment  # Only runs when deploying from scratch
+def test_deployment_history_captured(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that config and up logs are captured in jd history after deployment.
+
+    This test runs after test_immediately_available_after_deployment and verifies:
+    1. Exactly 1 config log exists
+    2. Exactly 1 up log exists
+    3. Config log contains terraform initialization output
+    4. Up log contains terraform apply output
+    """
+    # Verify exactly 1 config log exists
+    config_list_result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "list", "config", "--text"])
+    config_logs = [line for line in config_list_result.stdout.strip().split("\n") if line.strip()]
+    assert len(config_logs) == 1, f"Expected exactly 1 config log, found {len(config_logs)}"
+
+    # Verify exactly 1 up log exists
+    up_list_result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "list", "up", "--text"])
+    up_logs = [line for line in up_list_result.stdout.strip().split("\n") if line.strip()]
+    assert len(up_logs) == 1, f"Expected exactly 1 up log, found {len(up_logs)}"
+
+    # Retrieve and verify config log content
+    config_show_result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "show", "config"])
+    config_content = config_show_result.stdout
+    assert "Terraform has been successfully initialized!" in config_content, (
+        "Expected 'Terraform has been successfully initialized!' in config log"
+    )
+
+    # Retrieve and verify up log content
+    up_show_result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "show", "up"])
+    up_content = up_show_result.stdout
+    assert "Apply complete!" in up_content, "Expected 'Apply complete!' in up log"
+    assert "Outputs:" in up_content, "Expected 'Outputs:' section in up log"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_deployment.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_deployment.py
@@ -24,7 +24,7 @@ def test_immediately_available_after_deployment(
     """
     # Immediately verify OAuth proxy is accessible
     # This will land on OAuth login page (before authentication)
-    github_oauth_app.verify_oauth_proxy_accessible()
+    github_oauth_app.verify_oauth_proxy_accessible(max_retries=20)
 
     # Now authenticate and verify full JupyterLab access
     github_oauth_app.ensure_authenticated()

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/constants.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/constants.py
@@ -11,10 +11,6 @@ AUTH_DIR = ".auth"
 # File names
 ENV_FILE = ".env"
 GITHUB_OAUTH_STATE_FILE = "github-oauth-state.json"
-E2E_UP_LOG_FILE = "e2e-up.log"
-E2E_DOWN_LOG_FILE = "e2e-down.log"
-E2E_UPGRADE_INSTANCE_LOG_FILE = "e2e-upgrade-instance.log"
-E2E_CONFIG_LOG_FILE = "e2e-config.log"
 
 # Configuration
 CONFIGURATION_DEFAULT_NAME = "base"

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
@@ -362,7 +362,7 @@ class GitHubOAuth2ProxyApplication:
             # Unexpected error - re-raise
             raise RuntimeError(f"Unexpected error while verifying server is unaccessible: {e}") from e
 
-    def verify_oauth_proxy_accessible(self) -> None:
+    def verify_oauth_proxy_accessible(self, max_retries: int = 10) -> None:
         """Verify that the OAuth2 Proxy page is accessible and responding.
 
         This method navigates to the JupyterLab URL and verifies that the OAuth2 Proxy
@@ -377,7 +377,7 @@ class GitHubOAuth2ProxyApplication:
         """
         # Navigate to the JupyterLab URL
         # Allows higher retry to account for route53 stabilization.
-        self._navigate_with_retry(self.jupyterlab_url, timeout=60000, max_retries=10)
+        self._navigate_with_retry(self.jupyterlab_url, timeout=60000, max_retries=max_retries)
 
         # Verify OAuth2 Proxy sign-in button is visible
         sign_in_button = self.page.get_by_role("button", name="Sign in with GitHub")


### PR DESCRIPTION
This PR adds E2E tests for a/ interactive experience for `jd config` (w/ and w/o `--verbose`), b/ ensure that command runs logs get recorded and are accessible afterwards.

Addresses #142 

Also in this PR:
- remove unnecessary `try`/`except` around `jd up` calls in E2E tests now that we hardened the waiter script (see #125, #127, #135, #139)
- remove unnecessary adhoc command log records in plugin and E2E tests now that we have `jd history` commands (see #137 and #141 )
- instruction for `jd history` commands in `CLAUDE.md` 

### User experience
- no change, test code only

### Testing
- Ran E2E tests