### PR TITLE
release: v0.4.0

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/__init__.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/__init__.py
@@ -4,4 +4,4 @@ Relies on traefik for proxy, letsencrypt to generate the TLS certificate
 and external oauth provider.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/main.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/main.tf
@@ -15,7 +15,7 @@ resource "random_id" "postfix" {
 
 locals {
   template_name    = "tf-aws-ec2-base"
-  template_version = "0.3.0"
+  template_version = "0.4.0"
 
   default_tags = {
     Source       = "jupyter-deploy"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 template:
   name: tf-aws-ec2-base
   engine: terraform
-  version: 0.3.0
+  version: 0.4.0
 requirements:
 - name: terraform
 - name: awscli
@@ -522,32 +522,32 @@ supervised-execution:
   config:
     config.terraform-plan:
       default-phase:
-        label: "Reading data sources"
-        progress-pattern: "(Read complete after|Refreshing state)"
+        label: Reading data sources
+        progress-pattern: (Read complete after|Refreshing state)
         progress-events-estimate: 50
       phases:
-        - enter-pattern: "Terraform will perform the following actions:"
-          progress-pattern: "(will be created|will be read during apply|will be destroyed)"
-          progress-events-estimate: 70
-          label: "Generating plan"
-          weight: 50
+      - enter-pattern: 'Terraform will perform the following actions:'
+        progress-pattern: (will be created|will be read during apply|will be destroyed)
+        progress-events-estimate: 70
+        label: Generating plan
+        weight: 50
   up:
     up.terraform-apply:
       phases:
-        - enter-pattern: "null_resource.wait_for_instance_ready: Creating"
-          exit-pattern: "null_resource.wait_for_instance_ready: Creation complete"
-          label: "Configuring EC2 instance"
-          weight: 40
-          phases:
-            - enter-pattern: "Waiting for SSM agent"
-              label: "Waiting for SSM agent"
-              weight: 10
-            - enter-pattern: "Cloudinit script is running"
-              label: "Configuring EC2 instance"
-              weight: 50
-            - enter-pattern: "Checking instance status"
-              label: "Checking instance status"
-              weight: 20
-            - enter-pattern: "fetching TLS certificates"
-              label: "Getting TLS certificates"
-              weight: 20
+      - enter-pattern: 'null_resource.wait_for_instance_ready: Creating'
+        exit-pattern: 'null_resource.wait_for_instance_ready: Creation complete'
+        label: Configuring EC2 instance
+        weight: 40
+        phases:
+        - enter-pattern: Waiting for SSM agent
+          label: Waiting for SSM agent
+          weight: 10
+        - enter-pattern: Cloudinit script is running
+          label: Configuring EC2 instance
+          weight: 50
+        - enter-pattern: Checking instance status
+          label: Checking instance status
+          weight: 20
+        - enter-pattern: fetching TLS certificates
+          label: Getting TLS certificates
+          weight: 20

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pixi.jupyter.toml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pixi.jupyter.toml.tftpl
@@ -11,7 +11,7 @@ platforms = [
     "linux-64",
 %{ endif ~}
 ]
-version = "0.3.0"
+version = "0.4.0"
 
 [tasks]
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pyproject.kernel.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pyproject.kernel.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-uv-kernel"
-version = "0.3.0"
+version = "0.4.0"
 description = "A jupyter kernel configuration managed by UV"
 requires-python = ">=3.12"
 dependencies = [

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter"
-version = "0.3.0"
+version = "0.4.0"
 description = "A basic image with jupyterlab and server-documents"
 requires-python = ">=3.12"
 dependencies = [

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.kernel.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.kernel.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-kernel"
-version = "0.3.0"
+version = "0.4.0"
 description = "A placeholder additional jupyter kernel configuration"
 requires-python = ">=3.12"
 dependencies = []

--- a/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-tf-aws-ec2-base"
-version = "0.3.0"
+version = "0.4.0"
 description = "Base terraform template to deploy a JupyterLab application on an AWS EC2 instance."
 readme = "README.md"
 authors = [
@@ -64,18 +64,18 @@ select = [
     "B",
     "SIM",
     "I",
-    "PLC0415",  # import-outside-toplevel - disallow lazy imports
+    "PLC0415",
 ]
 ignore = [
-    # Ignore other preview rules we're not ready for yet
-    "UP042",  # Replace str/Enum with StrEnum (Python 3.11+)
-    "UP046",  # Use PEP 695 type parameters (Python 3.12+)
-    "UP047",  # Use PEP 695 type parameters for functions (Python 3.12+)
+    "UP042",
+    "UP046",
+    "UP047",
 ]
 
 [tool.ruff.lint.per-file-ignores]
-# Allow lazy imports in tests (common pattern for imports after mocks)
-"tests/**/*.py" = ["PLC0415"]
+"tests/**/*.py" = [
+    "PLC0415",
+]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy"
-version = "0.3.0"
+version = "0.4.0"
 description = "CLI based tool to deploy Jupyter applications that integrates with infrastructure as code frameworks."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-monorepo"
-version = "0.3.0"
+version = "0.4.0"
 description = "Monorepo for Jupyter deploy packages"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -292,7 +292,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-deploy"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "libs/jupyter-deploy" }
 dependencies = [
     { name = "click" },
@@ -354,7 +354,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-monorepo"
-version = "0.3.0"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jupyter-deploy", extra = ["aws"] },
@@ -395,7 +395,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-tf-aws-ec2-base"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "libs/jupyter-deploy-tf-aws-ec2-base" }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Release PR for:
- jupyter-deploy: v0.2.6 -> v0.3.0
- base template: v0.2.6 -> v0.3.0

Not publishing the pytest plugin to `pypi` yet; tracking in #134 
