### PR TITLE
fix: jupyter-deploy build setting

### DIFF
--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -48,9 +48,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["jupyter_deploy"]
 
-[tool.hatch.build.targets.wheel.force-include]
-"jupyter_deploy/handlers/init_static" = "jupyter_deploy/handlers/init_static"
-
 [dependency-groups]
 dev = [
     "mypy>=1.15.0",


### PR DESCRIPTION
Remove unnecessary custom hatch build introduced by #146 

### Testing
- build the distribution `.whl` locally, unzip, verified the static files are present