### PR TITLE
fix: class refactor, args consistency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,45 @@ Then module `provider/instruction_runner_factory` handles these optional imports
 You MUST NOT break that pattern with import statements to cloud-provider or infrastructure-as-code specific libraries
 outside of the instruction runner code paths.
 
+### Three-Layer Architecture
+
+**1. Core Layer** (handlers, engine, provider):
+- Handlers provide abstraction for each `jupyter-deploy` commands
+- Raise exceptions from `jupyter_deploy/exceptions.py` for errors
+- Accept `DisplayManager` instance from CLI, then use its method: `info()`, `warning()`, `success()`, `hint()`
+- Defines `SupervisedExecutor` class for managing infrastructure-as-code subprocesses
+  - Located in `engine/supervised_execution`
+  - Emits progress events that `DisplayManager` handles
+  - Supports switching between `stdin` and `stdout` when subprocess prompts for input
+- Defines the abstract, provider-agnostic command runner: `/provider/manifest_command_runner`
+  - Run commands declared in a template manifest
+  - Use a specific provider module (e.g. `/provider/aws`), which calls provider-SDK (e.g. `boto3`)
+  - Optional install thanks to lazy import in factory module `/provider/instruction_runner_factory`
+
+**2. Provider and Engine Implementations** (unified abstraction):
+- Engine implement specific command Handlers for a specific infrastructure-as-code engine; current engines:
+  - `terraform`
+- Engine {Config|Up|Down}Handlers leverage `SupervisedExecutor` to run the infrastructure-as-code subprocess calls
+- Provider instruction runners implement the `InstructionRunner` interface to make API calls with the specific provider SDK; current providers:
+  - `aws`
+
+**3. CLI Layer** (cli/):
+- Instantiate Console and error handler
+- Call core handlers and catch exceptions
+- Format and display results using rich/typer
+- Implement `DisplayManager` protocol with display managers; implementations:
+  - `SimpleDisplayManager` (cli/simple_display.py) - Spinners, status messages for SDK-style operations
+  - `ProgressDisplayManager` (cli/progress_display.py) - Progress bars, log boxes for long operations
+  - `NullDisplay` (engine/supervised_execution.py) - No-op for programmatic/test usage
+
+### Key Principles
+
+1. **Exception Handling**: All custom exceptions in `jupyter_deploy/exceptions.py`
+2. **Keep Core Generic**: Core defines interfaces, instantiates engine-specific and provider-specific instance as needed
+3. **No Terminal-specific Dependencies in Core**: rich/typer only in cli/ module
+4. **No Engine-specific implementation in Core**: use the `/engine/<engine-name>` module
+5. **Not Provider-specific implementation in Core**: use the `/provider/<provider-name>` or `/api/<api-name>` modules
+
 ## Base template package
 Code: `./libs/jupyter-deploy-tf-ec2-base`
 
@@ -112,7 +151,7 @@ This will:
 ## Running E2E Tests
 Run E2E tests against an existing deployment: `just test-e2e <project-dir> TEST-SELECTOR`
 
-Examples:
+Examples (for project-dir == sandbox3):
 - Run all E2E tests without mutating the project: `just test-e2e sandbox3 ""`
 - Run all E2E tests: `just test-e2e sandbox3 "" mutate=true`
 - Run specific test file: `just test-e2e sandbox3 test_users` (possibly needs `mutate=true`)
@@ -120,39 +159,20 @@ Examples:
 **NOTE:** mutate tests are long, pipe to log stream to file: `just test-e2e <project-dir> TEST-SELECTOR mutate=true 2>&1 | tee results.log`   
 The test container saves screenshots of failed tests to `./test-results`, use the read image tool.
 
-# Debugging and Investing Deployments
+# Debugging and Investigating Deployments
 
-## Useful jd commands
-Essential commands for debugging a deployed instance that uses the base template.
-- `jd server status` - Check server health status (IN_SERVICE, OUT_OF_SERVICE, etc.)
-- `jd server restart` - Restart all services
-- `jd host status` - Check EC2 instance status
-- `jd host exec -- "command"` - Execute commands on the instance
-- `jd server exec -s SERVICE -- CMD` - Execute commands in the container on the instance
-- `jd host exec -- tail -50 /var/log/jupyter-deploy/LOG-FILENAME` - View command logs (e.g. `update-server.log` for `jd server restart` logs)
-- `jd host exec -- tail -50 /var/log/services/LOG-FILENAME` - View historic service logs (survives container restart)
-- `jd server logs -s SERVICE` - View service logs
-- `jd config` - Reconfigure deployment (generates terraform plan)
-- `jd up` - Apply infrastructure changes
+**Important:** Most `jd` commands (`init` excepted) assume the `cwd` is a particular project; change dir, or use the `--path` attribute (most commands support it).
+
+Essential commands for debugging a deploy project:
+- `jd --help` or `jd CMD SUB-CMD --help` - Find out about API shapes
 - `jd show --variables --list` - Display list of available variables
 - `jd show --outputs --list` - Display list of available outputs
 - `jd show -v VARIABLE-NAME --text` - Display the variable value (careful: it does not guarantee it was applied with `jd up`)
 - `jd show -o OUTPUT-NAME --text` - Display the output value
+- `jd config` - Reconfigure deployment
+- `jd up` - Apply infrastructure changes
 - `jd history show CMD` - Display the content of the latest CMD (`config` or `up`) run (pass `-n 2` for the second-to-latest, etc)
 - `jd history show up -n 100 -s 100` - Display lines [-200:-100] of the latest `up` run
-- `jd --help` or `jd CMD SUB-CMD --help` - Find out about API shapes 
 
-## Key file locations on instance in the base template
-
-### Deployment scripts (downloaded from S3 by SSM association)
-- `/usr/local/bin/check-status-internal.sh` - Status checking logic
-- `/usr/local/bin/get-status.sh` - Status code mapping
-- `/usr/local/bin/update-server.sh` - Service management (start/stop/restart)
-- `/usr/local/bin/update-auth.sh` - OAuth configuration updates
-- `/usr/local/bin/sync-acme.sh` - TLS certificate sync from Secrets Manager
-
-### Docker configuration files
-- `/opt/docker/docker-compose.yml` - Docker Compose configuration
-- `/opt/docker/docker-startup.sh` - Docker services startup script
-- `/opt/docker/dockerfile.jupyter` - Jupyter container Dockerfile
-- `/opt/docker/traefik.yml` - Traefik reverse proxy configuration
+More specific commands are template-dependent.
+Read the `AGENT.md` in the project directory for detailed instructions.

--- a/libs/jupyter-deploy/jupyter_deploy/api/aws/ec2/ec2_instance.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/aws/ec2/ec2_instance.py
@@ -15,7 +15,7 @@ from mypy_boto3_ec2.type_defs import (
     StopInstancesRequestTypeDef,
 )
 
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 
 
 class Ec2InstanceState(str, Enum):
@@ -137,7 +137,7 @@ def poll_for_instance_status(
     ec2_client: EC2Client,
     instance_id: str,
     desired_state: Ec2InstanceState,
-    terminal_handler: TerminalHandler | None = None,
+    display_manager: DisplayManager,
     timeout_seconds: int = 60,
     wait_after_seconds: int = 2,
     poll_interval_seconds: int = 5,
@@ -148,7 +148,7 @@ def poll_for_instance_status(
         ec2_client: EC2 client to use
         instance_id: Instance ID to poll
         desired_state: Desired instance state
-        terminal_handler: Optional terminal handler for status updates
+        display_manager: Display manager for status updates
         timeout_seconds: Timeout in seconds
         wait_after_seconds: Wait time after first API call
         poll_interval_seconds: Polling interval in seconds
@@ -168,16 +168,14 @@ def poll_for_instance_status(
         curr_time = time.time()
 
         if state == desired_state:
-            if terminal_handler:
-                terminal_handler.success(f"Instance reached desired state: '{desired_state.value}'")
+            display_manager.success(f"Instance reached desired state: '{desired_state.value}'")
             return response
         elif state.is_terminal():
             raise ValueError(f"Unexpected terminal state for instance '{instance_id}': '{state.value}'")
         elif curr_time - start_time > timeout_seconds:
             raise TimeoutError(f"Timed out polling state of instance '{instance_id}', end state '{state.value}'")
         else:
-            if terminal_handler:
-                terminal_handler.info(f"Polling status of instance '{instance_id}', current state: '{state.value}'...")
+            display_manager.info(f"Polling status of instance '{instance_id}', current state: '{state.value}'...")
             time.sleep(poll_interval_seconds)
 
 

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -1,6 +1,5 @@
 import subprocess
 import sys
-from contextlib import nullcontext
 from pathlib import Path
 from typing import Annotated
 
@@ -217,10 +216,12 @@ def config(
     with handle_cli_errors(console):
         preset_name = None if defaults_preset_name == "none" else defaults_preset_name
 
-        # Create progress display manager (or None if verbose mode)
-        progress_display = None if verbose else ProgressDisplayManager()
+        # Create display manager: SimpleDisplayManager for verbose, ProgressDisplayManager for non-verbose
+        display_manager = (
+            SimpleDisplayManager(console=console, pass_through=True) if verbose else ProgressDisplayManager()
+        )
 
-        handler = config_handler.ConfigHandler(output_filename=output_filename, terminal_handler=progress_display)
+        handler = config_handler.ConfigHandler(output_filename=output_filename, display_manager=display_manager)
 
         # Validate and set preset
         # First, verify whether there are recorded variables values from user inputs
@@ -275,7 +276,7 @@ def config(
                 console.rule("[bold]jupyter-deploy:[/] configuring the project")
 
             completion_context = None
-            with progress_display or nullcontext():
+            with display_manager:
                 try:
                     completion_context = handler.configure(variable_overrides=variables)
                 except LogCleanupError as e:
@@ -284,14 +285,19 @@ def config(
 
             if verbose:
                 console.rule("[bold]jupyter-deploy:[/] recording input values")
-
-            handler.record(record_vars=True, record_secrets=record_secrets)
-
-            if verbose:
+                handler.record(record_vars=True, record_secrets=record_secrets)
                 if record_secrets:
                     console.print(":floppy_disk: Recorded configuration, variables and secrets")
                 else:
                     console.print(":floppy_disk: Recorded configuration and variables")
+            else:
+                # Show spinner during record phase in non-verbose mode
+                with display_manager.spinner("Recording configuration..."):
+                    handler.record(record_vars=True, record_secrets=record_secrets)
+                    if record_secrets:
+                        display_manager.info(":floppy_disk: Recorded configuration, variables and secrets")
+                    else:
+                        display_manager.info(":floppy_disk: Recorded configuration and variables")
 
             # finally, display a message to the user if config ignored the template defaults
             # in favor of the recorded variables, with instructions on how to change this behavior.
@@ -354,11 +360,13 @@ def up(
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
-        # Create progress display manager (or None if verbose mode)
-        progress_display = None if verbose else ProgressDisplayManager()
+        # Create display manager: SimpleDisplayManager for verbose, ProgressDisplayManager for non-verbose
+        display_manager = (
+            SimpleDisplayManager(console=console, pass_through=True) if verbose else ProgressDisplayManager()
+        )
 
         # Pass to handler via protocol
-        handler = UpHandler(terminal_handler=progress_display)
+        handler = UpHandler(display_manager=display_manager)
 
         if verbose:
             console.rule("[bold]jupyter-deploy:[/] verifying presence of config file")
@@ -367,7 +375,7 @@ def up(
         if verbose:
             console.rule("[bold]jupyter-deploy:[/] applying infrastructure changes")
         completion_context = None
-        with progress_display or nullcontext():
+        with display_manager:
             try:
                 completion_context = handler.apply(config_file_path, auto_approve)
             except LogCleanupError as e:
@@ -410,10 +418,10 @@ def down(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         # Create display manager based on mode
-        terminal_handler = SimpleDisplayManager(console, pass_through=True) if verbose else ProgressDisplayManager()
+        display_manager = SimpleDisplayManager(console, pass_through=True) if verbose else ProgressDisplayManager()
 
         # Pass to handler via protocol
-        handler = DownHandler(terminal_handler=terminal_handler)
+        handler = DownHandler(display_manager=display_manager)
 
         # Check for persisting resources and display warning
         persisting_resources = handler.get_persisting_resources()
@@ -425,7 +433,7 @@ def down(
 
         if verbose:
             console.rule("[bold]jupyter-deploy:[/] destroying infrastructure resources")
-        with terminal_handler:
+        with display_manager:
             try:
                 handler.destroy(auto_approve)
             except LogCleanupError as e:

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -29,7 +29,7 @@ def status(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = host_handler.HostHandler(terminal_handler=simple_display_manager)
+        handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Checking host status..."):
             status = handler.get_host_status()
@@ -52,7 +52,7 @@ def stop(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = host_handler.HostHandler(terminal_handler=simple_display_manager)
+        handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Stopping host..."):
             handler.stop_host()
@@ -73,7 +73,7 @@ def start(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = host_handler.HostHandler(terminal_handler=simple_display_manager)
+        handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Starting host..."):
             handler.start_host()
@@ -94,7 +94,7 @@ def restart(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = host_handler.HostHandler(terminal_handler=simple_display_manager)
+        handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Restarting host..."):
             handler.restart_host()
@@ -115,7 +115,7 @@ def connect(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = host_handler.HostHandler(terminal_handler=simple_display_manager)
+        handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Connecting to host..."):
             handler.connect()
@@ -151,7 +151,7 @@ def exec(
 
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = host_handler.HostHandler(terminal_handler=simple_display_manager)
+        handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Executing command..."):
             stdout, stderr, returncode = handler.exec_command(command_args)

--- a/libs/jupyter-deploy/jupyter_deploy/cli/organization_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/organization_app.py
@@ -30,7 +30,7 @@ def set(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = organization_handler.OrganizationHandler(terminal_handler=simple_display_manager)
+        handler = organization_handler.OrganizationHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Setting organization..."):
             handler.set_organization(organization)
@@ -51,7 +51,7 @@ def unset(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = organization_handler.OrganizationHandler(terminal_handler=simple_display_manager)
+        handler = organization_handler.OrganizationHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Removing organization..."):
             handler.unset_organization()
@@ -72,7 +72,7 @@ def get(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = organization_handler.OrganizationHandler(terminal_handler=simple_display_manager)
+        handler = organization_handler.OrganizationHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Fetching organization..."):
             organization = handler.get_organization()

--- a/libs/jupyter-deploy/jupyter_deploy/cli/progress_display.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/progress_display.py
@@ -1,7 +1,7 @@
 """Progress display manager for CLI commands using Rich.
 
 This module provides the ProgressDisplayManager class that implements
-the TerminalHandler protocol for Rich-based terminal display.
+the DisplayManager protocol for Rich-based terminal display.
 """
 
 from collections.abc import Iterator
@@ -20,7 +20,7 @@ from jupyter_deploy.engine.supervised_execution import ExecutionProgress, Intera
 class ProgressDisplayManager:
     """Rich-based terminal display manager for supervised execution.
 
-    Implements the TerminalHandler protocol to provide:
+    Implements the DisplayManager protocol to provide:
     - Progress bar with spinner and percentage
     - Live log box displaying lines provided by the engine callback
     - Interactive prompt handling (whenever the underlying process prompts):
@@ -269,7 +269,7 @@ class ProgressDisplayManager:
         """Stop the current spinner if one is active.
 
         Not applicable for ProgressDisplayManager (no persistent spinner).
-        This is a no-op to satisfy the TerminalHandler protocol.
+        This is a no-op to satisfy the DisplayManager protocol.
         """
         pass
 
@@ -282,6 +282,17 @@ class ProgressDisplayManager:
             Always returns False
         """
         return False
+
+    def on_log_line(self, line: str) -> None:
+        """Handle subprocess output line.
+
+        Stub implementation - ProgressDisplayManager handles log output via update_log_box()
+        instead of individual line processing. This method is a no-op.
+
+        Args:
+            line: A single line of output (without trailing newline)
+        """
+        pass
 
     def _get_display_panel(self) -> Panel:
         """Create Rich Panel with top messages, progress bar, and log box.

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -31,7 +31,7 @@ def status(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = server_handler.ServerHandler(terminal_handler=simple_display_manager)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Checking server status..."):
             server_status = handler.get_server_status()
@@ -59,7 +59,7 @@ def start(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = server_handler.ServerHandler(terminal_handler=simple_display_manager)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Starting server..."):
             handler.start_server(service)
@@ -90,7 +90,7 @@ def stop(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = server_handler.ServerHandler(terminal_handler=simple_display_manager)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Stopping server..."):
             handler.stop_server(service)
@@ -121,7 +121,7 @@ def restart(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = server_handler.ServerHandler(terminal_handler=simple_display_manager)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Restarting server..."):
             handler.restart_server(service)
@@ -165,7 +165,7 @@ def logs(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = server_handler.ServerHandler(terminal_handler=simple_display_manager)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Fetching logs..."):
             logs, err_logs = handler.get_server_logs(service=service, extra=extra)
@@ -223,7 +223,7 @@ def exec(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = server_handler.ServerHandler(terminal_handler=simple_display_manager)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Executing command..."):
             stdout, stderr, returncode = handler.exec_command(service=service, command_args=command_args)
@@ -274,7 +274,7 @@ def connect(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = server_handler.ServerHandler(terminal_handler=simple_display_manager)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Connecting to service..."):
             handler.connect(service=service)

--- a/libs/jupyter-deploy/jupyter_deploy/cli/simple_display.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/simple_display.py
@@ -1,7 +1,7 @@
 """Simple terminal handler for SDK-style operations.
 
 This module provides the SimpleDisplayManager class that implements
-the TerminalHandler protocol with lightweight display (spinner, info, warnings, success).
+the DisplayManager protocol with lightweight display (spinner, info, warnings, success).
 No progress bars or complex UI elements.
 """
 
@@ -18,7 +18,7 @@ from jupyter_deploy.engine.supervised_execution import ExecutionProgress, Intera
 class SimpleDisplayManager:
     """Lightweight terminal handler for SDK-style operations.
 
-    Implements TerminalHandler protocol with simple display elements:
+    Implements DisplayManager protocol with simple display elements:
     spinner, info messages, warnings, and success messages.
     No progress bars or log boxes.
 
@@ -135,7 +135,7 @@ class SimpleDisplayManager:
         """
         return self._pass_through
 
-    # Stub implementations for TerminalHandler protocol methods we don't use:
+    # Stub implementations for DisplayManager protocol methods we don't use:
 
     def on_progress(self, progress: ExecutionProgress) -> None:
         """Stub implementation (not used for SDK-style operations).
@@ -173,3 +173,14 @@ class SimpleDisplayManager:
         """
         for line in lines:
             self.console.print(line, style="red")
+
+    def on_log_line(self, line: str) -> None:
+        """Handle subprocess output line.
+
+        Prints line if in pass-through mode (verbose), otherwise ignores.
+
+        Args:
+            line: A single line of output (without trailing newline)
+        """
+        if self._pass_through:
+            print(line, flush=True)

--- a/libs/jupyter-deploy/jupyter_deploy/cli/teams_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/teams_app.py
@@ -30,7 +30,7 @@ def add(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = team_handler.TeamsHandler(terminal_handler=simple_display_manager)
+        handler = team_handler.TeamsHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Adding teams..."):
             handler.add_teams(teams)
@@ -52,7 +52,7 @@ def remove(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = team_handler.TeamsHandler(terminal_handler=simple_display_manager)
+        handler = team_handler.TeamsHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Removing teams..."):
             handler.remove_teams(teams)
@@ -74,7 +74,7 @@ def set(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = team_handler.TeamsHandler(terminal_handler=simple_display_manager)
+        handler = team_handler.TeamsHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Setting teams..."):
             handler.set_teams(teams)
@@ -96,7 +96,7 @@ def list_teams(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = team_handler.TeamsHandler(terminal_handler=simple_display_manager)
+        handler = team_handler.TeamsHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Fetching teams..."):
             teams = handler.list_teams()

--- a/libs/jupyter-deploy/jupyter_deploy/cli/users_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/users_app.py
@@ -30,7 +30,7 @@ def add(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = user_handler.UsersHandler(terminal_handler=simple_display_manager)
+        handler = user_handler.UsersHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Adding users..."):
             handler.add_users(users)
@@ -52,7 +52,7 @@ def remove(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = user_handler.UsersHandler(terminal_handler=simple_display_manager)
+        handler = user_handler.UsersHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Removing users..."):
             handler.remove_users(users)
@@ -74,7 +74,7 @@ def set(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = user_handler.UsersHandler(terminal_handler=simple_display_manager)
+        handler = user_handler.UsersHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Setting users..."):
             handler.set_users(users)
@@ -96,7 +96,7 @@ def list_users(
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         simple_display_manager = SimpleDisplayManager(console=console)
-        handler = user_handler.UsersHandler(terminal_handler=simple_display_manager)
+        handler = user_handler.UsersHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Fetching users..."):
             users = handler.list_users()

--- a/libs/jupyter-deploy/jupyter_deploy/engine/engine_variables.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/engine_variables.py
@@ -5,7 +5,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from jupyter_deploy import constants, fs_utils
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
 from jupyter_deploy.exceptions import InvalidVariablesDotYamlError
 from jupyter_deploy.handlers import base_project_handler
@@ -23,18 +23,18 @@ class EngineVariablesHandler(ABC):
         self,
         project_path: Path,
         project_manifest: JupyterDeployManifest,
-        terminal_handler: TerminalHandler | None = None,
+        display_manager: DisplayManager,
     ) -> None:
         """Instantiate the base handler for the decorator.
 
         Args:
             project_path: Path to the project directory
             project_manifest: The project manifest
-            terminal_handler: Optional terminal handler for status updates
+            display_manager: Display manager for status updates
         """
         self.project_path = project_path
         self.project_manifest = project_manifest
-        self.terminal_handler = terminal_handler
+        self.display_manager = display_manager
         self._variables_config: JupyterDeployVariablesConfig | None = None
 
     def get_variables_config_path(self) -> Path:
@@ -67,8 +67,8 @@ class EngineVariablesHandler(ABC):
             return variables_config
         except FileNotFoundError:
             # the user has deleted their variables.yaml, reset it to a fallback
-            if self.terminal_handler:
-                self.terminal_handler.warning(
+            if self.display_manager:
+                self.display_manager.warning(
                     f"Variables config not found at: {variables_config_path.absolute()}, resetting to defaults"
                 )
             reset_variables_config = self._get_reset_variables_config()
@@ -76,15 +76,15 @@ class EngineVariablesHandler(ABC):
             return self._variables_config
         except InvalidVariablesDotYamlError:
             # the user has corrupted their variables.yaml, reset to a fallback
-            if self.terminal_handler:
-                self.terminal_handler.warning("Variables config was not a dict, resetting to defaults")
+            if self.display_manager:
+                self.display_manager.warning("Variables config was not a dict, resetting to defaults")
             reset_variables_config = self._get_reset_variables_config()
             self._variables_config = reset_variables_config
             return self._variables_config
         except ValidationError as e:
             # the user has corrupted their variables.yaml, reset to a fallback
-            if self.terminal_handler:
-                self.terminal_handler.warning(f"Variables config is invalid, resetting to defaults: {e}")
+            if self.display_manager:
+                self.display_manager.warning(f"Variables config is invalid, resetting to defaults: {e}")
             reset_variables_config = self._get_reset_variables_config()
             self._variables_config = reset_variables_config
             return self._variables_config

--- a/libs/jupyter-deploy/jupyter_deploy/engine/supervised_execution.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/supervised_execution.py
@@ -1,5 +1,6 @@
 """Core types and protocols for supervised execution with progress tracking."""
 
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
@@ -109,10 +110,11 @@ class ExecutionCallback(Protocol):
         ...
 
 
-class TerminalHandler(Protocol):
-    """Protocol for terminal interaction during supervised execution.
+class DisplayManager(Protocol):
+    """Protocol for display management during supervised execution.
 
-    This unified protocol handles all terminal display concerns:
+    This unified protocol handles all display concerns across different interfaces
+    (terminal, web UI, API, etc.):
     - Progress updates with progress bars (for process-wrapping commands)
     - Live log boxes (for process output)
     - Interactive prompts (for user input)
@@ -240,3 +242,74 @@ class TerminalHandler(Protocol):
         without buffering or progress display (verbose mode behavior).
         """
         ...
+
+    def on_log_line(self, line: str) -> None:
+        """Handle a subprocess output line.
+
+        Called for each line of subprocess output in verbose/pass-through mode.
+        In pass-through mode, prints directly; otherwise may be buffered or ignored.
+
+        Args:
+            line: A single line of output (without trailing newline)
+        """
+        ...
+
+
+class NullDisplay:
+    """No-op display manager for programmatic/test usage.
+
+    Implements DisplayManager protocol with all methods as no-ops.
+    Use when you don't want any display output (e.g., in tests, programmatic API usage).
+    """
+
+    def on_progress(self, progress: ExecutionProgress) -> None:
+        """No-op implementation."""
+        pass
+
+    def update_log_box(self, lines: list[str]) -> None:
+        """No-op implementation."""
+        pass
+
+    def on_interaction_start(self, context: InteractionContext) -> None:
+        """No-op implementation."""
+        pass
+
+    def on_interaction_end(self) -> None:
+        """No-op implementation."""
+        pass
+
+    def display_error_context(self, lines: list[str]) -> None:
+        """No-op implementation."""
+        pass
+
+    def info(self, message: str) -> None:
+        """No-op implementation."""
+        pass
+
+    def warning(self, message: str) -> None:
+        """No-op implementation."""
+        pass
+
+    def success(self, message: str) -> None:
+        """No-op implementation."""
+        pass
+
+    def hint(self, message: str) -> None:
+        """No-op implementation."""
+        pass
+
+    def spinner(self, initial_message: str) -> Any:
+        """No-op spinner - returns nullcontext."""
+        return nullcontext()
+
+    def stop_spinning(self) -> None:
+        """No-op implementation."""
+        pass
+
+    def is_pass_through(self) -> bool:
+        """Always returns False."""
+        return False
+
+    def on_log_line(self, line: str) -> None:
+        """No-op implementation."""
+        pass

--- a/libs/jupyter-deploy/jupyter_deploy/engine/supervised_execution_callback.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/supervised_execution_callback.py
@@ -2,7 +2,7 @@
 
 This module provides the base class for implementing engine-specific
 callbacks that handle output buffering, prompt detection, and context
-extraction while delegating display to a TerminalHandler.
+extraction while delegating display to a DisplayManager.
 """
 
 from abc import ABC, abstractmethod
@@ -10,9 +10,9 @@ from collections import deque
 
 from jupyter_deploy.engine.supervised_execution import (
     CompletionContext,
+    DisplayManager,
     ExecutionProgress,
     InteractionContext,
-    TerminalHandler,
 )
 
 
@@ -120,7 +120,7 @@ class EngineExecutionCallback(ExecutionCallbackInterface):
 
     def __init__(
         self,
-        terminal_handler: TerminalHandler,
+        display_manager: DisplayManager,
         buffer_size: int = 200,
         log_display_lines: int = 2,
         error_display_lines: int = 50,
@@ -128,7 +128,7 @@ class EngineExecutionCallback(ExecutionCallbackInterface):
         """Initialize the engine callback.
 
         Args:
-            terminal_handler: Handler for terminal display (progress, logs, prompts)
+            display_manager: Handler for terminal display (progress, logs, prompts)
             buffer_size: Number of output lines to keep in buffer for context extraction
             log_display_lines: Number of lines to display in log box during normal operation
             error_display_lines: Number of lines to display when execution fails
@@ -141,7 +141,7 @@ class EngineExecutionCallback(ExecutionCallbackInterface):
         if buffer_size < error_display_lines:
             raise ValueError(f"buffer_size ({buffer_size}) must be >= error_display_lines ({error_display_lines})")
 
-        self._terminal_handler = terminal_handler
+        self._display_manager = display_manager
         self._line_buffer: deque[str] = deque(maxlen=buffer_size)  # For context extraction
         self._display_buffer: deque[str] = deque(maxlen=log_display_lines)  # For display
         self._error_display_lines = error_display_lines
@@ -190,16 +190,16 @@ class EngineExecutionCallback(ExecutionCallbackInterface):
             # This line triggered the interaction - extract context and notify
             context = self._extract_interaction_context(line)
             self._waiting_for_interaction = True
-            self._terminal_handler.on_interaction_start(context)
+            self._display_manager.on_interaction_start(context)
             # Don't check for completion on the same line that started interaction
         else:
             # We're in interaction mode - check if interaction is complete
             if self._is_interaction_complete(line):
                 self._waiting_for_interaction = False
-                self._terminal_handler.on_interaction_end()
+                self._display_manager.on_interaction_end()
 
                 # Update log box back to normal size using display buffer
-                self._terminal_handler.update_log_box(list(self._display_buffer))
+                self._display_manager.update_log_box(list(self._display_buffer))
 
     def on_log_line(self, line: str) -> None:
         """Handle a normal log line (not part of interaction).
@@ -214,14 +214,14 @@ class EngineExecutionCallback(ExecutionCallbackInterface):
         self._display_buffer.append(line)  # For normal display (e.g. 2 lines)
 
         # Update log box with display buffer
-        self._terminal_handler.update_log_box(list(self._display_buffer))
+        self._display_manager.update_log_box(list(self._display_buffer))
 
     def on_progress(self, progress: ExecutionProgress) -> None:
         """Handle a progress update.
 
         Delegates directly to terminal handler.
         """
-        self._terminal_handler.on_progress(progress)
+        self._display_manager.on_progress(progress)
 
     def on_execution_error(self, retcode: int) -> None:
         """Handle command execution failure.
@@ -233,7 +233,7 @@ class EngineExecutionCallback(ExecutionCallbackInterface):
         """
         # Extract error context from buffer using configured line count
         error_context_lines = list(self._line_buffer)[-self._error_display_lines :]
-        self._terminal_handler.display_error_context(error_context_lines)
+        self._display_manager.display_error_context(error_context_lines)
 
     def get_completion_context(self) -> CompletionContext | None:
         """Return CompletionContext with lines to display, or None if no context captured.
@@ -293,11 +293,17 @@ class EngineExecutionCallback(ExecutionCallbackInterface):
 class NoopExecutionCallback(ExecutionCallbackInterface, ABC):
     """Abstract base class for no-op execution callbacks in verbose mode.
 
-    This callback provides default no-op implementations for most methods, but requires
-    subclasses to implement engine-specific prompt detection for stdin coordination.
-    Used when terminal_handler is None (verbose mode).
-    SupervisedExecutor will still print to stdout and write to log file.
+    This callback delegates output to a DisplayManager for testability and consistency.
+    Requires subclasses to implement engine-specific prompt detection for stdin coordination.
     """
+
+    def __init__(self, display_manager: DisplayManager) -> None:
+        """Initialize with a display manager.
+
+        Args:
+            display_manager: DisplayManager for handling output
+        """
+        self.display_manager = display_manager
 
     def should_parse_progress(self) -> bool:
         """Progress parsing is disabled for NoopExecutionCallback."""
@@ -327,8 +333,8 @@ class NoopExecutionCallback(ExecutionCallbackInterface, ABC):
         pass
 
     def on_log_line(self, line: str) -> None:
-        """Print to stdout for verbose mode."""
-        print(line, flush=True)
+        """Delegate line output to display manager."""
+        self.display_manager.on_log_line(line)
 
     def on_progress(self, progress: ExecutionProgress) -> None:
         """No-op - no progress tracking in verbose mode."""

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 from jupyter_deploy import cmd_utils, fs_utils
 from jupyter_deploy.engine.engine_config import EngineConfigHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import CompletionContext, TerminalHandler
+from jupyter_deploy.engine.supervised_execution import CompletionContext, DisplayManager
 from jupyter_deploy.engine.supervised_execution_callback import ExecutionCallbackInterface
 from jupyter_deploy.engine.terraform import (
     tf_plan,
@@ -52,11 +52,11 @@ class TerraformConfigHandler(EngineConfigHandler):
         project_path: Path,
         project_manifest: JupyterDeployManifest,
         command_history_handler: CommandHistoryHandler,
+        display_manager: DisplayManager,
         output_filename: str | None = None,
-        terminal_handler: TerminalHandler | None = None,
     ) -> None:
         variables_handler = tf_variables.TerraformVariablesHandler(
-            project_path=project_path, project_manifest=project_manifest, terminal_handler=terminal_handler
+            project_path=project_path, project_manifest=project_manifest, display_manager=display_manager
         )
         super().__init__(
             project_path=project_path,
@@ -67,7 +67,7 @@ class TerraformConfigHandler(EngineConfigHandler):
         )
         self.engine_dir_path = project_path / TF_ENGINE_DIR
         self.plan_out_path = self.engine_dir_path / (output_filename or TF_DEFAULT_PLAN_FILENAME)
-        self.terminal_handler = terminal_handler
+        self.display_manager = display_manager
         self._log_file: Path | None = None
 
         # use a different name from parent attribute to not confuse mypy
@@ -115,13 +115,13 @@ class TerraformConfigHandler(EngineConfigHandler):
 
         # Choose callback: full featured with progress tracking, or no-op for verbose mode
         init_callback: ExecutionCallbackInterface
-        if self.terminal_handler:
+        if self.display_manager.is_pass_through():
+            init_callback = TerraformNoopExecutionCallback(display_manager=self.display_manager)
+        else:
             init_callback = TerraformSupervisedExecutionCallback(
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
                 sequence_id=TerraformSequenceId.config_init,
             )
-        else:
-            init_callback = TerraformNoopExecutionCallback()
         init_executor = tf_supervised_executor_factory.create_terraform_executor(
             sequence_id=TerraformSequenceId.config_init,
             exec_dir=self.engine_dir_path,
@@ -167,13 +167,13 @@ class TerraformConfigHandler(EngineConfigHandler):
 
         # 2.5/ call terraform plan with supervised execution
         plan_callback: ExecutionCallbackInterface
-        if self.terminal_handler:
+        if self.display_manager.is_pass_through():
+            plan_callback = TerraformNoopExecutionCallback(display_manager=self.display_manager)
+        else:
             plan_callback = TerraformSupervisedExecutionCallback(
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
                 sequence_id=TerraformSequenceId.config_plan,
             )
-        else:
-            plan_callback = TerraformNoopExecutionCallback()
 
         plan_executor = tf_supervised_executor_factory.create_terraform_executor(
             sequence_id=TerraformSequenceId.config_plan,

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_down.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_down.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError
 
 from jupyter_deploy import cmd_utils, fs_utils
 from jupyter_deploy.engine.engine_down import EngineDownHandler
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.supervised_execution_callback import ExecutionCallbackInterface
 from jupyter_deploy.engine.terraform import tf_outputs, tf_supervised_executor_factory
 from jupyter_deploy.engine.terraform.tf_constants import (
@@ -35,7 +35,7 @@ class TerraformDownHandler(EngineDownHandler):
         project_path: Path,
         project_manifest: JupyterDeployManifest,
         command_history_handler: CommandHistoryHandler,
-        terminal_handler: TerminalHandler,
+        display_manager: DisplayManager,
     ) -> None:
         outputs_handler = tf_outputs.TerraformOutputsHandler(
             project_path=project_path,
@@ -45,7 +45,7 @@ class TerraformDownHandler(EngineDownHandler):
         super().__init__(project_path=project_path, project_manifest=project_manifest, output_handler=outputs_handler)
         self.engine_dir_path = project_path / TF_ENGINE_DIR
         self.command_history_handler = command_history_handler
-        self.terminal_handler = terminal_handler
+        self.display_manager = display_manager
         self._log_file: Path | None = None
 
     def _get_destroy_tfvars_file_path(self) -> Path:
@@ -67,7 +67,7 @@ class TerraformDownHandler(EngineDownHandler):
             if not auto_approve:
                 raise DownAutoApproveRequiredError(persisting_resources)
 
-            self.terminal_handler.info("Running dry-run to detach resources from terraform state...")
+            self.display_manager.info("Running dry-run to detach resources from terraform state...")
 
             dryrun_rm_cmd = TF_RM_FROM_STATE_CMD.copy()
             dryrun_rm_cmd.append("--dry-run")
@@ -75,25 +75,25 @@ class TerraformDownHandler(EngineDownHandler):
             try:
                 cmd_utils.run_cmd_and_capture_output(dryrun_rm_cmd, exec_dir=self.engine_dir_path)
             except CalledProcessError as e:
-                self.terminal_handler.warning("Error performing dry-run of removing resources from Terraform state.")
-                self.terminal_handler.warning(f"Details: {e}")
+                self.display_manager.warning("Error performing dry-run of removing resources from Terraform state.")
+                self.display_manager.warning(f"Details: {e}")
                 return
 
-            self.terminal_handler.success("Dry-run succeeded.")
+            self.display_manager.success("Dry-run succeeded.")
 
             # otherwise, remove the resources from the state using supervised execution
-            self.terminal_handler.info("Removing persisting resources from the Terraform state...")
+            self.display_manager.info("Removing persisting resources from the Terraform state...")
 
             rm_cmd = TF_RM_FROM_STATE_CMD.copy()
             rm_cmd.extend([pr for pr in persisting_resources])
 
             # Choose callback: full featured with progress tracking, or no-op for pass-through mode
             rm_callback: ExecutionCallbackInterface
-            if self.terminal_handler.is_pass_through():
-                rm_callback = TerraformNoopExecutionCallback()
+            if self.display_manager.is_pass_through():
+                rm_callback = TerraformNoopExecutionCallback(self.display_manager)
             else:
                 rm_callback = TerraformSupervisedExecutionCallback(
-                    terminal_handler=self.terminal_handler,
+                    display_manager=self.display_manager,
                     sequence_id=TerraformSequenceId.down_rm_state,
                 )
 
@@ -113,7 +113,7 @@ class TerraformDownHandler(EngineDownHandler):
                     message="Error removing persisting resources from Terraform state.",
                 )
 
-            self.terminal_handler.success("Removed the persisting resources from the Terraform state.")
+            self.display_manager.success("Removed the persisting resources from the Terraform state.")
 
         # second: run terraform destroy with supervised execution
         destroy_cmd = TF_DESTROY_CMD.copy()
@@ -128,11 +128,11 @@ class TerraformDownHandler(EngineDownHandler):
 
         # Choose callback: full featured with progress tracking, or no-op for pass-through mode
         destroy_callback: ExecutionCallbackInterface
-        if self.terminal_handler.is_pass_through():
-            destroy_callback = TerraformNoopExecutionCallback()
+        if self.display_manager.is_pass_through():
+            destroy_callback = TerraformNoopExecutionCallback(self.display_manager)
         else:
             destroy_callback = TerraformSupervisedExecutionCallback(
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
                 sequence_id=TerraformSequenceId.down_destroy,
             )
 

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_supervised_execution_callback.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_supervised_execution_callback.py
@@ -2,7 +2,7 @@
 
 import re
 
-from jupyter_deploy.engine.supervised_execution import CompletionContext, InteractionContext, TerminalHandler
+from jupyter_deploy.engine.supervised_execution import CompletionContext, DisplayManager, InteractionContext
 from jupyter_deploy.engine.supervised_execution_callback import EngineExecutionCallback, NoopExecutionCallback
 from jupyter_deploy.engine.terraform.tf_enums import TerraformSequenceId
 
@@ -21,14 +21,14 @@ class TerraformSupervisedExecutionCallback(EngineExecutionCallback):
     - Extracts plan summaries for UP/DOWN commands
     """
 
-    def __init__(self, terminal_handler: TerminalHandler, sequence_id: TerraformSequenceId):
+    def __init__(self, display_manager: DisplayManager, sequence_id: TerraformSequenceId):
         """Initialize the terraform callback.
 
         Args:
-            terminal_handler: Handler for terminal display
+            display_manager: Handler for terminal display
             sequence_id: The terraform command sequence being executed (CONFIG_INIT, UP_APPLY, etc.)
         """
-        super().__init__(terminal_handler)
+        super().__init__(display_manager)
         self.sequence_id = sequence_id
 
     def _detect_interaction(self, line: str) -> bool:
@@ -195,7 +195,7 @@ class TerraformSupervisedExecutionCallback(EngineExecutionCallback):
                 # Found error line - extract from here to end (max 50 lines)
                 end_index = min(i + 50, len(buffer_list))
                 error_context = buffer_list[i:end_index]
-                self._terminal_handler.display_error_context(error_context)
+                self._display_manager.display_error_context(error_context)
                 return
 
         # Fallback: no "Error: " found, use default behavior
@@ -206,8 +206,15 @@ class TerraformNoopExecutionCallback(NoopExecutionCallback):
     """No-op execution callback with terraform-specific prompt detection for verbose mode.
 
     Extends NoopExecutionCallback to add terraform prompt detection for stdin coordination.
-    Used when terminal_handler is None (verbose mode) but we still need prompts to work.
     """
+
+    def __init__(self, display_manager: DisplayManager) -> None:
+        """Initialize with a display manager.
+
+        Args:
+            display_manager: DisplayManager for handling output
+        """
+        super().__init__(display_manager)
 
     def is_requesting_user_input(self, line: str) -> bool:
         """Detect terraform prompts for stdin coordination.

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_up.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_up.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from jupyter_deploy.engine.engine_up import EngineUpHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import CompletionContext, TerminalHandler
+from jupyter_deploy.engine.supervised_execution import CompletionContext, DisplayManager
 from jupyter_deploy.engine.supervised_execution_callback import ExecutionCallbackInterface
 from jupyter_deploy.engine.terraform import tf_plan_metadata, tf_supervised_executor_factory
 from jupyter_deploy.engine.terraform.tf_constants import (
@@ -33,13 +33,13 @@ class TerraformUpHandler(EngineUpHandler):
         project_path: Path,
         project_manifest: JupyterDeployManifest,
         command_history_handler: CommandHistoryHandler,
-        terminal_handler: TerminalHandler | None = None,
+        display_manager: DisplayManager,
     ) -> None:
         self.engine_dir_path = project_path / TF_ENGINE_DIR
         super().__init__(project_path=project_path, engine=EngineType.TERRAFORM, engine_dir_path=self.engine_dir_path)
         self.project_manifest = project_manifest
         self.command_history_handler = command_history_handler
-        self.terminal_handler = terminal_handler
+        self.display_manager = display_manager
         self._log_file: Path | None = None
 
     def get_default_config_filename(self) -> str:
@@ -57,13 +57,13 @@ class TerraformUpHandler(EngineUpHandler):
 
         # Choose callback: full featured with progress tracking, or no-op for verbose mode
         apply_callback: ExecutionCallbackInterface
-        if self.terminal_handler:
+        if self.display_manager.is_pass_through():
+            apply_callback = TerraformNoopExecutionCallback(display_manager=self.display_manager)
+        else:
             apply_callback = TerraformSupervisedExecutionCallback(
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
                 sequence_id=TerraformSequenceId.up_apply,
             )
-        else:
-            apply_callback = TerraformNoopExecutionCallback()
 
         # Load plan metadata for dynamic progress tracking
         metadata_path = self.engine_dir_path / TF_PLAN_METADATA_FILENAME

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_variables.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_variables.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from jupyter_deploy import fs_utils
 from jupyter_deploy.engine.engine_variables import EngineVariablesHandler
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_varfiles
 from jupyter_deploy.engine.terraform.tf_constants import (
     TF_CUSTOM_PRESET_FILENAME,
@@ -25,11 +25,9 @@ class TerraformVariablesHandler(EngineVariablesHandler):
         self,
         project_path: Path,
         project_manifest: JupyterDeployManifest,
-        terminal_handler: TerminalHandler | None = None,
+        display_manager: DisplayManager,
     ) -> None:
-        super().__init__(
-            project_path=project_path, project_manifest=project_manifest, terminal_handler=terminal_handler
-        )
+        super().__init__(project_path=project_path, project_manifest=project_manifest, display_manager=display_manager)
         self._template_vars: dict[str, TemplateVariableDefinition] | None = None
         self.engine_dir_path = project_path / TF_ENGINE_DIR
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/access/organization_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/access/organization_handler.py
@@ -1,7 +1,7 @@
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.engine_variables import EngineVariablesHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
@@ -14,9 +14,9 @@ class OrganizationHandler(BaseProjectHandler):
     _output_handler: EngineOutputsHandler
     _variable_handler: EngineVariablesHandler
 
-    def __init__(self, terminal_handler: TerminalHandler | None = None) -> None:
+    def __init__(self, display_manager: DisplayManager) -> None:
         """Instantiate the Organization handler."""
-        super().__init__(terminal_handler=terminal_handler)
+        super().__init__(display_manager=display_manager)
 
         if self.engine == EngineType.TERRAFORM:
             self._output_handler = tf_outputs.TerraformOutputsHandler(
@@ -25,7 +25,7 @@ class OrganizationHandler(BaseProjectHandler):
             self._variable_handler = tf_variables.TerraformVariablesHandler(
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
             )
         else:
             raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
@@ -34,7 +34,7 @@ class OrganizationHandler(BaseProjectHandler):
         """Allowlist the organization whose members or teams may access the Jupyter app."""
         command = self.project_manifest.get_command("organization.set")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -52,7 +52,7 @@ class OrganizationHandler(BaseProjectHandler):
         """Remove allowlisting by organization to the Jupyter app."""
         command = self.project_manifest.get_command("organization.unset")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -69,7 +69,7 @@ class OrganizationHandler(BaseProjectHandler):
         """Return the organization allowlisted to access the Jupyter app."""
         command = self.project_manifest.get_command("organization.get")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/access/team_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/access/team_handler.py
@@ -1,7 +1,7 @@
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.engine_variables import EngineVariablesHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
@@ -14,9 +14,9 @@ class TeamsHandler(BaseProjectHandler):
     _output_handler: EngineOutputsHandler
     _variable_handler: EngineVariablesHandler
 
-    def __init__(self, terminal_handler: TerminalHandler | None = None) -> None:
+    def __init__(self, display_manager: DisplayManager) -> None:
         """Instantiate the TeamsHandler."""
-        super().__init__(terminal_handler=terminal_handler)
+        super().__init__(display_manager=display_manager)
 
         if self.engine == EngineType.TERRAFORM:
             self._output_handler = tf_outputs.TerraformOutputsHandler(
@@ -25,7 +25,7 @@ class TeamsHandler(BaseProjectHandler):
             self._variable_handler = tf_variables.TerraformVariablesHandler(
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
             )
         else:
             raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
@@ -34,7 +34,7 @@ class TeamsHandler(BaseProjectHandler):
         """Allowlist the teams to access the Jupyter app."""
         command = self.project_manifest.get_command("teams.add")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -55,7 +55,7 @@ class TeamsHandler(BaseProjectHandler):
         """Remove the teams from the allowlist of the Jupyter app."""
         command = self.project_manifest.get_command("teams.remove")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -76,7 +76,7 @@ class TeamsHandler(BaseProjectHandler):
         """Replace the list of teams allowlisted to the Jupyter app."""
         command = self.project_manifest.get_command("teams.set")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -98,7 +98,7 @@ class TeamsHandler(BaseProjectHandler):
         command = self.project_manifest.get_command("teams.list")
 
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/access/user_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/access/user_handler.py
@@ -1,7 +1,7 @@
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.engine_variables import EngineVariablesHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
@@ -14,9 +14,9 @@ class UsersHandler(BaseProjectHandler):
     _output_handler: EngineOutputsHandler
     _variable_handler: EngineVariablesHandler
 
-    def __init__(self, terminal_handler: TerminalHandler | None = None) -> None:
+    def __init__(self, display_manager: DisplayManager) -> None:
         """Instantiate the Users handler."""
-        super().__init__(terminal_handler=terminal_handler)
+        super().__init__(display_manager=display_manager)
 
         if self.engine == EngineType.TERRAFORM:
             self._output_handler = tf_outputs.TerraformOutputsHandler(
@@ -25,7 +25,7 @@ class UsersHandler(BaseProjectHandler):
             self._variable_handler = tf_variables.TerraformVariablesHandler(
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
             )
         else:
             raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
@@ -34,7 +34,7 @@ class UsersHandler(BaseProjectHandler):
         """Allowlist the users to access the Jupyter app."""
         command = self.project_manifest.get_command("users.add")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -55,7 +55,7 @@ class UsersHandler(BaseProjectHandler):
         """Remove the users from the allowlist of the Jupyter app."""
         command = self.project_manifest.get_command("users.remove")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -76,7 +76,7 @@ class UsersHandler(BaseProjectHandler):
         """Replace the list of users allowlisted to access the Jupyter app."""
         command = self.project_manifest.get_command("users.set")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -97,7 +97,7 @@ class UsersHandler(BaseProjectHandler):
         """Return a list of users allowlisted to access the Jupyter app."""
         command = self.project_manifest.get_command("users.list")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/base_project_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/base_project_handler.py
@@ -6,7 +6,7 @@ from yaml.parser import ParserError
 from yaml.scanner import ScannerError
 
 from jupyter_deploy import constants, fs_utils, manifest, variables_config
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.exceptions import (
     InvalidManifestError,
     InvalidVariablesDotYamlError,
@@ -24,18 +24,18 @@ class BaseProjectHandler:
     otherwise this class will raise a typer.Exit().
     """
 
-    def __init__(self, terminal_handler: TerminalHandler | None = None) -> None:
+    def __init__(self, display_manager: DisplayManager) -> None:
         """Attempts to identify the engine associated with the project.
 
         Args:
-            terminal_handler: Optional terminal handler for status updates
+            display_manager: Display manager for status updates
 
         Raises:
             ManifestNotFoundError: If project manifest not found
             ReadManifestError: If manifest cannot be read due to I/O error
             InvalidManifestError: If manifest cannot be parsed or validated
         """
-        self.terminal_handler = terminal_handler
+        self.display_manager = display_manager
         self.project_path = Path.cwd()
         self.command_history_handler = CommandHistoryHandler(self.project_path)
         manifest_path = self.project_path / constants.MANIFEST_FILENAME

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/config_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/config_handler.py
@@ -1,7 +1,7 @@
 from jupyter_deploy import verify_utils
 from jupyter_deploy.engine.engine_config import EngineConfigHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import CompletionContext, TerminalHandler
+from jupyter_deploy.engine.supervised_execution import CompletionContext, DisplayManager
 from jupyter_deploy.engine.terraform import tf_config
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
 from jupyter_deploy.exceptions import InvalidPresetError
@@ -11,9 +11,9 @@ from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 class ConfigHandler(BaseProjectHandler):
     _handler: EngineConfigHandler
 
-    def __init__(self, output_filename: str | None = None, terminal_handler: TerminalHandler | None = None) -> None:
+    def __init__(self, display_manager: DisplayManager, output_filename: str | None = None) -> None:
         """Base class to manage the configuration of a jupyter-deploy project."""
-        super().__init__(terminal_handler=terminal_handler)
+        super().__init__(display_manager=display_manager)
         self.preset_name: str | None = None
 
         if self.engine == EngineType.TERRAFORM:
@@ -22,7 +22,7 @@ class ConfigHandler(BaseProjectHandler):
                 project_manifest=self.project_manifest,
                 command_history_handler=self.command_history_handler,
                 output_filename=output_filename,
-                terminal_handler=terminal_handler,
+                display_manager=display_manager,
             )
         else:
             raise NotImplementedError(f"ConfigHandler implementation not found for engine: {self.engine}")

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/down_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/down_handler.py
@@ -1,6 +1,6 @@
 from jupyter_deploy.engine.engine_down import EngineDownHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_down
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 
@@ -8,16 +8,16 @@ from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 class DownHandler(BaseProjectHandler):
     _handler: EngineDownHandler
 
-    def __init__(self, terminal_handler: TerminalHandler) -> None:
+    def __init__(self, display_manager: DisplayManager) -> None:
         """Base class to manage the down command of a jupyter-deploy project."""
-        super().__init__(terminal_handler=terminal_handler)
+        super().__init__(display_manager=display_manager)
 
         if self.engine == EngineType.TERRAFORM:
             self._handler = tf_down.TerraformDownHandler(
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
                 command_history_handler=self.command_history_handler,
-                terminal_handler=terminal_handler,
+                display_manager=display_manager,
             )
         else:
             raise NotImplementedError(f"DownHandler implementation not found for engine: {self.engine}")

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/open_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/open_handler.py
@@ -2,6 +2,7 @@ import webbrowser
 
 from jupyter_deploy.engine.engine_open import EngineOpenHandler
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.terraform import tf_open
 from jupyter_deploy.exceptions import OpenWebBrowserError, UrlNotSecureError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
@@ -12,7 +13,7 @@ class OpenHandler(BaseProjectHandler):
 
     def __init__(self) -> None:
         """Base class to manage the open command of a jupyter-deploy project."""
-        super().__init__(terminal_handler=None)
+        super().__init__(display_manager=NullDisplay())
 
         if self.engine == EngineType.TERRAFORM:
             self._handler = tf_open.TerraformOpenHandler(

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/show_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/show_handler.py
@@ -2,6 +2,7 @@ from jupyter_deploy.engine import outdefs
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.engine_variables import EngineVariablesHandler
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
 from jupyter_deploy.exceptions import OutputNotFoundError, VariableNotFoundError
@@ -16,7 +17,7 @@ class ShowHandler(BaseProjectHandler):
 
     def __init__(self) -> None:
         """Initialize the show handler."""
-        super().__init__(terminal_handler=None)
+        super().__init__(display_manager=NullDisplay())
 
         if self.engine == EngineType.TERRAFORM:
             self._outputs_handler = tf_outputs.TerraformOutputsHandler(
@@ -26,7 +27,7 @@ class ShowHandler(BaseProjectHandler):
             self._variables_handler = tf_variables.TerraformVariablesHandler(
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
             )
         else:
             raise NotImplementedError(f"ShowHandler implementation not found for engine: {self.engine}")

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/up_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/up_handler.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from jupyter_deploy.engine.engine_up import EngineUpHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import CompletionContext, TerminalHandler
+from jupyter_deploy.engine.supervised_execution import CompletionContext, DisplayManager
 from jupyter_deploy.engine.terraform import tf_up
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 
@@ -10,16 +10,16 @@ from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 class UpHandler(BaseProjectHandler):
     _handler: EngineUpHandler
 
-    def __init__(self, terminal_handler: TerminalHandler | None = None) -> None:
+    def __init__(self, display_manager: DisplayManager) -> None:
         """Base class to manage the up command of a jupyter-deploy project."""
-        super().__init__(terminal_handler=terminal_handler)
+        super().__init__(display_manager=display_manager)
 
         if self.engine == EngineType.TERRAFORM:
             self._handler = tf_up.TerraformUpHandler(
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
                 command_history_handler=self.command_history_handler,
-                terminal_handler=terminal_handler,
+                display_manager=display_manager,
             )
         else:
             raise NotImplementedError(f"UpHandler implementation not found for engine: {self.engine}")

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/variables_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/variables_handler.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from jupyter_deploy.engine.engine_variables import EngineVariablesHandler
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.terraform import tf_variables
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
 from jupyter_deploy.manifest import JupyterDeployManifest
@@ -18,7 +19,7 @@ class VariablesHandler:
 
         if engine == EngineType.TERRAFORM:
             self._handler = tf_variables.TerraformVariablesHandler(
-                project_path=project_path, project_manifest=project_manifest
+                project_path=project_path, project_manifest=project_manifest, display_manager=NullDisplay()
             )
         else:
             raise NotImplementedError(f"VariablesHandler implementation not found for engine: {engine}")

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
@@ -1,6 +1,6 @@
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
@@ -12,9 +12,9 @@ class HostHandler(BaseProjectHandler):
 
     _output_handler: EngineOutputsHandler
 
-    def __init__(self, terminal_handler: TerminalHandler | None = None) -> None:
+    def __init__(self, display_manager: DisplayManager) -> None:
         """Instantiate the Host handler."""
-        super().__init__(terminal_handler=terminal_handler)
+        super().__init__(display_manager=display_manager)
 
         if self.engine == EngineType.TERRAFORM:
             self._output_handler = tf_outputs.TerraformOutputsHandler(
@@ -23,7 +23,7 @@ class HostHandler(BaseProjectHandler):
             self._variable_handler = tf_variables.TerraformVariablesHandler(
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
             )
         else:
             raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
@@ -32,7 +32,7 @@ class HostHandler(BaseProjectHandler):
         """Returns the status of the host machine."""
         command = self.project_manifest.get_command("host.status")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -43,7 +43,7 @@ class HostHandler(BaseProjectHandler):
         """Stop the host machine."""
         command = self.project_manifest.get_command("host.stop")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -53,7 +53,7 @@ class HostHandler(BaseProjectHandler):
         """Start the host machine."""
         command = self.project_manifest.get_command("host.start")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -66,7 +66,7 @@ class HostHandler(BaseProjectHandler):
         """Restart the host machine."""
         command = self.project_manifest.get_command("host.restart")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -79,7 +79,7 @@ class HostHandler(BaseProjectHandler):
         """Start an SSH-style connection to the host."""
         command = self.project_manifest.get_command("host.connect")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -92,7 +92,7 @@ class HostHandler(BaseProjectHandler):
         """Execute a command on the host, return the stdout, stderr, and exit code."""
         command = self.project_manifest.get_command("host.exec")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
@@ -1,6 +1,6 @@
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
@@ -12,9 +12,9 @@ class ServerHandler(BaseProjectHandler):
 
     _output_handler: EngineOutputsHandler
 
-    def __init__(self, terminal_handler: TerminalHandler | None = None) -> None:
+    def __init__(self, display_manager: DisplayManager) -> None:
         """Instantiate the Users handler."""
-        super().__init__(terminal_handler=terminal_handler)
+        super().__init__(display_manager=display_manager)
 
         if self.engine == EngineType.TERRAFORM:
             self._output_handler = tf_outputs.TerraformOutputsHandler(
@@ -23,7 +23,7 @@ class ServerHandler(BaseProjectHandler):
             self._variable_handler = tf_variables.TerraformVariablesHandler(
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
-                terminal_handler=self.terminal_handler,
+                display_manager=self.display_manager,
             )
         else:
             raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
@@ -32,7 +32,7 @@ class ServerHandler(BaseProjectHandler):
         """Sends an health check to the jupyter server app, return status."""
         command = self.project_manifest.get_command("server.status")
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -44,7 +44,7 @@ class ServerHandler(BaseProjectHandler):
         command = self.project_manifest.get_command("server.start")
         validated_service = self.project_manifest.get_validated_service(service, allow_all=True)
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -61,7 +61,7 @@ class ServerHandler(BaseProjectHandler):
         command = self.project_manifest.get_command("server.stop")
         validated_service = self.project_manifest.get_validated_service(service, allow_all=True)
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -78,7 +78,7 @@ class ServerHandler(BaseProjectHandler):
         command = self.project_manifest.get_command("server.restart")
         validated_service = self.project_manifest.get_validated_service(service, allow_all=True)
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -95,7 +95,7 @@ class ServerHandler(BaseProjectHandler):
         command = self.project_manifest.get_command("server.logs")
         validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -116,7 +116,7 @@ class ServerHandler(BaseProjectHandler):
         command = self.project_manifest.get_command("server.exec")
         validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
@@ -141,7 +141,7 @@ class ServerHandler(BaseProjectHandler):
         command = self.project_manifest.get_command("server.connect")
         validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
         runner = cmd_runner.ManifestCommandRunner(
-            terminal_handler=self.terminal_handler,
+            display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ec2_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ec2_runner.py
@@ -4,7 +4,7 @@ import boto3
 from mypy_boto3_ec2.client import EC2Client
 
 from jupyter_deploy.api.aws.ec2 import ec2_instance
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.exceptions import IncompatibleHostStateError, InstructionNotFoundError
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
 from jupyter_deploy.provider.resolved_argdefs import (
@@ -31,29 +31,27 @@ class AwsEc2Runner(InstructionRunner):
 
     client: EC2Client
 
-    def __init__(self, region_name: str | None) -> None:
+    def __init__(self, display_manager: DisplayManager, region_name: str | None) -> None:
         """Instantiates the EC2 boto3 client."""
+        super().__init__(display_manager)
         self.client: EC2Client = boto3.client("ec2", region_name=region_name)
 
     def _describe_instance_status(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         # retrieve required parameters
         instance_id_arg = require_arg(resolved_arguments, "instance_id", StrResolvedInstructionArgument)
         instance_id = instance_id_arg.value
 
-        if terminal_handler:
-            terminal_handler.info(f"Retrieving status of instance: {instance_id}")
+        self.display_manager.info(f"Retrieving status of instance: {instance_id}")
 
         instance_status = ec2_instance.describe_instance_status(
             self.client,
             instance_id=instance_id,
         )
 
-        if terminal_handler:
-            terminal_handler.info(f"Successfully retrieved status of instance: {instance_id}")
+        self.display_manager.info(f"Successfully retrieved status of instance: {instance_id}")
 
         return {
             "InstanceStateName": StrResolvedInstructionResult(
@@ -65,7 +63,6 @@ class AwsEc2Runner(InstructionRunner):
     def _start_instance(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         # retrieve required parameters
         instance_id_arg = require_arg(resolved_arguments, "instance_id", StrResolvedInstructionArgument)
@@ -106,15 +103,13 @@ class AwsEc2Runner(InstructionRunner):
             instance_id=instance_id_arg.value,
         )
 
-        if terminal_handler:
-            terminal_handler.success(f"Starting instance {instance_id}...")
+        self.display_manager.success(f"Starting instance {instance_id}...")
 
         return {}
 
     def _stop_instance(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         # retrieve required parameters
         instance_id_arg = require_arg(resolved_arguments, "instance_id", StrResolvedInstructionArgument)
@@ -155,15 +150,13 @@ class AwsEc2Runner(InstructionRunner):
             instance_id=instance_id,
         )
 
-        if terminal_handler:
-            terminal_handler.success(f"Instance {instance_id} is stopping...")
+        self.display_manager.success(f"Instance {instance_id} is stopping...")
 
         return {}
 
     def _reboot_instance(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         # retrieve required parameters
         instance_id_arg = require_arg(resolved_arguments, "instance_id", StrResolvedInstructionArgument)
@@ -205,15 +198,13 @@ class AwsEc2Runner(InstructionRunner):
             instance_id=instance_id,
         )
 
-        if terminal_handler:
-            terminal_handler.success(f"Instance {instance_id} is rebooting...")
+        self.display_manager.success(f"Instance {instance_id} is rebooting...")
 
         return {}
 
     def _wait_for_state(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None,
         desired_state: ec2_instance.Ec2InstanceState,
         timeout_seconds: int = 60,
     ) -> dict[str, ResolvedInstructionResult]:
@@ -223,7 +214,7 @@ class AwsEc2Runner(InstructionRunner):
             self.client,
             instance_id=instance_id,
             desired_state=desired_state,
-            terminal_handler=terminal_handler,
+            display_manager=self.display_manager,
             timeout_seconds=timeout_seconds,
         )
         return {
@@ -237,39 +228,32 @@ class AwsEc2Runner(InstructionRunner):
         self,
         instruction_name: str,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         if instruction_name == AwsEc2Instruction.DESCRIBE_INSTANCE_STATUS:
             return self._describe_instance_status(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
             )
         elif instruction_name == AwsEc2Instruction.START_INSTANCE:
             return self._start_instance(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
             )
         elif instruction_name == AwsEc2Instruction.STOP_INSTANCE:
             return self._stop_instance(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
             )
         elif instruction_name == AwsEc2Instruction.REBOOT_INSTANCE:
             return self._reboot_instance(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
             )
         elif instruction_name == AwsEc2Instruction.WAIT_FOR_RUNNING:
             return self._wait_for_state(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
                 desired_state=ec2_instance.Ec2InstanceState.RUNNING,
                 timeout_seconds=60,  # EC2:StartInstances is generally fast
             )
         elif instruction_name == AwsEc2Instruction.WAIT_FOR_STOPPED:
             return self._wait_for_state(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
                 desired_state=ec2_instance.Ec2InstanceState.STOPPED,
                 timeout_seconds=600,  # GPU instances take a while to stop
             )

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_runner.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.exceptions import InstructionNotFoundError
 from jupyter_deploy.provider.aws.aws_ec2_runner import AwsEc2Runner
 from jupyter_deploy.provider.aws.aws_ssm_runner import AwsSsmRunner
@@ -22,8 +22,9 @@ class AwsApiRunner(InstructionRunner):
     Requires the user to install jupyter-deploy[aws].
     """
 
-    def __init__(self, region_name: str | None) -> None:
+    def __init__(self, display_manager: DisplayManager, region_name: str | None) -> None:
         """Instantiate the map of AWS services runner."""
+        super().__init__(display_manager)
         self.region_name = region_name
         self.service_runners: dict[str, InstructionRunner] = {}
 
@@ -47,11 +48,11 @@ class AwsApiRunner(InstructionRunner):
             return service_runner
 
         if service_name == AwsService.SSM:
-            service_runner = AwsSsmRunner(region_name=self.region_name)
+            service_runner = AwsSsmRunner(self.display_manager, region_name=self.region_name)
             self.service_runners[service_name] = service_runner
             return service_runner
         elif service_name == AwsService.EC2:
-            service_runner = AwsEc2Runner(region_name=self.region_name)
+            service_runner = AwsEc2Runner(self.display_manager, region_name=self.region_name)
             self.service_runners[service_name] = service_runner
             return service_runner
 
@@ -61,12 +62,10 @@ class AwsApiRunner(InstructionRunner):
         self,
         instruction_name: str,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         service_name, sub_instruction_name = AwsApiRunner._get_service_and_sub_instruction_name(instruction_name)
         service_runner = self._get_service_runner(service_name)
         return service_runner.execute_instruction(
             instruction_name=sub_instruction_name,
             resolved_arguments=resolved_arguments,
-            terminal_handler=terminal_handler,
         )

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
@@ -5,7 +5,7 @@ from mypy_boto3_ssm.client import SSMClient
 
 from jupyter_deploy import cmd_utils, verify_utils
 from jupyter_deploy.api.aws.ssm import ssm_command, ssm_session
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import JupyterDeployTool
 from jupyter_deploy.exceptions import (
     HostCommandInstructionError,
@@ -46,33 +46,31 @@ class AwsSsmRunner(InstructionRunner):
 
     client: SSMClient
 
-    def __init__(self, region_name: str | None) -> None:
+    def __init__(self, display_manager: DisplayManager, region_name: str | None) -> None:
         """Instantiates the SSM boto3 client."""
+        super().__init__(display_manager)
         self.client: SSMClient = boto3.client("ssm", region_name=region_name)
 
     def _verify_ec2_instance_accessible(
         self,
         instance_id: str,
-        terminal_handler: TerminalHandler | None = None,
         silent_success: bool = True,
     ) -> None:
         """Call SSM API and verify instance is accessible.
 
         Args:
             instance_id: The EC2 instance ID to verify
-            terminal_handler: Optional terminal handler for status updates
             silent_success: If True, don't display success message
 
         Raises:
             UnreachableHostError: If SSM agent is not reachable
         """
-
         instance_info_response = ssm_session.describe_instance_information(self.client, instance_id=instance_id)
         ping_status = instance_info_response.get("PingStatus")
 
         if ping_status == "Online":
-            if terminal_handler and not silent_success:
-                terminal_handler.info(f"SSM agent running on instance '{instance_id}'")
+            if not silent_success:
+                self.display_manager.info(f"SSM agent running on instance '{instance_id}'")
             return
         elif ping_status == "ConnectionLost":
             last_ping_date = instance_info_response.get("LastPingDateTime", "unknown")
@@ -89,7 +87,6 @@ class AwsSsmRunner(InstructionRunner):
     def _send_cmd_to_one_instance_and_wait_sync(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         # retrieve required parameters
         doc_name_arg = require_arg(resolved_arguments, "document_name", StrResolvedInstructionArgument)
@@ -114,15 +111,14 @@ class AwsSsmRunner(InstructionRunner):
                 parameters[n] = [v.value]
 
         # verify SSM agent connection status
-        self._verify_ec2_instance_accessible(instance_id=instance_id_arg.value, terminal_handler=terminal_handler)
+        self._verify_ec2_instance_accessible(instance_id=instance_id_arg.value)
 
         # provide information to the user
-        if terminal_handler:
-            info = f"Executing SSM document '{doc_name_arg.value}' on instance '{instance_id_arg.value}'"
-            if not parameters:
-                terminal_handler.info(f"{info}...")
-            else:
-                terminal_handler.info(f"{info} with parameters: {parameters}...")
+        info = f"Executing SSM document '{doc_name_arg.value}' on instance '{instance_id_arg.value}'"
+        if not parameters:
+            self.display_manager.info(f"{info}...")
+        else:
+            self.display_manager.info(f"{info} with parameters: {parameters}...")
 
         response = ssm_command.send_cmd_to_one_instance_and_wait_sync(
             self.client,
@@ -160,7 +156,6 @@ class AwsSsmRunner(InstructionRunner):
     def _send_cmd_to_one_instance_using_default_shell_doc_and_wait_sync(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         # retrieve required parameters
         instance_id_arg = require_arg(resolved_arguments, "instance_id", StrResolvedInstructionArgument)
@@ -177,11 +172,10 @@ class AwsSsmRunner(InstructionRunner):
         commands_arg = require_arg(resolved_arguments, "commands", ListStrResolvedInstructionArgument)
 
         # verify SSM agent connection status
-        self._verify_ec2_instance_accessible(instance_id=instance_id_arg.value, terminal_handler=terminal_handler)
+        self._verify_ec2_instance_accessible(instance_id=instance_id_arg.value)
 
         # provide information to the user
-        if terminal_handler:
-            terminal_handler.info(f"Executing command on instance '{instance_id_arg.value}'...")
+        self.display_manager.info(f"Executing command on instance '{instance_id_arg.value}'...")
 
         response = ssm_command.send_cmd_to_one_instance_and_wait_sync(
             self.client,
@@ -219,7 +213,6 @@ class AwsSsmRunner(InstructionRunner):
     def _start_session(
         self,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         # retrieve required parameters
         target_id_arg = require_arg(resolved_arguments, "target_id", StrResolvedInstructionArgument)
@@ -238,15 +231,12 @@ class AwsSsmRunner(InstructionRunner):
         )
 
         # verify that the SSM agent status on the instance
-        self._verify_ec2_instance_accessible(
-            instance_id=target_id_arg.value, terminal_handler=terminal_handler, silent_success=False
-        )
+        self._verify_ec2_instance_accessible(instance_id=target_id_arg.value, silent_success=False)
 
         # provide information to the user
-        if terminal_handler:
-            terminal_handler.hint("Type 'exit' to disconnect the SSM session.")
-            # Stop spinner before starting interactive session
-            terminal_handler.stop_spinning()
+        self.display_manager.hint("Type 'exit' to disconnect the SSM session.")
+        # Stop spinner before starting interactive session
+        self.display_manager.stop_spinning()
 
         # start the session
         start_session_cmds = START_SESSION_CMD.copy()
@@ -282,22 +272,18 @@ class AwsSsmRunner(InstructionRunner):
         self,
         instruction_name: str,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
         if instruction_name == AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC:
             return self._send_cmd_to_one_instance_and_wait_sync(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
             )
         elif instruction_name == AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC:
             return self._send_cmd_to_one_instance_using_default_shell_doc_and_wait_sync(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
             )
         elif instruction_name == AwsSsmInstruction.START_SESSION:
             return self._start_session(
                 resolved_arguments=resolved_arguments,
-                terminal_handler=terminal_handler,
             )
 
         raise InstructionNotFoundError(f"No execution implementation for command: aws.ssm.{instruction_name}")

--- a/libs/jupyter-deploy/jupyter_deploy/provider/instruction_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/instruction_runner.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.provider.resolved_argdefs import ResolvedInstructionArgument
 from jupyter_deploy.provider.resolved_resultdefs import ResolvedInstructionResult
 
@@ -12,11 +12,27 @@ class InstructionRunner(ABC):
     runner classes.
     """
 
+    def __init__(self, display_manager: DisplayManager) -> None:
+        """Initialize the instruction runner.
+
+        Args:
+            display_manager: Display manager for status updates
+        """
+        self.display_manager = display_manager
+
     @abstractmethod
     def execute_instruction(
         self,
         instruction_name: str,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
-        terminal_handler: TerminalHandler | None = None,
     ) -> dict[str, ResolvedInstructionResult]:
+        """Execute an instruction.
+
+        Args:
+            instruction_name: Name of the instruction to execute
+            resolved_arguments: Resolved instruction arguments
+
+        Returns:
+            Dictionary of resolved instruction results
+        """
         return {}

--- a/libs/jupyter-deploy/jupyter_deploy/provider/instruction_runner_factory.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/instruction_runner_factory.py
@@ -1,5 +1,6 @@
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.provider.enum import ProviderType
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
 
@@ -13,7 +14,9 @@ class InstructionRunnerFactory:
     _provider_runner_map: dict[ProviderType, InstructionRunner] = {}
 
     @staticmethod
-    def get_provider_instruction_runner(api_name: str, outputs_handler: EngineOutputsHandler) -> InstructionRunner:
+    def get_provider_instruction_runner(
+        api_name: str, outputs_handler: EngineOutputsHandler, display_manager: DisplayManager
+    ) -> InstructionRunner:
         """Return the instruction runner for the cloud provider.
 
         Raises:
@@ -30,7 +33,7 @@ class InstructionRunnerFactory:
             # do NOT move import to top level
             from jupyter_deploy.provider.aws import aws_runner
 
-            provider_runner = aws_runner.AwsApiRunner(region_name=aws_region_def.value)
+            provider_runner = aws_runner.AwsApiRunner(display_manager=display_manager, region_name=aws_region_def.value)
             InstructionRunnerFactory._provider_runner_map[provider] = provider_runner
             return provider_runner
 

--- a/libs/jupyter-deploy/jupyter_deploy/provider/manifest_command_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/manifest_command_runner.py
@@ -3,7 +3,7 @@ from typing import Any, TypeVar, get_origin
 from jupyter_deploy import transform_utils
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.engine_variables import EngineVariablesHandler
-from jupyter_deploy.engine.supervised_execution import TerminalHandler
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import InstructionArgumentSource, ResultSource, UpdateSource
 from jupyter_deploy.exceptions import InvalidInstructionArgumentError, InvalidInstructionResultError
 from jupyter_deploy.manifest import JupyterDeployCommandV1
@@ -25,18 +25,18 @@ class ManifestCommandRunner:
 
     def __init__(
         self,
-        terminal_handler: TerminalHandler | None,
+        display_manager: DisplayManager,
         output_handler: EngineOutputsHandler,
         variable_handler: EngineVariablesHandler,
     ) -> None:
         """Instantiate the command runner.
 
         Args:
-            terminal_handler: Optional terminal handler for status updates
+            display_manager: Display manager for status updates
             output_handler: Handler for template outputs
             variable_handler: Handler for template variables
         """
-        self._terminal_handler = terminal_handler
+        self._display_manager = display_manager
         self._output_handler = output_handler
         self._variable_handler = variable_handler
         self._resolved_resultdefs: dict[str, ResolvedInstructionResult] = {}
@@ -52,7 +52,9 @@ class ManifestCommandRunner:
         # run instructions
         for instruction_idx, instruction in enumerate(cmd_def.sequence):
             api_name = instruction.api_name
-            runner = InstructionRunnerFactory.get_provider_instruction_runner(api_name, self._output_handler)
+            runner = InstructionRunnerFactory.get_provider_instruction_runner(
+                api_name, self._output_handler, self._display_manager
+            )
             output_defs = self._output_handler.get_full_project_outputs()  # cached - okay to call in loop
             resolved_argdefs: dict[str, ResolvedInstructionArgument] = {}
 
@@ -79,7 +81,6 @@ class ManifestCommandRunner:
             instruction_results = runner.execute_instruction(
                 instruction_name=api_name,
                 resolved_arguments=resolved_argdefs,
-                terminal_handler=self._terminal_handler,
             )
             for instruction_result_name, instruction_result_def in instruction_results.items():
                 indexed_result_name = f"[{instruction_idx}].{instruction_result_name}"

--- a/libs/jupyter-deploy/tests/unit/api/aws/ec2/test_ec2_instance.py
+++ b/libs/jupyter-deploy/tests/unit/api/aws/ec2/test_ec2_instance.py
@@ -14,6 +14,7 @@ from jupyter_deploy.api.aws.ec2.ec2_instance import (
     start_instance,
     stop_instance,
 )
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 
 
 class TestEc2InstanceStateEnum(unittest.TestCase):
@@ -211,7 +212,9 @@ class TestPollInstanceStatus(unittest.TestCase):
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "running", "Code": 16}}
 
         # Execute
-        poll_for_instance_status(mock_ec2_client, "i-123", Ec2InstanceState.RUNNING, wait_after_seconds=5)
+        poll_for_instance_status(
+            mock_ec2_client, "i-123", Ec2InstanceState.RUNNING, NullDisplay(), wait_after_seconds=5
+        )
 
         # Verify
         mock_sleep.assert_called_with(5)
@@ -224,7 +227,7 @@ class TestPollInstanceStatus(unittest.TestCase):
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "running", "Code": 16}}
 
         # Execute
-        poll_for_instance_status(mock_ec2_client, "i-123", Ec2InstanceState.RUNNING)
+        poll_for_instance_status(mock_ec2_client, "i-123", Ec2InstanceState.RUNNING, NullDisplay())
 
         # Verify
         mock_sleep.assert_called_once()
@@ -241,7 +244,7 @@ class TestPollInstanceStatus(unittest.TestCase):
         mock_describe_instance_status.return_value = instance_status
 
         # Execute
-        result = poll_for_instance_status(mock_ec2_client, "i-123", Ec2InstanceState.RUNNING)
+        result = poll_for_instance_status(mock_ec2_client, "i-123", Ec2InstanceState.RUNNING, NullDisplay())
 
         # Verify
         self.assertEqual(result, instance_status)
@@ -256,7 +259,7 @@ class TestPollInstanceStatus(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(ValueError) as context:
-            poll_for_instance_status(mock_ec2_client, "i-123", Ec2InstanceState.RUNNING)
+            poll_for_instance_status(mock_ec2_client, "i-123", Ec2InstanceState.RUNNING, NullDisplay())
 
         mock_sleep.assert_called_once()
         self.assertIn("Unexpected terminal state", str(context.exception))
@@ -278,6 +281,7 @@ class TestPollInstanceStatus(unittest.TestCase):
                 mock_ec2_client,
                 "i-123",
                 Ec2InstanceState.RUNNING,
+                NullDisplay(),
                 timeout_seconds=10,  # Less than the time difference (100)
             )
 
@@ -307,6 +311,7 @@ class TestPollInstanceStatus(unittest.TestCase):
             mock_ec2_client,
             "i-123",
             Ec2InstanceState.RUNNING,
+            NullDisplay(),
             timeout_seconds=100,
             poll_interval_seconds=2,
         )

--- a/libs/jupyter-deploy/tests/unit/cli/test_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app.py
@@ -419,10 +419,10 @@ class TestUpCommand(unittest.TestCase):
 
     @patch("jupyter_deploy.cli.app.UpHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
-    def test_up_command_with_verbose_uses_no_terminal_handler(
+    def test_up_command_with_verbose_uses_simple_display_manager(
         self, mock_project_ctx_manager: Mock, mock_up_handler_cls: Mock
     ) -> None:
-        """Test that up with --verbose passes None as terminal_handler."""
+        """Test that up with --verbose uses SimpleDisplayManager in pass-through mode."""
         mock_project_ctx_manager.side_effect = TestUpCommand.mock_project_dir
 
         mock_up_handler_instance, mock_up_fns = self.get_mock_up_handler(config_file_exists=True)
@@ -432,9 +432,9 @@ class TestUpCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["up", "--verbose"])
 
         self.assertEqual(result.exit_code, 0)
-        # terminal_handler should be None when verbose is True
+        # display_manager should be SimpleDisplayManager when verbose is True
         call_kwargs = mock_up_handler_cls.call_args.kwargs
-        self.assertIsNone(call_kwargs["terminal_handler"])
+        self.assertIsInstance(call_kwargs["display_manager"], SimpleDisplayManager)
 
     @patch("jupyter_deploy.cli.app.UpHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -524,7 +524,7 @@ class TestDownCommand(unittest.TestCase):
     def test_down_command_with_verbose_uses_simple_display_manager(
         self, mock_project_ctx_manager: Mock, mock_down_handler_cls: Mock
     ) -> None:
-        """Test that down with --verbose passes SimpleDisplayManager as terminal_handler."""
+        """Test that down with --verbose passes SimpleDisplayManager as display_manager."""
         mock_project_ctx_manager.side_effect = TestDownCommand.mock_project_dir
 
         mock_down_handler_instance, _ = self.get_mock_down_handler()
@@ -534,9 +534,9 @@ class TestDownCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["down", "--verbose"])
 
         self.assertEqual(result.exit_code, 0)
-        # terminal_handler should be SimpleDisplayManager when verbose is True
+        # display_manager should be SimpleDisplayManager when verbose is True
         call_kwargs = mock_down_handler_cls.call_args.kwargs
-        self.assertIsInstance(call_kwargs["terminal_handler"], SimpleDisplayManager)
+        self.assertIsInstance(call_kwargs["display_manager"], SimpleDisplayManager)
 
     @patch("jupyter_deploy.cli.app.DownHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_config.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_config.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, Mock, patch
 from typer.testing import CliRunner
 
 from jupyter_deploy.cli.app import runner as app_runner
+from jupyter_deploy.cli.simple_display import SimpleDisplayManager
 from jupyter_deploy.exceptions import InvalidPresetError, LogCleanupError, SupervisedExecutionError
 from jupyter_deploy.verify_utils import ToolRequiredError
 
@@ -91,8 +92,8 @@ class TestConfigCommand(unittest.TestCase):
 
         # Verify
         self.assertEqual(result.exit_code, 0)
-        # Check that ConfigHandler is called with terminal_handler (ProgressDisplayManager instance)
-        mock_config_handler.assert_called_once_with(output_filename=None, terminal_handler=ANY)
+        # Check that ConfigHandler is called with display_manager (ProgressDisplayManager instance)
+        mock_config_handler.assert_called_once_with(output_filename=None, display_manager=ANY)
         mock_config_fns["has_recorded_variables"].assert_called_once()
         mock_config_fns["validate_preset"].assert_called_once_with("all")
         mock_config_fns["set_preset"].assert_called_once_with("all")
@@ -100,7 +101,7 @@ class TestConfigCommand(unittest.TestCase):
 
     @patch("jupyter_deploy.handlers.project.config_handler.ConfigHandler")
     def test_config_default_uses_progress_display(self, mock_config_handler: Mock) -> None:
-        """Test that config command by default creates ProgressDisplayManager for terminal_handler."""
+        """Test that config command by default creates ProgressDisplayManager for display_manager."""
         mock_config_handler_instance, _ = self.get_mock_config_handler()
         mock_config_handler.return_value = mock_config_handler_instance
 
@@ -110,13 +111,13 @@ class TestConfigCommand(unittest.TestCase):
 
         # Verify
         self.assertEqual(result.exit_code, 0)
-        # terminal_handler should be a ProgressDisplayManager instance (not None)
+        # display_manager should be a ProgressDisplayManager instance (not None)
         call_kwargs = mock_config_handler.call_args.kwargs
-        self.assertIsNotNone(call_kwargs["terminal_handler"])
+        self.assertIsNotNone(call_kwargs["display_manager"])
 
     @patch("jupyter_deploy.handlers.project.config_handler.ConfigHandler")
-    def test_config_with_verbose_uses_no_terminal_handler(self, mock_config_handler: Mock) -> None:
-        """Test that config with --verbose passes None as terminal_handler."""
+    def test_config_with_verbose_uses_simple_display_manager(self, mock_config_handler: Mock) -> None:
+        """Test that config with --verbose uses SimpleDisplayManager in pass-through mode."""
         mock_config_handler_instance, _ = self.get_mock_config_handler()
         mock_config_handler.return_value = mock_config_handler_instance
 
@@ -126,8 +127,11 @@ class TestConfigCommand(unittest.TestCase):
 
         # Verify
         self.assertEqual(result.exit_code, 0)
-        # terminal_handler should be None when verbose is True
-        mock_config_handler.assert_called_once_with(output_filename=None, terminal_handler=None)
+        # display_manager should be SimpleDisplayManager when verbose is True
+        mock_config_handler.assert_called_once()
+        call_kwargs = mock_config_handler.call_args.kwargs
+        self.assertEqual(call_kwargs["output_filename"], None)
+        self.assertIsInstance(call_kwargs["display_manager"], SimpleDisplayManager)
 
     @patch("jupyter_deploy.handlers.project.config_handler.ConfigHandler")
     def test_config_passes_no_preset_when_user_passes_none(self, mock_config_handler: Mock) -> None:
@@ -140,7 +144,7 @@ class TestConfigCommand(unittest.TestCase):
 
         # Verify
         self.assertEqual(result.exit_code, 0)
-        mock_config_handler.assert_called_once_with(output_filename=None, terminal_handler=ANY)
+        mock_config_handler.assert_called_once_with(output_filename=None, display_manager=ANY)
         mock_config_fns["has_recorded_variables"].assert_called_once()
         mock_config_fns["validate_preset"].assert_not_called()  # None preset doesn't need validation
         mock_config_fns["set_preset"].assert_called_once_with(None)
@@ -157,7 +161,7 @@ class TestConfigCommand(unittest.TestCase):
 
         # Verify
         self.assertEqual(result.exit_code, 0)
-        mock_config_handler.assert_called_once_with(output_filename=None, terminal_handler=ANY)
+        mock_config_handler.assert_called_once_with(output_filename=None, display_manager=ANY)
         mock_config_fns["has_recorded_variables"].assert_called_once()
         mock_config_fns["validate_preset"].assert_called_once_with("some-preset")
         mock_config_fns["set_preset"].assert_called_once_with("some-preset")

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_config.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_config.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 from pydantic import ValidationError
 
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.terraform.tf_config import TerraformConfigHandler
 from jupyter_deploy.engine.terraform.tf_constants import (
     TF_DEFAULT_PLAN_FILENAME,
@@ -84,7 +85,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         mock_vars_handler, mock_vars_fns = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
-        handler = TerraformConfigHandler(path, manifest, mock_history)
+        handler = TerraformConfigHandler(path, manifest, mock_history, NullDisplay())
 
         # Assert
         self.assertIsNotNone(handler)
@@ -104,7 +105,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         custom_output = "custom-output-file"
         mock_vars_handler, _ = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
-        handler = TerraformConfigHandler(path, manifest, self.get_mock_command_history(), output_filename=custom_output)
+        handler = TerraformConfigHandler(
+            path, manifest, self.get_mock_command_history(), NullDisplay(), output_filename=custom_output
+        )
 
         # Assert
         self.assertIsNotNone(handler)
@@ -118,7 +121,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         path = Path("/fake/path")
         mock_vars_handler, _ = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         handler.verify_preset_exists("all")
@@ -141,7 +146,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         path = Path("/fake/path")
         mock_vars_handler, _ = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         presets = handler.list_presets()
@@ -162,7 +169,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         path = Path("/fake/path")
         mock_vars_handler, _ = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         presets = handler.list_presets()
@@ -176,7 +185,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         path = Path("/fake/path")
         mock_vars_handler, mock_vars_fns = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         handler.reset_recorded_variables()
@@ -190,7 +201,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         path = Path("/fake/path")
         mock_vars_handler, mock_vars_fns = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         handler.reset_recorded_secrets()
@@ -210,7 +223,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_executor.execute.return_value = 0  # Return code 0 (success)
         mock_create_executor.return_value = mock_executor
 
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act
         handler.configure()
@@ -237,7 +250,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_executor.execute.return_value = 0  # Return code 0 (success)
         mock_create_executor.return_value = mock_executor
 
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act
         handler.configure()
@@ -262,7 +275,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_create_executor.return_value = mock_executor
 
         path = Path("/fake/path")
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         handler.configure(preset_name="all")
@@ -290,7 +305,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_create_executor.return_value = mock_executor
 
         path = Path("/fake/path")
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         mock_var1 = Mock(spec=StrTemplateVariableDefinition)
         mock_var2 = Mock(spec=FloatTemplateVariableDefinition)
@@ -352,7 +369,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_executor.execute.return_value = 1  # Return code 1 (failure)
         mock_create_executor.return_value = mock_executor
 
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act & Assert - should raise ExecutionError
         with self.assertRaises(SupervisedExecutionError) as context:
@@ -378,7 +395,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_executor.execute.side_effect = TimeoutError("Command timed out")
         mock_create_executor.return_value = mock_executor
 
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act & Assert - should raise TimeoutError
         with self.assertRaises(TimeoutError):
@@ -402,7 +419,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_executor.execute.side_effect = [0, 1]  # init=0 (success), plan=1 (failure)
         mock_create_executor.return_value = mock_executor
 
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act & Assert - should raise ExecutionError
         with self.assertRaises(SupervisedExecutionError) as context:
@@ -428,7 +445,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_executor.execute.side_effect = [0, TimeoutError("Command timed out")]  # init=0 (success), plan=timeout
         mock_create_executor.return_value = mock_executor
 
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act & Assert - should raise TimeoutError
         with self.assertRaises(TimeoutError):
@@ -456,7 +473,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         # Arrange
         mock_vars_handler, mock_vars_fns = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Mock the plan parsing and resource counts extraction (always happens)
         mock_capture.return_value = "plan-json-string"
@@ -520,7 +537,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_format.return_value = ["var1 = 1\n", 'var2 = "two"\n']
 
         path = Path("/fake/path")
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         handler.record(record_vars=True)
@@ -586,7 +605,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_format.return_value = ['secret1 = "nuclear-codes"\n']
 
         path = Path("/fake/path")
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         handler.record(record_secrets=True)
@@ -645,7 +666,9 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_format.side_effect = [["var1 = 1\n", 'var2 = "two"\n'], ['secret1 = "nuclear-codes"\n']]
 
         path = Path("/fake/path")
-        handler = TerraformConfigHandler(path, Mock(), command_history_handler=self.get_mock_command_history())
+        handler = TerraformConfigHandler(
+            path, Mock(), command_history_handler=self.get_mock_command_history(), display_manager=NullDisplay()
+        )
 
         # Act
         handler.record(record_vars=True, record_secrets=True)
@@ -687,7 +710,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_capture.side_effect = subprocess.CalledProcessError(
             1, ["terraform", "show", "-json"], "something went wrong", None
         )
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act & Assert
         with self.assertRaises(ReadConfigurationError):
@@ -721,7 +744,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_parse.return_value = mock_plan
         mock_extract_counts.return_value = (5, 3, 2)
         mock_extract.side_effect = ValidationError("some error", [])
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act & Assert
         with self.assertRaises(ReadConfigurationError):
@@ -751,7 +774,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_variable_handler_cls.return_value = mock_vars_handler
         mock_capture.return_value = "i-am-a-serialized-plan"
         mock_parse.side_effect = ValueError("Invalid JSON")
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history())
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
 
         # Act & Assert
         with self.assertRaises(ReadConfigurationError):
@@ -765,13 +788,13 @@ class TestTerraformConfigHandler(unittest.TestCase):
     @patch("jupyter_deploy.engine.terraform.tf_config.TerraformSupervisedExecutionCallback")
     @patch("jupyter_deploy.engine.terraform.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
-    def test_configure_with_terminal_handler_uses_supervised_callback(
+    def test_configure_with_display_manager_uses_supervised_callback(
         self,
         mock_variable_handler_cls: Mock,
         mock_create_executor: Mock,
         mock_callback_cls: Mock,
     ) -> None:
-        """Test that configure with terminal_handler uses TerraformSupervisedExecutionCallback."""
+        """Test that configure with display_manager uses TerraformSupervisedExecutionCallback."""
         # Arrange
         mock_vars_handler, _ = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
@@ -785,13 +808,14 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_callback = Mock()
         mock_callback_cls.return_value = mock_callback
 
-        # Create handler WITH terminal_handler
-        mock_terminal_handler = Mock()
+        # Create handler WITH display_manager
+        mock_display_manager = Mock()
+        mock_display_manager.is_pass_through.return_value = False  # Use supervised callbacks
         handler = TerraformConfigHandler(
             Path("/fake/path"),
             Mock(),
             self.get_mock_command_history(),
-            terminal_handler=mock_terminal_handler,  # type: ignore[arg-type]
+            display_manager=mock_display_manager,  # type: ignore[arg-type]
         )
 
         # Act
@@ -804,12 +828,12 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         # Verify init callback
         init_callback_call = mock_callback_cls.call_args_list[0]
-        self.assertEqual(init_callback_call.kwargs["terminal_handler"], mock_terminal_handler)
+        self.assertEqual(init_callback_call.kwargs["display_manager"], mock_display_manager)
         self.assertEqual(init_callback_call.kwargs["sequence_id"], TerraformSequenceId.config_init)
 
         # Verify plan callback
         plan_callback_call = mock_callback_cls.call_args_list[1]
-        self.assertEqual(plan_callback_call.kwargs["terminal_handler"], mock_terminal_handler)
+        self.assertEqual(plan_callback_call.kwargs["display_manager"], mock_display_manager)
         self.assertEqual(plan_callback_call.kwargs["sequence_id"], TerraformSequenceId.config_plan)
 
         # Verify executor was created with the supervised callback
@@ -823,13 +847,13 @@ class TestTerraformConfigHandler(unittest.TestCase):
     @patch("jupyter_deploy.engine.terraform.tf_config.TerraformNoopExecutionCallback")
     @patch("jupyter_deploy.engine.terraform.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
-    def test_configure_without_terminal_handler_uses_noop_callback(
+    def test_configure_without_display_manager_uses_noop_callback(
         self,
         mock_variable_handler_cls: Mock,
         mock_create_executor: Mock,
         mock_noop_callback_cls: Mock,
     ) -> None:
-        """Test that configure without terminal_handler uses TerraformNoopExecutionCallback."""
+        """Test that configure without display_manager uses TerraformNoopExecutionCallback."""
         # Arrange
         mock_vars_handler, _ = self.get_mock_variable_handler_and_fns()
         mock_variable_handler_cls.return_value = mock_vars_handler
@@ -843,12 +867,14 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_noop = Mock()
         mock_noop_callback_cls.return_value = mock_noop
 
-        # Create handler WITHOUT terminal_handler
+        # Create handler with pass-through display_manager (verbose mode)
+        mock_display_manager = Mock()
+        mock_display_manager.is_pass_through.return_value = True  # Use noop callbacks
         handler = TerraformConfigHandler(
             Path("/fake/path"),
             Mock(),
             self.get_mock_command_history(),
-            terminal_handler=None,
+            display_manager=mock_display_manager,  # type: ignore[arg-type]
         )
 
         # Act
@@ -883,7 +909,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_create_executor.return_value = mock_executor
 
         mock_history = self.get_mock_command_history()
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), mock_history)
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), mock_history, NullDisplay())
 
         # Act
         handler.configure()
@@ -907,7 +933,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_create_executor.return_value = mock_executor
 
         mock_history = self.get_mock_command_history()
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), mock_history)
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), mock_history, NullDisplay())
 
         # Act & Assert - should raise ExecutionError
         with self.assertRaises(SupervisedExecutionError):
@@ -933,7 +959,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         mock_history = self.get_mock_command_history()
         mock_history.clear_logs.side_effect = LogCleanupError("Failed to delete 2 log file(s)")
-        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), mock_history)
+        handler = TerraformConfigHandler(Path("/fake/path"), Mock(), mock_history, NullDisplay())
 
         # Act & Assert - should raise LogCleanupError from clear_logs
         with self.assertRaises(LogCleanupError) as context:

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_down.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_down.py
@@ -32,7 +32,7 @@ class TestTerraformDownHandler(unittest.TestCase):
         mock_manifest.get_engine = mock_get_engine
         return mock_manifest, {"get_engine": mock_get_engine}
 
-    def get_mock_terminal_handler(self) -> Mock:
+    def get_mock_display_manager(self) -> Mock:
         """Return a mock terminal handler (non-pass-through mode)."""
         mock_handler = Mock()
         mock_handler.is_pass_through.return_value = False
@@ -50,7 +50,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         self.assertEqual(handler.project_path, project_path)
@@ -68,7 +68,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         # Mock the executor
@@ -92,7 +92,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         # Mock the executor to return error
@@ -117,7 +117,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         # Mock the executor to raise an exception
@@ -141,7 +141,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         # Mock the executor
@@ -164,12 +164,12 @@ class TestTerraformDownHandler(unittest.TestCase):
         mock_manifest, _ = self.get_mock_manifest_and_fns()
         mock_history_handler = Mock()
         mock_history_handler.create_log_file.return_value = Path("/mock/log.log")
-        mock_terminal_handler = self.get_mock_terminal_handler()
+        mock_display_manager = self.get_mock_display_manager()
         handler = TerraformDownHandler(
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
         )
 
         # Mock the get_persisting_resources method to return resources
@@ -189,10 +189,10 @@ class TestTerraformDownHandler(unittest.TestCase):
         # Verify dry-run was NOT called (fail fast)
         mock_cmd_utils.run_cmd_and_capture_output.assert_not_called()
 
-        # Verify terminal_handler calls were NOT made (fails before dry-run)
-        mock_terminal_handler.info.assert_not_called()
-        mock_terminal_handler.warning.assert_not_called()
-        mock_terminal_handler.success.assert_not_called()
+        # Verify display_manager calls were NOT made (fails before dry-run)
+        mock_display_manager.info.assert_not_called()
+        mock_display_manager.warning.assert_not_called()
+        mock_display_manager.success.assert_not_called()
 
     @patch("jupyter_deploy.engine.terraform.tf_down.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_down.cmd_utils")
@@ -205,12 +205,12 @@ class TestTerraformDownHandler(unittest.TestCase):
         mock_manifest, _ = self.get_mock_manifest_and_fns()
         mock_history_handler = Mock()
         mock_history_handler.create_log_file.return_value = Path("/mock/log.log")
-        mock_terminal_handler = self.get_mock_terminal_handler()
+        mock_display_manager = self.get_mock_display_manager()
         handler = TerraformDownHandler(
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
         )
 
         # Mock the get_persisting_resources method to return resources
@@ -251,11 +251,11 @@ class TestTerraformDownHandler(unittest.TestCase):
         self.assertIn("destroy", destroy_call_args)
         self.assertIn("-auto-approve", destroy_call_args)
 
-        # Verify terminal_handler calls
-        mock_terminal_handler.info.assert_any_call("Running dry-run to detach resources from terraform state...")
-        mock_terminal_handler.success.assert_any_call("Dry-run succeeded.")
-        mock_terminal_handler.info.assert_any_call("Removing persisting resources from the Terraform state...")
-        mock_terminal_handler.success.assert_any_call("Removed the persisting resources from the Terraform state.")
+        # Verify display_manager calls
+        mock_display_manager.info.assert_any_call("Running dry-run to detach resources from terraform state...")
+        mock_display_manager.success.assert_any_call("Dry-run succeeded.")
+        mock_display_manager.info.assert_any_call("Removing persisting resources from the Terraform state...")
+        mock_display_manager.success.assert_any_call("Removed the persisting resources from the Terraform state.")
 
     @patch("jupyter_deploy.engine.terraform.tf_down.cmd_utils")
     def test_destroy_raises_on_failed_dryrun(self, mock_cmd_utils: Mock) -> None:
@@ -264,12 +264,12 @@ class TestTerraformDownHandler(unittest.TestCase):
         mock_manifest, _ = self.get_mock_manifest_and_fns()
         mock_history_handler = Mock()
         mock_history_handler.create_log_file.return_value = Path("/mock/log.log")
-        mock_terminal_handler = self.get_mock_terminal_handler()
+        mock_display_manager = self.get_mock_display_manager()
         handler = TerraformDownHandler(
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
         )
 
         # Mock the get_persisting_resources method to return resources
@@ -292,14 +292,12 @@ class TestTerraformDownHandler(unittest.TestCase):
         # Verify we don't proceed with terraform state rm or destroy
         mock_cmd_utils.run_cmd_and_pipe_to_terminal.assert_not_called()
 
-        # Verify terminal_handler calls
-        mock_terminal_handler.info.assert_called_once_with(
-            "Running dry-run to detach resources from terraform state..."
-        )
-        mock_terminal_handler.warning.assert_any_call(
+        # Verify display_manager calls
+        mock_display_manager.info.assert_called_once_with("Running dry-run to detach resources from terraform state...")
+        mock_display_manager.warning.assert_any_call(
             "Error performing dry-run of removing resources from Terraform state."
         )
-        self.assertEqual(mock_terminal_handler.warning.call_count, 2)  # Called twice (error + details)
+        self.assertEqual(mock_display_manager.warning.call_count, 2)  # Called twice (error + details)
 
     @patch("jupyter_deploy.engine.terraform.tf_down.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_down.cmd_utils")
@@ -312,12 +310,12 @@ class TestTerraformDownHandler(unittest.TestCase):
         mock_manifest, _ = self.get_mock_manifest_and_fns()
         mock_history_handler = Mock()
         mock_history_handler.create_log_file.return_value = Path("/mock/log.log")
-        mock_terminal_handler = self.get_mock_terminal_handler()
+        mock_display_manager = self.get_mock_display_manager()
         handler = TerraformDownHandler(
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
         )
 
         # Mock the get_persisting_resources method to return resources
@@ -347,10 +345,10 @@ class TestTerraformDownHandler(unittest.TestCase):
         self.assertEqual(context.exception.retcode, 1)
         self.assertEqual(context.exception.command, "down")
 
-        # Verify terminal_handler calls (dry-run succeeded, but removal failed)
-        mock_terminal_handler.info.assert_any_call("Running dry-run to detach resources from terraform state...")
-        mock_terminal_handler.success.assert_any_call("Dry-run succeeded.")
-        mock_terminal_handler.info.assert_any_call("Removing persisting resources from the Terraform state...")
+        # Verify display_manager calls (dry-run succeeded, but removal failed)
+        mock_display_manager.info.assert_any_call("Running dry-run to detach resources from terraform state...")
+        mock_display_manager.success.assert_any_call("Dry-run succeeded.")
+        mock_display_manager.info.assert_any_call("Removing persisting resources from the Terraform state...")
 
     @patch("jupyter_deploy.engine.terraform.tf_down.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_down.fs_utils")
@@ -365,7 +363,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
         engine_path = project_path / "engine"
 
@@ -407,7 +405,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         # Mock fs_utils to indicate that destroy.tfvars does NOT exist
@@ -432,10 +430,10 @@ class TestTerraformDownHandler(unittest.TestCase):
 
     @patch("jupyter_deploy.engine.terraform.tf_down.TerraformSupervisedExecutionCallback")
     @patch("jupyter_deploy.engine.terraform.tf_down.tf_supervised_executor_factory.create_terraform_executor")
-    def test_destroy_with_terminal_handler_uses_supervised_callback(
+    def test_destroy_with_display_manager_uses_supervised_callback(
         self, mock_create_executor: Mock, mock_callback_cls: Mock
     ) -> None:
-        """Test that destroy with terminal_handler uses TerraformSupervisedExecutionCallback."""
+        """Test that destroy with display_manager uses TerraformSupervisedExecutionCallback."""
         project_path = Path("/mock/project")
         mock_manifest, _ = self.get_mock_manifest_and_fns()
         mock_history_handler = Mock()
@@ -450,13 +448,13 @@ class TestTerraformDownHandler(unittest.TestCase):
         mock_callback = Mock()
         mock_callback_cls.return_value = mock_callback
 
-        # Create handler WITH terminal_handler
-        mock_terminal_handler = self.get_mock_terminal_handler()
+        # Create handler WITH display_manager
+        mock_display_manager = self.get_mock_display_manager()
         handler = TerraformDownHandler(
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
         )
 
         # Act
@@ -465,7 +463,7 @@ class TestTerraformDownHandler(unittest.TestCase):
         # Assert
         # Verify TerraformSupervisedExecutionCallback was created (once for destroy)
         mock_callback_cls.assert_called_once_with(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.down_destroy,
         )
 
@@ -475,10 +473,10 @@ class TestTerraformDownHandler(unittest.TestCase):
 
     @patch("jupyter_deploy.engine.terraform.tf_down.TerraformSupervisedExecutionCallback")
     @patch("jupyter_deploy.engine.terraform.tf_down.tf_supervised_executor_factory.create_terraform_executor")
-    def test_destroy_with_terminal_handler_handles_error(
+    def test_destroy_with_display_manager_handles_error(
         self, mock_create_executor: Mock, mock_callback_cls: Mock
     ) -> None:
-        """Test that destroy with terminal_handler properly raises ExecutionError on failure."""
+        """Test that destroy with display_manager properly raises ExecutionError on failure."""
         project_path = Path("/mock/project")
         mock_manifest, _ = self.get_mock_manifest_and_fns()
         mock_history_handler = Mock()
@@ -493,13 +491,13 @@ class TestTerraformDownHandler(unittest.TestCase):
         mock_callback = Mock()
         mock_callback_cls.return_value = mock_callback
 
-        # Create handler WITH terminal_handler
-        mock_terminal_handler = self.get_mock_terminal_handler()
+        # Create handler WITH display_manager
+        mock_display_manager = self.get_mock_display_manager()
         handler = TerraformDownHandler(
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
         )
 
         # Act & Assert
@@ -511,7 +509,7 @@ class TestTerraformDownHandler(unittest.TestCase):
 
         # Verify TerraformSupervisedExecutionCallback was created
         mock_callback_cls.assert_called_once_with(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.down_destroy,
         )
 
@@ -544,7 +542,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         # Act
@@ -578,7 +576,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         # Act & Assert - should raise ExecutionError
@@ -613,7 +611,7 @@ class TestTerraformDownHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=self.get_mock_terminal_handler(),
+            display_manager=self.get_mock_display_manager(),
         )
 
         # Act & Assert - should raise LogCleanupError from clear_logs

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_supervised_execution_callback.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_supervised_execution_callback.py
@@ -4,6 +4,7 @@ import unittest
 from collections import deque
 from unittest.mock import Mock
 
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.terraform.tf_enums import TerraformSequenceId
 from jupyter_deploy.engine.terraform.tf_supervised_execution_callback import (
     ANSI_ESCAPE,
@@ -19,7 +20,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_positive_simple_prompt(self) -> None:
         """Test that _detect_interaction detects simple 'Enter a value:' prompt."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -31,7 +32,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_positive_with_ansi_codes(self) -> None:
         """Test that _detect_interaction detects prompt with ANSI codes."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -44,7 +45,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_positive_prompt_with_leading_whitespace(self) -> None:
         """Test that _detect_interaction detects prompt with leading whitespace."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -56,7 +57,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_positive_prompt_with_ansi_and_spaces(self) -> None:
         """Test that _detect_interaction detects prompt with ANSI codes and spaces."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -68,7 +69,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_negative_no_prompt(self) -> None:
         """Test that _detect_interaction returns False for normal output."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -80,7 +81,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_negative_prompt_in_middle(self) -> None:
         """Test that _detect_interaction returns False when prompt is not at end."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -92,7 +93,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_negative_partial_prompt(self) -> None:
         """Test that _detect_interaction returns False for partial prompt text."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -104,7 +105,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_negative_similar_text(self) -> None:
         """Test that _detect_interaction returns False for similar but different text."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -116,7 +117,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_negative_empty_line(self) -> None:
         """Test that _detect_interaction returns False for empty line."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -128,7 +129,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_detect_interaction_negative_whitespace_only(self) -> None:
         """Test that _detect_interaction returns False for whitespace-only line."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -141,7 +142,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_positive_finds_var(self) -> None:
         """Test that _extract_variable_context finds and extracts variable description."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -168,7 +169,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_positive_finds_var_with_ansi(self) -> None:
         """Test that _extract_variable_context finds variable with ANSI codes."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -193,7 +194,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_positive_multiple_vars_finds_most_recent(self) -> None:
         """Test that _extract_variable_context finds the most recent var when multiple exist."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -219,7 +220,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_positive_var_at_beginning_of_buffer(self) -> None:
         """Test that _extract_variable_context handles var at start of buffer."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -241,7 +242,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_negative_no_var_found(self) -> None:
         """Test that _extract_variable_context falls back when no var. found."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -264,7 +265,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_negative_empty_buffer(self) -> None:
         """Test that _extract_variable_context handles empty buffer gracefully."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -278,7 +279,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_negative_large_buffer_fallback(self) -> None:
         """Test that _extract_variable_context caps fallback at 10 lines."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -296,7 +297,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_negative_var_in_middle_of_line(self) -> None:
         """Test that _extract_variable_context ignores 'var.' in middle of line."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -317,7 +318,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_positive_preserves_ansi_codes(self) -> None:
         """Test that _extract_variable_context preserves ANSI codes in returned lines."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -340,7 +341,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_negative_var_with_special_characters(self) -> None:
         """Test that _extract_variable_context handles lines with var-like patterns."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -361,7 +362,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_positive_buffer_maxlen_respected(self) -> None:
         """Test that _extract_variable_context respects buffer maxlen in fallback."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_init,
         )
 
@@ -379,7 +380,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_extract_variable_context_negative_none_maxlen_uses_default(self) -> None:
         """Test that _extract_variable_context handles None maxlen."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -433,7 +434,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_get_completion_context_config_plan_finds_plan_summary(self) -> None:
         """Test that completion context finds Plan: summary in buffer for config_plan."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -460,7 +461,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_get_completion_context_config_plan_handles_ansi_codes(self) -> None:
         """Test that completion context handles ANSI codes in Plan line."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -486,7 +487,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_get_completion_context_up_apply_finds_apply_complete(self) -> None:
         """Test that completion context finds Apply complete in buffer for up_apply."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.up_apply,
         )
 
@@ -515,7 +516,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_get_completion_context_returns_none_for_other_sequences(self) -> None:
         """Test that completion context returns None for sequences without completion patterns."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_init,  # Not config_plan or up_apply
         )
 
@@ -527,7 +528,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_get_completion_context_returns_none_when_pattern_not_found(self) -> None:
         """Test that completion context is None when pattern not in buffer."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -542,7 +543,7 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
     def test_get_completion_context_limits_lines_returned(self) -> None:
         """Test that completion context caps at max lines for sequence."""
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=Mock(),  # type: ignore[arg-type]
+            display_manager=Mock(),  # type: ignore[arg-type]
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -560,9 +561,9 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
 
     def test_on_execution_error_finds_error_line(self) -> None:
         """Test that on_execution_error finds and displays from Error: line."""
-        mock_terminal_handler: Mock = Mock()  # type: ignore[assignment]
+        mock_display_manager: Mock = Mock()  # type: ignore[assignment]
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -584,17 +585,17 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
         callback.on_execution_error(retcode=1)
 
         # Should call display_error_context with lines from "Error: " onwards
-        mock_terminal_handler.display_error_context.assert_called_once()
-        error_lines = mock_terminal_handler.display_error_context.call_args[0][0]
+        mock_display_manager.display_error_context.assert_called_once()
+        error_lines = mock_display_manager.display_error_context.call_args[0][0]
         self.assertEqual(len(error_lines), 6)
         self.assertIn("Error: Invalid configuration", error_lines[0])
         self.assertIn("This configuration is not valid.", error_lines[-1])
 
     def test_on_execution_error_handles_ansi_codes(self) -> None:
         """Test that on_execution_error strips ANSI codes when searching for errors."""
-        mock_terminal_handler: Mock = Mock()  # type: ignore[assignment]
+        mock_display_manager: Mock = Mock()  # type: ignore[assignment]
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.up_apply,
         )
 
@@ -611,8 +612,8 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
         callback.on_execution_error(retcode=1)
 
         # Should find the error despite ANSI codes
-        mock_terminal_handler.display_error_context.assert_called_once()
-        error_lines = mock_terminal_handler.display_error_context.call_args[0][0]
+        mock_display_manager.display_error_context.assert_called_once()
+        error_lines = mock_display_manager.display_error_context.call_args[0][0]
         self.assertEqual(len(error_lines), 2)
         # Should preserve ANSI codes in output
         self.assertIn("\x1b[1m", error_lines[0])
@@ -620,9 +621,9 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
 
     def test_on_execution_error_limits_to_50_lines(self) -> None:
         """Test that on_execution_error limits output to 50 lines from error."""
-        mock_terminal_handler: Mock = Mock()  # type: ignore[assignment]
+        mock_display_manager: Mock = Mock()  # type: ignore[assignment]
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -633,17 +634,17 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
         callback.on_execution_error(retcode=1)
 
         # Should limit to 50 lines from the error
-        mock_terminal_handler.display_error_context.assert_called_once()
-        error_lines = mock_terminal_handler.display_error_context.call_args[0][0]
+        mock_display_manager.display_error_context.assert_called_once()
+        error_lines = mock_display_manager.display_error_context.call_args[0][0]
         self.assertEqual(len(error_lines), 50)
         self.assertIn("Error: Something went wrong", error_lines[0])
         self.assertEqual("Line 48", error_lines[-1])
 
     def test_on_execution_error_fallback_when_no_error_found(self) -> None:
         """Test that on_execution_error falls back to default behavior when no Error: found."""
-        mock_terminal_handler: Mock = Mock()  # type: ignore[assignment]
+        mock_display_manager: Mock = Mock()  # type: ignore[assignment]
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.config_plan,
         )
 
@@ -660,16 +661,16 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
         callback.on_execution_error(retcode=1)
 
         # Should fall back to base class behavior (last 50 lines)
-        mock_terminal_handler.display_error_context.assert_called_once()
-        error_lines = mock_terminal_handler.display_error_context.call_args[0][0]
+        mock_display_manager.display_error_context.assert_called_once()
+        error_lines = mock_display_manager.display_error_context.call_args[0][0]
         # Base class takes last N lines from buffer
         self.assertEqual(len(error_lines), 3)
 
     def test_on_execution_error_finds_last_error_when_multiple(self) -> None:
         """Test that on_execution_error finds the last Error: when there are multiple."""
-        mock_terminal_handler: Mock = Mock()  # type: ignore[assignment]
+        mock_display_manager: Mock = Mock()  # type: ignore[assignment]
         callback = TerraformSupervisedExecutionCallback(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.up_apply,
         )
 
@@ -689,8 +690,8 @@ class TestTerraformSupervisedExecutionCallback(unittest.TestCase):
         callback.on_execution_error(retcode=1)
 
         # Should start from the last error (searching backwards finds most recent)
-        mock_terminal_handler.display_error_context.assert_called_once()
-        error_lines = mock_terminal_handler.display_error_context.call_args[0][0]
+        mock_display_manager.display_error_context.assert_called_once()
+        error_lines = mock_display_manager.display_error_context.call_args[0][0]
         self.assertEqual(len(error_lines), 2)
         self.assertIn("Second error", error_lines[0])
         self.assertIn("Details about second error", error_lines[1])
@@ -701,7 +702,7 @@ class TestTerraformNoopExecutionCallback(unittest.TestCase):
 
     def test_is_requesting_user_input_detects_terraform_prompts(self) -> None:
         """Test that is_requesting_user_input detects terraform prompts."""
-        callback = TerraformNoopExecutionCallback()
+        callback = TerraformNoopExecutionCallback(NullDisplay())
 
         # Should detect terraform prompts
         self.assertTrue(callback.is_requesting_user_input("Enter a value:"))
@@ -710,7 +711,7 @@ class TestTerraformNoopExecutionCallback(unittest.TestCase):
 
     def test_is_requesting_user_input_handles_ansi_codes(self) -> None:
         """Test that is_requesting_user_input handles ANSI codes in prompts."""
-        callback = TerraformNoopExecutionCallback()
+        callback = TerraformNoopExecutionCallback(NullDisplay())
 
         # Terraform wraps prompts with ANSI codes
         ansi_prompt = "\x1b[1m  Enter a value:\x1b[0m"
@@ -718,7 +719,7 @@ class TestTerraformNoopExecutionCallback(unittest.TestCase):
 
     def test_is_requesting_user_input_rejects_non_prompts(self) -> None:
         """Test that is_requesting_user_input rejects non-prompt patterns."""
-        callback = TerraformNoopExecutionCallback()
+        callback = TerraformNoopExecutionCallback(NullDisplay())
 
         # Should not detect other patterns
         self.assertFalse(callback.is_requesting_user_input("PROMPT:"))
@@ -729,14 +730,14 @@ class TestTerraformNoopExecutionCallback(unittest.TestCase):
 
     def test_is_requesting_user_input_handles_empty_input(self) -> None:
         """Test that is_requesting_user_input handles empty/whitespace input."""
-        callback = TerraformNoopExecutionCallback()
+        callback = TerraformNoopExecutionCallback(NullDisplay())
 
         self.assertFalse(callback.is_requesting_user_input(""))
         self.assertFalse(callback.is_requesting_user_input("   "))
 
     def test_handle_interaction_prints_to_stdout(self) -> None:
         """Test that handle_interaction prints prompt lines to stdout without newline."""
-        callback = TerraformNoopExecutionCallback()
+        callback = TerraformNoopExecutionCallback(NullDisplay())
 
         # Capture stdout
         captured_output = io.StringIO()
@@ -753,7 +754,7 @@ class TestTerraformNoopExecutionCallback(unittest.TestCase):
 
     def test_handle_interaction_adds_trailing_space(self) -> None:
         """Test that handle_interaction adds trailing space if not present."""
-        callback = TerraformNoopExecutionCallback()
+        callback = TerraformNoopExecutionCallback(NullDisplay())
 
         # Capture stdout
         captured_output = io.StringIO()

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_up.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_up.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.terraform.tf_enums import TerraformSequenceId
 from jupyter_deploy.engine.terraform.tf_plan_metadata import TerraformPlanMetadata
 from jupyter_deploy.engine.terraform.tf_up import TerraformUpHandler
@@ -20,6 +21,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         self.assertEqual(handler.project_path, project_path)
@@ -33,6 +35,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         result = handler.get_default_config_filename()
@@ -52,6 +55,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         # Mock the executor
@@ -77,6 +81,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         # Mock the executor to return error
@@ -103,6 +108,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         # Mock the executor
@@ -119,10 +125,10 @@ class TestTerraformUpHandler(unittest.TestCase):
 
     @patch("jupyter_deploy.engine.terraform.tf_up.TerraformSupervisedExecutionCallback")
     @patch("jupyter_deploy.engine.terraform.tf_up.tf_supervised_executor_factory.create_terraform_executor")
-    def test_apply_with_terminal_handler_uses_supervised_callback(
+    def test_apply_with_display_manager_uses_supervised_callback(
         self, mock_create_executor: Mock, mock_callback_cls: Mock
     ) -> None:
-        """Test that apply with terminal_handler uses TerraformSupervisedExecutionCallback."""
+        """Test that apply with display_manager uses TerraformSupervisedExecutionCallback."""
         path = Path("/mock/path")
         project_path = Path("/mock/project")
         mock_manifest = Mock()
@@ -138,13 +144,14 @@ class TestTerraformUpHandler(unittest.TestCase):
         mock_callback = Mock()
         mock_callback_cls.return_value = mock_callback
 
-        # Create handler WITH terminal_handler
-        mock_terminal_handler = Mock()
+        # Create handler WITH display_manager
+        mock_display_manager = Mock()
+        mock_display_manager.is_pass_through.return_value = False  # Use supervised callbacks
         handler = TerraformUpHandler(
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
         )
 
         # Act
@@ -153,7 +160,7 @@ class TestTerraformUpHandler(unittest.TestCase):
         # Assert
         # Verify TerraformSupervisedExecutionCallback was created
         mock_callback_cls.assert_called_once_with(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.up_apply,
         )
 
@@ -163,10 +170,10 @@ class TestTerraformUpHandler(unittest.TestCase):
 
     @patch("jupyter_deploy.engine.terraform.tf_up.TerraformSupervisedExecutionCallback")
     @patch("jupyter_deploy.engine.terraform.tf_up.tf_supervised_executor_factory.create_terraform_executor")
-    def test_apply_with_terminal_handler_handles_error(
+    def test_apply_with_display_manager_handles_error(
         self, mock_create_executor: Mock, mock_callback_cls: Mock
     ) -> None:
-        """Test that apply with terminal_handler properly raises ExecutionError on failure."""
+        """Test that apply with display_manager properly raises ExecutionError on failure."""
         path = Path("/mock/path")
         project_path = Path("/mock/project")
         mock_manifest = Mock()
@@ -182,13 +189,14 @@ class TestTerraformUpHandler(unittest.TestCase):
         mock_callback = Mock()
         mock_callback_cls.return_value = mock_callback
 
-        # Create handler WITH terminal_handler
-        mock_terminal_handler = Mock()
+        # Create handler WITH display_manager
+        mock_display_manager = Mock()
+        mock_display_manager.is_pass_through.return_value = False  # Use supervised callbacks
         handler = TerraformUpHandler(
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
         )
 
         # Act & Assert
@@ -200,7 +208,7 @@ class TestTerraformUpHandler(unittest.TestCase):
 
         # Verify TerraformSupervisedExecutionCallback was created
         mock_callback_cls.assert_called_once_with(
-            terminal_handler=mock_terminal_handler,
+            display_manager=mock_display_manager,
             sequence_id=TerraformSequenceId.up_apply,
         )
 
@@ -227,6 +235,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         # Act
@@ -254,6 +263,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         # Act & Assert - should raise ExecutionError
@@ -282,6 +292,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         # Act & Assert - should raise LogCleanupError from clear_logs
@@ -314,6 +325,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         # Act
@@ -352,6 +364,7 @@ class TestTerraformUpHandler(unittest.TestCase):
             project_path=project_path,
             project_manifest=mock_manifest,
             command_history_handler=mock_history_handler,
+            display_manager=NullDisplay(),
         )
 
         # Act

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_variables.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_variables.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.terraform.tf_variables import TerraformVariablesHandler
 
 
@@ -9,14 +10,18 @@ class TestTerraformVariablesHandler(unittest.TestCase):
     def test_successfully_instantiates(self) -> None:
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
         self.assertEqual(handler.project_path, project_path)
         self.assertEqual(handler.project_manifest, manifest)
 
     def test_get_recorded_variables_filepath(self) -> None:
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Get the filepath and verify it's correct
         result = handler.get_recorded_variables_filepath()
@@ -27,7 +32,9 @@ class TestTerraformVariablesHandler(unittest.TestCase):
     def test_get_recorded_secrets_filepath(self) -> None:
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Get the filepath and verify it's correct
         result = handler.get_recorded_secrets_filepath()
@@ -42,7 +49,9 @@ class TestIsTemplateDir(unittest.TestCase):
         mock_file_exists.return_value = True
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         result = handler.is_template_directory()
         self.assertTrue(result)
@@ -53,7 +62,9 @@ class TestIsTemplateDir(unittest.TestCase):
         mock_file_exists.return_value = False
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         result = handler.is_template_directory()
         self.assertFalse(result)
@@ -99,7 +110,9 @@ class TestGetTemplateVariables(unittest.TestCase):
         mock_parse_tfvars.side_effect = tfvars_side_effect
 
         # Act
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
         result = handler.get_template_variables()
 
         # Assert
@@ -131,7 +144,9 @@ class TestGetTemplateVariables(unittest.TestCase):
         mock_read_short_file.side_effect = RuntimeError("File is too large!")
 
         # Act
-        handler = TerraformVariablesHandler(project_path=Path("/mock/project"), project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=Path("/mock/project"), project_manifest=Mock(), display_manager=NullDisplay()
+        )
         with self.assertRaises(RuntimeError):
             handler.get_template_variables()
 
@@ -151,7 +166,9 @@ class TestGetTemplateVariables(unittest.TestCase):
         mock_parse_variables.return_value = {}
 
         # Act
-        handler = TerraformVariablesHandler(project_path=Path("/mock/project"), project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=Path("/mock/project"), project_manifest=Mock(), display_manager=NullDisplay()
+        )
         with self.assertRaises(RuntimeError):
             handler.get_template_variables()
 
@@ -175,7 +192,9 @@ class TestGetTemplateVariables(unittest.TestCase):
         mock_to_template_def_1.return_value = {"val": "1"}
 
         # Act
-        handler = TerraformVariablesHandler(project_path=Path("/mock/project"), project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=Path("/mock/project"), project_manifest=Mock(), display_manager=NullDisplay()
+        )
         result1 = handler.get_template_variables()
 
         # Verify-1
@@ -209,7 +228,9 @@ class TestUpdateVariablesRecord(unittest.TestCase):
         mock_get_updated_vars.return_value = ["updated_line1", "updated_line2"]
 
         # Create a handler with mocked template variables
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=Mock(), display_manager=NullDisplay()
+        )
         mock_validate1 = Mock()
         mock_validate2 = Mock()
         handler._template_vars = {
@@ -245,7 +266,9 @@ class TestUpdateVariablesRecord(unittest.TestCase):
         mock_get_updated_vars.return_value = ["line1", "line2"]
 
         # Create a handler with mocked template variables
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=Mock(), display_manager=NullDisplay()
+        )
         mock_validate = Mock()
         handler._template_vars = {
             "var1": Mock(validate_value=mock_validate),
@@ -267,7 +290,9 @@ class TestUpdateVariablesRecord(unittest.TestCase):
         project_path = Path("/mock/project")
 
         # Create a handler with mocked template variables
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=Mock(), display_manager=NullDisplay()
+        )
 
         # Mock that will raise TypeError
         mock_var = Mock()
@@ -292,7 +317,9 @@ class TestUpdateVariablesRecord(unittest.TestCase):
         project_path = Path("/mock/project")
 
         # Create a handler with mocked template variables
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=Mock(), display_manager=NullDisplay()
+        )
         handler._template_vars = {
             "var1": Mock(validate_value=Mock()),
         }
@@ -312,7 +339,9 @@ class TestUpdateVariablesRecord(unittest.TestCase):
         mock_read_file.side_effect = RuntimeError("File read error")
 
         # Create a handler with mocked template variables
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=Mock(), display_manager=NullDisplay()
+        )
         handler._template_vars = {
             "var1": Mock(validate_value=Mock()),
         }
@@ -336,7 +365,9 @@ class TestUpdateVariablesRecord(unittest.TestCase):
         mock_write_file.side_effect = RuntimeError("File write error")
 
         # Create a handler with mocked template variables
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=Mock(), display_manager=NullDisplay()
+        )
         handler._template_vars = {
             "var1": Mock(validate_value=Mock()),
         }
@@ -350,7 +381,9 @@ class TestUpdateVariablesRecord(unittest.TestCase):
         project_path = Path("/mock/project")
 
         # Create a handler with mocked get_template_variables
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=Mock())
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=Mock(), display_manager=NullDisplay()
+        )
         handler.get_template_variables = Mock()  # type: ignore
 
         # Execute
@@ -370,7 +403,9 @@ class TestCreateFilteredPresetFile(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock the retrieved variable names
         handler.get_variable_names_assigned_in_config = Mock(return_value=["var1", "var2"])  # type: ignore
@@ -400,7 +435,9 @@ class TestCreateFilteredPresetFile(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock the retrieved variable names
         handler.get_variable_names_assigned_in_config = Mock(return_value=["var1", "var2"])  # type: ignore
@@ -424,7 +461,9 @@ class TestCreateFilteredPresetFile(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock file read to raise FileNotFoundError
         mock_read_file.side_effect = FileNotFoundError("File not found")
@@ -439,7 +478,9 @@ class TestCreateFilteredPresetFile(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock file read to raise some other error
         mock_read_file.side_effect = RuntimeError("Error reading file")
@@ -458,7 +499,9 @@ class TestCreateFilteredPresetFile(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock the retrieved variable names
         handler.get_variable_names_assigned_in_config = Mock(return_value=["var1"])  # type: ignore
@@ -483,7 +526,9 @@ class TestResetRecordedVariables(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
         mock_delete_file.return_value = False  # File wasn't deleted
 
         # Execute
@@ -499,7 +544,9 @@ class TestResetRecordedVariables(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
         mock_delete_file.return_value = True  # File was deleted
         mock_parent_reset.return_value = False  # Parent didn't delete anything
 
@@ -519,7 +566,9 @@ class TestResetRecordedVariables(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
         mock_delete_file.side_effect = OSError("Permission denied")
 
         # Execute & Assert
@@ -537,7 +586,9 @@ class TestResetRecordedSecrets(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
         mock_delete_file.return_value = False  # File wasn't deleted
 
         # Execute
@@ -553,7 +604,9 @@ class TestResetRecordedSecrets(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
         mock_delete_file.return_value = True  # File was deleted
         mock_parent_reset.return_value = False  # Parent didn't delete anything
 
@@ -573,7 +626,9 @@ class TestResetRecordedSecrets(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = TerraformVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = TerraformVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
         mock_delete_file.side_effect = OSError("Permission denied")
 
         # Execute & Assert

--- a/libs/jupyter-deploy/tests/unit/engine/test_engine_variables.py
+++ b/libs/jupyter-deploy/tests/unit/engine/test_engine_variables.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 
 from jupyter_deploy import constants
 from jupyter_deploy.engine.engine_variables import EngineVariablesHandler
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
 from jupyter_deploy.exceptions import InvalidVariablesDotYamlError
 from jupyter_deploy.variables_config import (
@@ -54,7 +55,9 @@ class TestVariablesConfigProperty(unittest.TestCase):
         # Verify that _variables_config is None after initialization
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         self.assertIsNone(handler._variables_config)
 
@@ -63,7 +66,9 @@ class TestVariablesConfigProperty(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
         mock_retrieve.return_value = mock_config
@@ -81,7 +86,9 @@ class TestVariablesConfigProperty(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
         mock_retrieve.return_value = mock_config
@@ -100,7 +107,9 @@ class TestVariablesConfigProperty(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock retrieve to raise FileNotFoundError
         mock_retrieve.side_effect = FileNotFoundError("File not found")
@@ -117,7 +126,9 @@ class TestVariablesConfigProperty(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock retrieve to raise ValidationError
         mock_retrieve.side_effect = ValidationError.from_exception_data("Validation error", [])
@@ -134,7 +145,9 @@ class TestVariablesConfigProperty(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock retrieve to raise InvalidVariablesDotYamlError
         mock_retrieve.side_effect = InvalidVariablesDotYamlError("Invalid variables config")
@@ -152,7 +165,9 @@ class TestSyncEngineVarfilesWithProjectVariablesConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock the handler's update_variable_records method
         with patch.object(handler, "update_variable_records") as mock_update_records:
@@ -176,7 +191,9 @@ class TestSyncEngineVarfilesWithProjectVariablesConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock the handler's update_variable_records method
         with patch.object(handler, "update_variable_records") as mock_update_records:
@@ -200,7 +217,9 @@ class TestSyncEngineVarfilesWithProjectVariablesConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock the handler's update_variable_records method
         with patch.object(handler, "update_variable_records") as mock_update_records:
@@ -225,7 +244,9 @@ class TestSyncEngineVarfilesWithProjectVariablesConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Mock the handler's update_variable_records method to raise an exception
         with patch.object(handler, "update_variable_records", side_effect=ValueError("Test error")):
@@ -248,7 +269,9 @@ class TestGetVariableNamesAssignedInConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config with a mix of None and non-None values
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -277,7 +300,9 @@ class TestGetVariableNamesAssignedInConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config with empty dictionaries
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -298,7 +323,9 @@ class TestGetVariableNamesAssignedInConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config with all None values
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -319,7 +346,9 @@ class TestGetVariableNamesAssignedInConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config with defaults that have non-None values
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -349,7 +378,9 @@ class TestSyncProjectVariablesConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -388,7 +419,9 @@ class TestSyncProjectVariablesConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -424,7 +457,9 @@ class TestSyncProjectVariablesConfig(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -460,7 +495,9 @@ class TestResetRecordedVariables(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config with some values
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -497,7 +534,9 @@ class TestResetRecordedVariables(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -523,7 +562,9 @@ class TestResetRecordedVariables(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -549,7 +590,9 @@ class TestResetRecordedSecrets(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config with some values
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -592,7 +635,9 @@ class TestResetRecordedSecrets(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config
         mock_config = Mock(spec=JupyterDeployVariablesConfig)
@@ -618,7 +663,9 @@ class TestResetRecordedSecrets(unittest.TestCase):
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
-        handler = DummyVariablesHandler(project_path=project_path, project_manifest=manifest)
+        handler = DummyVariablesHandler(
+            project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
+        )
 
         # Create a mock variables_config
         mock_config = Mock(spec=JupyterDeployVariablesConfig)

--- a/libs/jupyter-deploy/tests/unit/engine/test_supervised_execution_callback.py
+++ b/libs/jupyter-deploy/tests/unit/engine/test_supervised_execution_callback.py
@@ -3,7 +3,12 @@ import sys
 import unittest
 from unittest.mock import Mock
 
-from jupyter_deploy.engine.supervised_execution import ExecutionProgress, InteractionContext, TerminalHandler
+from jupyter_deploy.engine.supervised_execution import (
+    DisplayManager,
+    ExecutionProgress,
+    InteractionContext,
+    NullDisplay,
+)
 from jupyter_deploy.engine.supervised_execution_callback import (
     EngineExecutionCallback,
     NoopExecutionCallback,
@@ -23,8 +28,58 @@ class ConcreteEngineCallback(EngineExecutionCallback):
         return True
 
 
+class MockPassThroughDisplay:
+    """Mock display manager that prints to stdout (simulates pass-through mode)."""
+
+    def on_log_line(self, line: str) -> None:
+        """Print line to stdout."""
+        print(line, flush=True)
+
+    def is_pass_through(self) -> bool:
+        """Always returns True."""
+        return True
+
+    # Stub implementations for other DisplayManager protocol methods
+    def on_progress(self, progress: ExecutionProgress) -> None:
+        pass
+
+    def update_log_box(self, lines: list[str]) -> None:
+        pass
+
+    def on_interaction_start(self, context: InteractionContext) -> None:
+        pass
+
+    def on_interaction_end(self) -> None:
+        pass
+
+    def display_error_context(self, lines: list[str]) -> None:
+        pass
+
+    def info(self, message: str) -> None:
+        pass
+
+    def warning(self, message: str) -> None:
+        pass
+
+    def success(self, message: str) -> None:
+        pass
+
+    def hint(self, message: str) -> None:
+        pass
+
+    def spinner(self, initial_message: str) -> None:
+        pass
+
+    def stop_spinning(self) -> None:
+        pass
+
+
 class ConcreteNoopCallback(NoopExecutionCallback):
     """Concrete implementation of NoopExecutionCallback for testing."""
+
+    def __init__(self, display_manager: DisplayManager) -> None:
+        """Initialize with display manager."""
+        super().__init__(display_manager)
 
     def is_requesting_user_input(self, line: str) -> bool:
         """Test implementation that never detects prompts."""
@@ -36,18 +91,18 @@ class TestEngineExecutionCallback(unittest.TestCase):
 
     def test_init_sets_attributes(self) -> None:
         """Test that initialization sets all attributes correctly."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal, buffer_size=100, log_display_lines=5)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal, buffer_size=100, log_display_lines=5)
 
-        self.assertEqual(callback._terminal_handler, mock_terminal)
+        self.assertEqual(callback._display_manager, mock_terminal)
         self.assertEqual(callback._line_buffer.maxlen, 100)
         self.assertEqual(callback._display_buffer.maxlen, 5)
         self.assertFalse(callback._waiting_for_interaction)
 
     def test_init_uses_default_values(self) -> None:
         """Test that initialization uses default values when not provided."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal)
 
         self.assertEqual(callback._line_buffer.maxlen, 200)
         self.assertEqual(callback._display_buffer.maxlen, 2)
@@ -55,42 +110,42 @@ class TestEngineExecutionCallback(unittest.TestCase):
 
     def test_should_parse_progress_returns_true(self) -> None:
         """Test that should_parse_progress returns True for EngineExecutionCallback."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal)
 
         self.assertTrue(callback.should_parse_progress())
 
     def test_is_waiting_for_interaction_returns_false_initially(self) -> None:
         """Test that is_waiting_for_interaction returns False initially."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal)
 
         self.assertFalse(callback.is_waiting_for_interaction())
 
     def test_init_raises_when_buffer_size_less_than_log_display_lines(self) -> None:
         """Test that initialization raises ValueError when buffer_size < log_display_lines."""
-        mock_terminal = Mock(spec=TerminalHandler)
+        mock_terminal = Mock(spec=DisplayManager)
 
         with self.assertRaises(ValueError) as context:
-            ConcreteEngineCallback(terminal_handler=mock_terminal, buffer_size=5, log_display_lines=10)
+            ConcreteEngineCallback(display_manager=mock_terminal, buffer_size=5, log_display_lines=10)
 
         self.assertIn("buffer_size", str(context.exception))
         self.assertIn("log_display_lines", str(context.exception))
 
     def test_init_raises_when_buffer_size_less_than_error_display_lines(self) -> None:
         """Test that initialization raises ValueError when buffer_size < error_display_lines."""
-        mock_terminal = Mock(spec=TerminalHandler)
+        mock_terminal = Mock(spec=DisplayManager)
 
         with self.assertRaises(ValueError) as context:
-            ConcreteEngineCallback(terminal_handler=mock_terminal, buffer_size=30, error_display_lines=50)
+            ConcreteEngineCallback(display_manager=mock_terminal, buffer_size=30, error_display_lines=50)
 
         self.assertIn("buffer_size", str(context.exception))
         self.assertIn("error_display_lines", str(context.exception))
 
     def test_on_log_line_adds_to_buffers(self) -> None:
         """Test that on_log_line adds lines to both buffers."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal)
 
         callback.on_log_line("Line 1")
         callback.on_log_line("Line 2")
@@ -102,8 +157,8 @@ class TestEngineExecutionCallback(unittest.TestCase):
 
     def test_on_log_line_updates_terminal(self) -> None:
         """Test that on_log_line updates the terminal display."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal)
 
         callback.on_log_line("Test line")
 
@@ -113,8 +168,8 @@ class TestEngineExecutionCallback(unittest.TestCase):
 
     def test_on_progress_delegates_to_terminal(self) -> None:
         """Test that on_progress delegates to terminal handler."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal)
 
         progress = ExecutionProgress(label="Test", reward=50)
         callback.on_progress(progress)
@@ -123,8 +178,8 @@ class TestEngineExecutionCallback(unittest.TestCase):
 
     def test_on_execution_error_extracts_context_from_buffer(self) -> None:
         """Test that on_execution_error extracts error context from buffer."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal, error_display_lines=3)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal, error_display_lines=3)
 
         # Add lines to buffer
         for i in range(10):
@@ -142,8 +197,8 @@ class TestEngineExecutionCallback(unittest.TestCase):
 
     def test_on_execution_error_handles_empty_buffer(self) -> None:
         """Test that on_execution_error handles empty buffer gracefully."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal)
 
         callback.on_execution_error(retcode=1)
 
@@ -154,8 +209,8 @@ class TestEngineExecutionCallback(unittest.TestCase):
 
     def test_on_execution_error_respects_error_display_lines_config(self) -> None:
         """Test that on_execution_error respects configured error_display_lines."""
-        mock_terminal = Mock(spec=TerminalHandler)
-        callback = ConcreteEngineCallback(terminal_handler=mock_terminal, buffer_size=100, error_display_lines=5)
+        mock_terminal = Mock(spec=DisplayManager)
+        callback = ConcreteEngineCallback(display_manager=mock_terminal, buffer_size=100, error_display_lines=5)
 
         # Add 20 lines to buffer
         for i in range(20):
@@ -175,31 +230,31 @@ class TestNoopExecutionCallback(unittest.TestCase):
 
     def test_should_parse_progress_returns_false(self) -> None:
         """Test that should_parse_progress returns False for NoopExecutionCallback."""
-        callback = ConcreteNoopCallback()
+        callback = ConcreteNoopCallback(NullDisplay())
         self.assertFalse(callback.should_parse_progress())
 
     def test_is_waiting_for_interaction_returns_false(self) -> None:
         """Test that is_waiting_for_interaction always returns False for NoopExecutionCallback."""
-        callback = ConcreteNoopCallback()
+        callback = ConcreteNoopCallback(NullDisplay())
         self.assertFalse(callback.is_waiting_for_interaction())
 
     def test_is_requesting_user_input_is_abstract(self) -> None:
         """Test that is_requesting_user_input must be implemented by subclasses."""
         # ConcreteNoopCallback provides a test implementation that returns False
-        callback = ConcreteNoopCallback()
+        callback = ConcreteNoopCallback(NullDisplay())
         self.assertFalse(callback.is_requesting_user_input("PROMPT:"))
         self.assertFalse(callback.is_requesting_user_input("Enter a value:"))
         self.assertFalse(callback.is_requesting_user_input("Some random text"))
 
     def test_handle_interaction_is_noop(self) -> None:
         """Test that handle_interaction does nothing."""
-        callback = ConcreteNoopCallback()
+        callback = ConcreteNoopCallback(NullDisplay())
         # Should not raise any errors
         callback.handle_interaction("Test line")
 
-    def test_on_log_line_prints_to_stdout(self) -> None:
-        """Test that on_log_line prints to stdout in NoopExecutionCallback."""
-        callback = ConcreteNoopCallback()
+    def test_on_log_line_delegates_to_display_manager(self) -> None:
+        """Test that on_log_line delegates to display manager."""
+        callback = ConcreteNoopCallback(MockPassThroughDisplay())
 
         # Capture stdout
         captured_output = io.StringIO()
@@ -215,13 +270,13 @@ class TestNoopExecutionCallback(unittest.TestCase):
 
     def test_on_progress_is_noop(self) -> None:
         """Test that on_progress does nothing."""
-        callback = ConcreteNoopCallback()
+        callback = ConcreteNoopCallback(NullDisplay())
         progress = ExecutionProgress(label="Test", reward=50)
         # Should not raise any errors
         callback.on_progress(progress)
 
     def test_on_execution_error_is_noop(self) -> None:
         """Test that on_execution_error does nothing."""
-        callback = ConcreteNoopCallback()
+        callback = ConcreteNoopCallback(NullDisplay())
         # Should not raise any errors
         callback.on_execution_error(retcode=1)

--- a/libs/jupyter-deploy/tests/unit/handlers/access/test_organization_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/access/test_organization_handler.py
@@ -1,10 +1,11 @@
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import yaml
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.handlers.access.organization_handler import OrganizationHandler
 from jupyter_deploy.manifest import JupyterDeployManifest, JupyterDeployManifestV1
 from jupyter_deploy.provider.resolved_clidefs import StrResolvedCliParameter
@@ -82,12 +83,12 @@ class TestOrganizationHandler(unittest.TestCase):
         mock_variable_handler = Mock()
         mock_tf_variables_handler.return_value = mock_variable_handler
 
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
 
         mock_retrieve_manifest.assert_called_once()
         mock_tf_outputs_handler.assert_called_once_with(project_path=path, project_manifest=mock_manifest)
         mock_tf_variables_handler.assert_called_once_with(
-            project_path=path, project_manifest=mock_manifest, terminal_handler=None
+            project_path=path, project_manifest=mock_manifest, display_manager=ANY
         )
         self.assertEqual(handler._output_handler, mock_output_handler)
         self.assertEqual(handler._variable_handler, mock_variable_handler)
@@ -114,7 +115,7 @@ class TestOrganizationHandler(unittest.TestCase):
             }
         )
         mock_retrieve_manifest.return_value = no_cmd_manifest
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
 
         with self.assertRaises(NotImplementedError):
             handler.set_organization("org-name")
@@ -141,7 +142,7 @@ class TestOrganizationHandler(unittest.TestCase):
         mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
         mock_tf_variables_handler.return_value = Mock()
 
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
 
         # verify methods work
         handler.set_organization("org-name")
@@ -172,7 +173,7 @@ class TestOrganizationHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["run_command_sequence"].side_effect = RuntimeError()
 
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
 
         # verify methods raise
         with self.assertRaises(RuntimeError):
@@ -204,7 +205,7 @@ class TestOrganizationHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["get_result_value"].side_effect = KeyError()
 
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
 
         # verify method raises
         # add only commands that return a result here
@@ -240,13 +241,13 @@ class TestOrganizationHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Execute
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
         handler.set_organization("org-name")
 
         # Verify
         mock_manifest_fns["get_command"].assert_called_once_with("organization.set")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -288,13 +289,13 @@ class TestOrganizationHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Execute
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
         handler.unset_organization()
 
         # Verify
         mock_manifest_fns["get_command"].assert_called_once_with("organization.unset")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -336,14 +337,14 @@ class TestOrganizationHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value"].return_value = "org-name"
 
         # Execute
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
         result = handler.get_organization()
 
         # Verify
         self.assertEqual(result, "org-name")
         mock_manifest_fns["get_command"].assert_called_once_with("organization.get")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -386,7 +387,7 @@ class TestOrganizationHandler(unittest.TestCase):
         mock_cmd_runner_fns["run_command_sequence"].return_value = (False, {})
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
-        handler = OrganizationHandler()
+        handler = OrganizationHandler(display_manager=NullDisplay())
 
         # Test set_organization
         handler.set_organization("org-name")

--- a/libs/jupyter-deploy/tests/unit/handlers/access/test_team_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/access/test_team_handler.py
@@ -1,10 +1,11 @@
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import yaml
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.handlers.access.team_handler import TeamsHandler
 from jupyter_deploy.manifest import JupyterDeployManifest, JupyterDeployManifestV1
 from jupyter_deploy.provider.resolved_clidefs import StrResolvedCliParameter
@@ -82,12 +83,12 @@ class TestTeamsHandler(unittest.TestCase):
         mock_variable_handler = Mock()
         mock_tf_variables_handler.return_value = mock_variable_handler
 
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
 
         mock_retrieve_manifest.assert_called_once()
         mock_tf_outputs_handler.assert_called_once_with(project_path=path, project_manifest=mock_manifest)
         mock_tf_variables_handler.assert_called_once_with(
-            project_path=path, project_manifest=mock_manifest, terminal_handler=None
+            project_path=path, project_manifest=mock_manifest, display_manager=ANY
         )
         self.assertEqual(handler._output_handler, mock_output_handler)
         self.assertEqual(handler._variable_handler, mock_variable_handler)
@@ -114,7 +115,7 @@ class TestTeamsHandler(unittest.TestCase):
             }
         )
         mock_retrieve_manifest.return_value = no_cmd_manifest
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
 
         with self.assertRaises(NotImplementedError):
             handler.add_teams(["team1", "team2"])
@@ -144,7 +145,7 @@ class TestTeamsHandler(unittest.TestCase):
         mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
         mock_tf_variables_handler.return_value = Mock()
 
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
 
         # verify methods work
         handler.add_teams(["team1", "team2"])
@@ -176,7 +177,7 @@ class TestTeamsHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["run_command_sequence"].side_effect = RuntimeError()
 
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
 
         # verify methods raise
         with self.assertRaises(RuntimeError):
@@ -210,7 +211,7 @@ class TestTeamsHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["get_result_value"].side_effect = KeyError()
 
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
 
         # verify methods raise
         # add only commands that return a result here
@@ -246,13 +247,13 @@ class TestTeamsHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Execute
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
         handler.add_teams(["team1", "team2"])
 
         # Verify
         mock_manifest_fns["get_command"].assert_called_once_with("teams.add")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -295,13 +296,13 @@ class TestTeamsHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Execute
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
         handler.remove_teams(["team1", "team2"])
 
         # Verify
         mock_manifest_fns["get_command"].assert_called_once_with("teams.remove")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -344,13 +345,13 @@ class TestTeamsHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Execute
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
         handler.set_teams(["team1", "team2"])
 
         # Verify
         mock_manifest_fns["get_command"].assert_called_once_with("teams.set")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -394,14 +395,14 @@ class TestTeamsHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value"].return_value = ["team1", "team2", "team3"]
 
         # Execute
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
         result = handler.list_teams()
 
         # Verify
         self.assertEqual(result, ["team1", "team2", "team3"])
         mock_manifest_fns["get_command"].assert_called_once_with("teams.list")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -444,7 +445,7 @@ class TestTeamsHandler(unittest.TestCase):
         mock_cmd_runner_fns["run_command_sequence"].return_value = (False, {})
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
-        handler = TeamsHandler()
+        handler = TeamsHandler(display_manager=NullDisplay())
 
         # Test add_teams
         handler.add_teams(["team1", "team2"])

--- a/libs/jupyter-deploy/tests/unit/handlers/access/test_user_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/access/test_user_handler.py
@@ -1,10 +1,11 @@
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import yaml
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.handlers.access.user_handler import UsersHandler
 from jupyter_deploy.manifest import JupyterDeployManifest, JupyterDeployManifestV1
 from jupyter_deploy.provider.resolved_clidefs import StrResolvedCliParameter
@@ -82,12 +83,12 @@ class TestUsersHandler(unittest.TestCase):
         mock_variable_handler = Mock()
         mock_tf_variables_handler.return_value = mock_variable_handler
 
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
 
         mock_retrieve_manifest.assert_called_once()
         mock_tf_outputs_handler.assert_called_once_with(project_path=path, project_manifest=mock_manifest)
         mock_tf_variables_handler.assert_called_once_with(
-            project_path=path, project_manifest=mock_manifest, terminal_handler=None
+            project_path=path, project_manifest=mock_manifest, display_manager=ANY
         )
         self.assertEqual(handler._output_handler, mock_output_handler)
         self.assertEqual(handler.engine, EngineType.TERRAFORM)
@@ -113,7 +114,7 @@ class TestUsersHandler(unittest.TestCase):
             }
         )
         mock_retrieve_manifest.return_value = no_cmd_manifest
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
 
         with self.assertRaises(NotImplementedError):
             handler.add_users(["user1", "user2"])
@@ -143,7 +144,7 @@ class TestUsersHandler(unittest.TestCase):
         mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
         mock_tf_variables_handler.return_value = Mock()
 
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
 
         # verify methods work
         handler.add_users(["user1", "user2"])
@@ -175,7 +176,7 @@ class TestUsersHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["run_command_sequence"].side_effect = RuntimeError()
 
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
 
         # verify methods raise
         with self.assertRaises(RuntimeError):
@@ -209,7 +210,7 @@ class TestUsersHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["get_result_value"].side_effect = KeyError()
 
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
 
         # verify methods raise
         # add only commands that return a result here
@@ -245,13 +246,13 @@ class TestUsersHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Execute
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
         handler.add_users(["user1", "user2"])
 
         # Verify
         mock_manifest_fns["get_command"].assert_called_once_with("users.add")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -294,13 +295,13 @@ class TestUsersHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Execute
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
         handler.remove_users(["user1", "user2"])
 
         # Verify
         mock_manifest_fns["get_command"].assert_called_once_with("users.remove")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -343,13 +344,13 @@ class TestUsersHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Execute
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
         handler.set_users(["user1", "user2"])
 
         # Verify
         mock_manifest_fns["get_command"].assert_called_once_with("users.set")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -393,14 +394,14 @@ class TestUsersHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value"].return_value = ["user1", "user2", "user3"]
 
         # Execute
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
         result = handler.list_users()
 
         # Verify
         self.assertEqual(result, ["user1", "user2", "user3"])
         mock_manifest_fns["get_command"].assert_called_once_with("users.list")
         mock_cmd_runner_class.assert_called_once_with(
-            terminal_handler=None,
+            display_manager=ANY,
             output_handler=mock_output_handler,
             variable_handler=mock_variable_handler,
         )
@@ -443,7 +444,7 @@ class TestUsersHandler(unittest.TestCase):
         mock_cmd_runner_fns["run_command_sequence"].return_value = (False, {})
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
-        handler = UsersHandler()
+        handler = UsersHandler(display_manager=NullDisplay())
 
         # Test add_users
         handler.add_users(["user1", "user2"])

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_config_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_config_handler.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import ANY, Mock, patch
 
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.exceptions import InvalidPresetError
 from jupyter_deploy.handlers.project.config_handler import ConfigHandler
 from jupyter_deploy.manifest import JupyterDeployManifestV1
@@ -61,7 +62,7 @@ class TestConfigHandler(unittest.TestCase):
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     def test_config_handler_reads_the_manifest(self, mock_retrieve_manifest: Mock) -> None:
         mock_retrieve_manifest.return_value = self.mock_manifest
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         mock_retrieve_manifest.assert_called_once()
         self.assertEqual(handler.project_manifest, self.mock_manifest)
         self.assertEqual(handler.engine, self.mock_manifest.get_engine())
@@ -78,7 +79,7 @@ class TestConfigHandler(unittest.TestCase):
 
         # right now, it defaults to terraform
         # in the future, it should infer it from the project
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
 
         tf_mock_handler_instance, tf_fns = self.get_mock_handler_and_fns()
         tf_mock_configure = tf_fns["configure"]
@@ -90,7 +91,7 @@ class TestConfigHandler(unittest.TestCase):
             project_manifest=self.mock_manifest,
             command_history_handler=ANY,
             output_filename=None,
-            terminal_handler=None,
+            display_manager=ANY,
         )
         tf_mock_configure.assert_not_called()
 
@@ -105,7 +106,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_has_recorded.return_value = True
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         result = handler.has_recorded_variables()
 
         self.assertTrue(result)
@@ -122,7 +123,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_verify_preset.return_value = True
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         result = handler.verify_preset_exists("all")
 
         self.assertTrue(result)
@@ -137,7 +138,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_list_presets.return_value = ["all", "base", "none"]
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         result = handler.list_presets()
 
         self.assertEqual(result, ["all", "base", "none"])
@@ -150,7 +151,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_handler_instance, _ = self.get_mock_handler_and_fns()
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         self.assertIsNone(handler.preset_name)
 
         handler.set_preset("all")
@@ -170,7 +171,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_verify_preset.return_value = True
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         # Should not raise
         handler.validate_preset("all")
         tf_mock_verify_preset.assert_called_once_with("all")
@@ -188,7 +189,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_list_presets.return_value = ["all", "base", "none"]
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         with self.assertRaises(InvalidPresetError) as context:
             handler.validate_preset("invalid")
 
@@ -212,7 +213,7 @@ class TestConfigHandler(unittest.TestCase):
             tf_mock_configure = tf_fns["configure"]
             mock_tf_handler.return_value = tf_mock_handler_instance
 
-            handler = ConfigHandler()
+            handler = ConfigHandler(display_manager=NullDisplay())
             handler.verify_requirements()
 
             mock_verify.assert_called_once_with([mock_req1, mock_req2])
@@ -229,7 +230,7 @@ class TestConfigHandler(unittest.TestCase):
         mock_tf_handler.return_value = tf_mock_handler_instance
         mock_verify.side_effect = ToolRequiredError("terraform", None, None)
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         with self.assertRaises(ToolRequiredError):
             handler.verify_requirements()
 
@@ -239,14 +240,14 @@ class TestConfigHandler(unittest.TestCase):
         self, mock_tf_handler: Mock, mock_retrieve_manifest: Mock
     ) -> None:
         mock_retrieve_manifest.return_value = self.mock_manifest
-        ConfigHandler()
+        ConfigHandler(display_manager=NullDisplay())
 
         tf_mock_handler_instance, tf_fns = self.get_mock_handler_and_fns()
         tf_mock_reset_vars = tf_fns["reset_recorded_variables"]
         tf_mock_reset_secrets = tf_fns["reset_recorded_secrets"]
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         handler.reset_recorded_variables()
 
         tf_mock_reset_vars.assert_called_once()
@@ -263,7 +264,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_reset_secrets = tf_fns["reset_recorded_secrets"]
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         handler.reset_recorded_secrets()
 
         tf_mock_reset_vars.assert_not_called()
@@ -279,7 +280,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_configure = tf_fns["configure"]
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         result = handler.configure()
 
         self.assertTrue(result)
@@ -293,7 +294,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_configure = tf_fns["configure"]
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         handler.set_preset("all")
         result = handler.configure()
 
@@ -308,7 +309,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_configure = tf_fns["configure"]
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         handler.set_preset("all")
 
         overrides = {"var1": Mock()}
@@ -330,7 +331,7 @@ class TestConfigHandler(unittest.TestCase):
         error = RuntimeError("another-error")
         tf_mock_configure.side_effect = error
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
 
         with self.assertRaisesRegex(RuntimeError, "another-error"):
             handler.configure()
@@ -343,7 +344,7 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_record = tf_fns["record"]
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         handler.record()
         tf_mock_record.assert_called_once_with(record_vars=False, record_secrets=False)
 
@@ -368,6 +369,6 @@ class TestConfigHandler(unittest.TestCase):
         mock_tf_handler.return_value = tf_mock_handler_instance
         tf_mock_record.side_effect = RuntimeError("Cannot record!")
 
-        handler = ConfigHandler()
+        handler = ConfigHandler(display_manager=NullDisplay())
         with self.assertRaises(RuntimeError):
             handler.record(record_vars=True)

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_down_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_down_handler.py
@@ -19,7 +19,7 @@ class TestDownHandler(unittest.TestCase):
             }
         )
 
-    def get_mock_terminal_handler(self) -> Mock:
+    def get_mock_display_manager(self) -> Mock:
         """Return a mock terminal handler."""
         mock_handler = Mock()
         mock_handler.is_pass_through.return_value = False
@@ -35,41 +35,41 @@ class TestDownHandler(unittest.TestCase):
         mock_retrieve_manifest.return_value = self.mock_manifest
         mock_tf_handler = Mock()
         mock_tf_handler_cls.return_value = mock_tf_handler
-        mock_terminal_handler = self.get_mock_terminal_handler()
+        mock_display_manager = self.get_mock_display_manager()
 
-        handler = DownHandler(terminal_handler=mock_terminal_handler)
+        handler = DownHandler(display_manager=mock_display_manager)
 
         # Verify TerraformDownHandler was called with correct arguments
         call_args = mock_tf_handler_cls.call_args
         self.assertEqual(call_args.kwargs["project_path"], Path("/mock/cwd"))
         self.assertEqual(call_args.kwargs["project_manifest"], self.mock_manifest)
         self.assertIsNotNone(call_args.kwargs["command_history_handler"])
-        self.assertEqual(call_args.kwargs["terminal_handler"], mock_terminal_handler)
+        self.assertEqual(call_args.kwargs["display_manager"], mock_display_manager)
         self.assertEqual(handler._handler, mock_tf_handler)
 
     @patch("jupyter_deploy.engine.terraform.tf_down.TerraformDownHandler")
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("pathlib.Path.cwd")
-    def test_init_passes_terminal_handler_to_terraform_handler(
+    def test_init_passes_display_manager_to_terraform_handler(
         self, mock_cwd: Mock, mock_retrieve_manifest: Mock, mock_tf_handler_cls: Mock
     ) -> None:
-        """Test that a non-None terminal_handler is passed through to TerraformDownHandler."""
+        """Test that a non-None display_manager is passed through to TerraformDownHandler."""
         mock_cwd.return_value = Path("/mock/cwd")
         mock_retrieve_manifest.return_value = self.mock_manifest
         mock_tf_handler = Mock()
         mock_tf_handler_cls.return_value = mock_tf_handler
 
         # Create a mock terminal handler
-        mock_terminal_handler = Mock()
+        mock_display_manager = Mock()
 
-        handler = DownHandler(terminal_handler=mock_terminal_handler)
+        handler = DownHandler(display_manager=mock_display_manager)
 
-        # Verify TerraformDownHandler was called with the terminal_handler
+        # Verify TerraformDownHandler was called with the display_manager
         call_args = mock_tf_handler_cls.call_args
         self.assertEqual(call_args.kwargs["project_path"], Path("/mock/cwd"))
         self.assertEqual(call_args.kwargs["project_manifest"], self.mock_manifest)
         self.assertIsNotNone(call_args.kwargs["command_history_handler"])
-        self.assertEqual(call_args.kwargs["terminal_handler"], mock_terminal_handler)
+        self.assertEqual(call_args.kwargs["display_manager"], mock_display_manager)
         self.assertEqual(handler._handler, mock_tf_handler)
 
     @patch("jupyter_deploy.engine.terraform.tf_down.TerraformDownHandler")
@@ -84,7 +84,7 @@ class TestDownHandler(unittest.TestCase):
         mock_tf_handler.destroy.return_value = True
         mock_tf_handler_cls.return_value = mock_tf_handler
 
-        handler = DownHandler(terminal_handler=self.get_mock_terminal_handler())
+        handler = DownHandler(display_manager=self.get_mock_display_manager())
         handler.destroy()
 
         mock_tf_handler.destroy.assert_called_once()
@@ -101,7 +101,7 @@ class TestDownHandler(unittest.TestCase):
         mock_tf_handler.destroy.side_effect = Exception("Destroy failed")
         mock_tf_handler_cls.return_value = mock_tf_handler
 
-        handler = DownHandler(terminal_handler=self.get_mock_terminal_handler())
+        handler = DownHandler(display_manager=self.get_mock_display_manager())
 
         with self.assertRaises(Exception) as context:
             handler.destroy()
@@ -120,7 +120,7 @@ class TestDownHandler(unittest.TestCase):
         mock_tf_handler = Mock()
         mock_tf_handler_cls.return_value = mock_tf_handler
 
-        handler = DownHandler(terminal_handler=self.get_mock_terminal_handler())
+        handler = DownHandler(display_manager=self.get_mock_display_manager())
         handler.destroy(True)
 
         mock_tf_handler.destroy.assert_called_once_with(True)
@@ -134,4 +134,4 @@ class TestDownHandler(unittest.TestCase):
         mock_retrieve_manifest.return_value = mock_manifest
 
         with self.assertRaises(ValueError):
-            DownHandler(terminal_handler=self.get_mock_terminal_handler())
+            DownHandler(display_manager=self.get_mock_display_manager())

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_up_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_up_handler.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.handlers.project.up_handler import UpHandler
 from jupyter_deploy.manifest import JupyterDeployManifestV1
 
@@ -31,23 +32,23 @@ class TestUpHandler(unittest.TestCase):
         mock_tf_handler_cls.return_value = mock_tf_handler
         mock_tf_handler.engine_dir_path = Path("/mock/cwd/engine")
 
-        handler = UpHandler()
+        handler = UpHandler(display_manager=NullDisplay())
 
         # Verify TerraformUpHandler was called with correct arguments
         call_args = mock_tf_handler_cls.call_args
         self.assertEqual(call_args.kwargs["project_path"], Path("/mock/cwd"))
         self.assertEqual(call_args.kwargs["project_manifest"], self.mock_manifest)
         self.assertIsNotNone(call_args.kwargs["command_history_handler"])
-        self.assertIsNone(call_args.kwargs["terminal_handler"])
+        self.assertIsInstance(call_args.kwargs["display_manager"], NullDisplay)
         self.assertEqual(handler._handler, mock_tf_handler)
 
     @patch("jupyter_deploy.engine.terraform.tf_up.TerraformUpHandler")
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("pathlib.Path.cwd")
-    def test_init_passes_terminal_handler_to_terraform_handler(
+    def test_init_passes_display_manager_to_terraform_handler(
         self, mock_cwd: Mock, mock_retrieve_manifest: Mock, mock_tf_handler_cls: Mock
     ) -> None:
-        """Test that a non-None terminal_handler is passed through to TerraformUpHandler."""
+        """Test that a non-None display_manager is passed through to TerraformUpHandler."""
         mock_cwd.return_value = Path("/mock/cwd")
         mock_retrieve_manifest.return_value = self.mock_manifest
         mock_tf_handler = Mock()
@@ -55,16 +56,16 @@ class TestUpHandler(unittest.TestCase):
         mock_tf_handler.engine_dir_path = Path("/mock/cwd/engine")
 
         # Create a mock terminal handler
-        mock_terminal_handler = Mock()
+        mock_display_manager = Mock()
 
-        handler = UpHandler(terminal_handler=mock_terminal_handler)
+        handler = UpHandler(display_manager=mock_display_manager)
 
-        # Verify TerraformUpHandler was called with the terminal_handler
+        # Verify TerraformUpHandler was called with the display_manager
         call_args = mock_tf_handler_cls.call_args
         self.assertEqual(call_args.kwargs["project_path"], Path("/mock/cwd"))
         self.assertEqual(call_args.kwargs["project_manifest"], self.mock_manifest)
         self.assertIsNotNone(call_args.kwargs["command_history_handler"])
-        self.assertEqual(call_args.kwargs["terminal_handler"], mock_terminal_handler)
+        self.assertEqual(call_args.kwargs["display_manager"], mock_display_manager)
         self.assertEqual(handler._handler, mock_tf_handler)
 
     @patch("jupyter_deploy.engine.terraform.tf_up.TerraformUpHandler")
@@ -80,7 +81,7 @@ class TestUpHandler(unittest.TestCase):
         mock_tf_handler_cls.return_value = mock_tf_handler
         mock_tf_handler.engine_dir_path = Path("/mock/cwd/engine")
 
-        handler = UpHandler()
+        handler = UpHandler(display_manager=NullDisplay())
         handler.apply(path, auto_approve=False)
 
         mock_tf_handler.apply.assert_called_once_with(path, False)
@@ -99,7 +100,7 @@ class TestUpHandler(unittest.TestCase):
         mock_tf_handler.engine_dir_path = Path("/mock/cwd/engine")
         mock_tf_handler_cls.return_value = mock_tf_handler
 
-        handler = UpHandler()
+        handler = UpHandler(display_manager=NullDisplay())
 
         with self.assertRaises(Exception) as context:
             handler.apply(path)
@@ -120,7 +121,7 @@ class TestUpHandler(unittest.TestCase):
         mock_tf_handler.get_default_config_filename.return_value = "jdout-tfplan"
         mock_tf_handler_cls.return_value = mock_tf_handler
 
-        handler = UpHandler()
+        handler = UpHandler(display_manager=NullDisplay())
         result = handler.get_default_config_filename()
 
         mock_tf_handler.get_default_config_filename.assert_called_once()
@@ -136,7 +137,7 @@ class TestUpHandler(unittest.TestCase):
         mock_retrieve_manifest.return_value = mock_manifest
 
         with self.assertRaises(ValueError):
-            UpHandler()
+            UpHandler(display_manager=NullDisplay())
 
     @patch("jupyter_deploy.engine.terraform.tf_up.TerraformUpHandler")
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
@@ -155,7 +156,7 @@ class TestUpHandler(unittest.TestCase):
         mock_tf_handler_cls.return_value = mock_tf_handler
 
         with patch.object(Path, "exists", return_value=True):
-            handler = UpHandler()
+            handler = UpHandler(display_manager=NullDisplay())
             result = handler.get_config_file_path("test-config")
 
         self.assertEqual(result, Path("/mock/cwd/engine/test-config"))
@@ -179,7 +180,7 @@ class TestUpHandler(unittest.TestCase):
         mock_tf_handler_cls.return_value = mock_tf_handler
 
         with patch.object(Path, "exists", return_value=False):
-            handler = UpHandler()
+            handler = UpHandler(display_manager=NullDisplay())
             with self.assertRaises(FileNotFoundError) as context:
                 handler.get_config_file_path("test-config")
 

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_variables_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_variables_handler.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.handlers.project.variables_handler import VariablesHandler
 
 
@@ -61,7 +62,10 @@ class TestVariablesHandler(unittest.TestCase):
 
         # Assert
         mock_manifest_fns["get_engine"].assert_called_once()
-        mock_tf_handler.assert_called_once_with(project_path=path, project_manifest=mock_manifest)
+        call_args = mock_tf_handler.call_args
+        self.assertEqual(call_args.kwargs["project_path"], path)
+        self.assertEqual(call_args.kwargs["project_manifest"], mock_manifest)
+        self.assertIsInstance(call_args.kwargs["display_manager"], NullDisplay)
         tf_fns["is_template_directory"].assert_not_called()
         tf_fns["get_template_variables"].assert_not_called()
 

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
@@ -1,11 +1,12 @@
 import unittest
 from pathlib import Path
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import yaml
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.handlers.resource.host_handler import HostHandler
 from jupyter_deploy.manifest import JupyterDeployManifest, JupyterDeployManifestV1
 
@@ -80,12 +81,12 @@ class TestHostHandler(unittest.TestCase):
         mock_manifest, _ = self.get_mock_manifest_and_fns()
         mock_retrieve_manifest.return_value = mock_manifest
 
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
 
         mock_retrieve_manifest.assert_called_once()
         mock_tf_outputs_handler.assert_called_once_with(project_path=path, project_manifest=mock_manifest)
         mock_tf_variables_handler.assert_called_once_with(
-            project_path=path, project_manifest=mock_manifest, terminal_handler=None
+            project_path=path, project_manifest=mock_manifest, display_manager=ANY
         )
 
         self.assertEqual(handler._output_handler, mock_output_handler)
@@ -114,7 +115,7 @@ class TestHostHandler(unittest.TestCase):
         )
         mock_retrieve_manifest.return_value = no_cmd_manifest
 
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
 
         with self.assertRaises(NotImplementedError):
             handler.get_host_status()
@@ -151,7 +152,7 @@ class TestHostHandler(unittest.TestCase):
         mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
         mock_tf_variables_handler.return_value = Mock()
 
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
 
         # Test get_host_status
         status = handler.get_host_status()
@@ -204,7 +205,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["run_command_sequence"].side_effect = RuntimeError()
 
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
 
         # verify methods raise
         with self.assertRaises(RuntimeError):
@@ -244,7 +245,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["get_result_value"].side_effect = KeyError()
 
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
 
         # verify methods raise
         # add only commands that return a result here
@@ -278,7 +279,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
         result = handler.get_host_status()
 
         # Verify
@@ -317,7 +318,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
         handler.start_host()
 
         # Verify
@@ -354,7 +355,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
         handler.stop_host()
 
         # Verify
@@ -391,7 +392,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
         handler.restart_host()
 
         # Verify
@@ -428,7 +429,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
         handler.connect()
 
         # Verify
@@ -469,7 +470,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 0
 
         # Act
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
         stdout, stderr, returncode = handler.exec_command(["echo", "hello"])
 
         # Verify
@@ -530,7 +531,7 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 127
 
         # Act
-        handler = HostHandler()
+        handler = HostHandler(display_manager=NullDisplay())
         stdout, stderr, returncode = handler.exec_command(["command_that_does_not_exist"])
 
         # Verify

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_server_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_server_handler.py
@@ -1,11 +1,12 @@
 import unittest
 from pathlib import Path
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 import yaml
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.handlers.resource.server_handler import ServerHandler
 from jupyter_deploy.manifest import JupyterDeployManifest, JupyterDeployManifestV1
 
@@ -87,12 +88,12 @@ class TestServerHandler(unittest.TestCase):
         mock_manifest, _ = self.get_mock_manifest_and_fns()
         mock_retrieve_manifest.return_value = mock_manifest
 
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
 
         mock_retrieve_manifest.assert_called_once()
         mock_tf_outputs_handler.assert_called_once_with(project_path=path, project_manifest=mock_manifest)
         mock_tf_variables_handler.assert_called_once_with(
-            project_path=path, project_manifest=mock_manifest, terminal_handler=None
+            project_path=path, project_manifest=mock_manifest, display_manager=ANY
         )
 
         self.assertEqual(handler._output_handler, mock_output_handler)
@@ -121,7 +122,7 @@ class TestServerHandler(unittest.TestCase):
         )
         mock_retrieve_manifest.return_value = no_cmd_manifest
 
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
 
         with self.assertRaises(NotImplementedError):
             handler.get_server_status()
@@ -158,7 +159,7 @@ class TestServerHandler(unittest.TestCase):
         mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
         mock_tf_variables_handler.return_value = Mock()
 
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
 
         # Test get_server_status
         status = handler.get_server_status()
@@ -216,7 +217,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["run_command_sequence"].side_effect = RuntimeError()
 
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
 
         # verify methods raise
         with self.assertRaises(RuntimeError):
@@ -256,7 +257,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
         mock_cmd_runner_fns["get_result_value"].side_effect = KeyError()
 
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
 
         # verify methods raise
         # add only commands that return a result here
@@ -290,7 +291,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
         result = handler.get_server_status()
 
         # Verify
@@ -330,7 +331,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
         handler.start_server("all")
 
         # Verify
@@ -378,7 +379,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
         handler.stop_server("jupyter")
 
         # Verify
@@ -426,7 +427,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
         handler.restart_server("sidecars")
 
         # Verify
@@ -475,7 +476,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
         logs, error_logs = handler.get_server_logs("oauth", ["-n", "200"])
 
         # Assert results
@@ -534,7 +535,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 0
 
         # Act
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
         stdout, stderr, returncode = handler.exec_command(service="jupyter", command_args=["whoami"])
 
         # Verify
@@ -603,7 +604,7 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 127
 
         # Act
-        handler = ServerHandler()
+        handler = ServerHandler(display_manager=NullDisplay())
         stdout, stderr, returncode = handler.exec_command(
             service="jupyter", command_args=["command_that_does_not_exist"]
         )

--- a/libs/jupyter-deploy/tests/unit/handlers/test_base_project_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_base_project_handler.py
@@ -7,6 +7,7 @@ from yaml.parser import ParserError
 
 from jupyter_deploy.constants import MANIFEST_FILENAME
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.exceptions import (
     InvalidManifestError,
     InvalidVariablesDotYamlError,
@@ -33,7 +34,7 @@ class TestBaseProjectHandler(unittest.TestCase):
         mock_retrieve.return_value = mock_manifest
 
         # Execute
-        handler = BaseProjectHandler()
+        handler = BaseProjectHandler(display_manager=NullDisplay())
 
         # Assert
         mock_retrieve.assert_called_once_with(Path("/fake/path/manifest.yaml"))
@@ -49,7 +50,7 @@ class TestBaseProjectHandler(unittest.TestCase):
 
         # Execute and Assert
         with self.assertRaises(ManifestNotFoundError):
-            BaseProjectHandler()
+            BaseProjectHandler(display_manager=NullDisplay())
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("pathlib.Path.cwd")
@@ -60,7 +61,7 @@ class TestBaseProjectHandler(unittest.TestCase):
 
         # Execute and Assert
         with self.assertRaises(InvalidManifestError):
-            BaseProjectHandler()
+            BaseProjectHandler(display_manager=NullDisplay())
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("pathlib.Path.cwd")
@@ -71,7 +72,7 @@ class TestBaseProjectHandler(unittest.TestCase):
 
         # Execute and Assert
         with self.assertRaises(InvalidManifestError):
-            BaseProjectHandler()
+            BaseProjectHandler(display_manager=NullDisplay())
 
 
 class TestRetrieveProjectManifestIfAvailable(unittest.TestCase):

--- a/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ec2_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ec2_runner.py
@@ -1,8 +1,9 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from jupyter_deploy.api.aws.ec2 import ec2_instance
 from jupyter_deploy.api.aws.ec2.ec2_instance import Ec2InstanceState
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.exceptions import IncompatibleHostStateError, InstructionNotFoundError
 from jupyter_deploy.provider.aws.aws_ec2_runner import AwsEc2Instruction, AwsEc2Runner
 from jupyter_deploy.provider.resolved_argdefs import ResolvedInstructionArgument, StrResolvedInstructionArgument
@@ -16,7 +17,7 @@ class TestAwsEc2Runner(unittest.TestCase):
         mock_boto3_client.return_value = mock_client
 
         # Execute
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Assert
         mock_boto3_client.assert_called_once_with("ec2", region_name="us-west-2")
@@ -24,13 +25,11 @@ class TestAwsEc2Runner(unittest.TestCase):
 
     def test_aws_ec2_raise_not_implemented_error_on_unmatched_instruction_name(self) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Execute & Assert
         with self.assertRaises(InstructionNotFoundError) as context:
-            runner.execute_instruction(
-                instruction_name="non-existent-instruction", resolved_arguments={}, terminal_handler=None
-            )
+            runner.execute_instruction(instruction_name="non-existent-instruction", resolved_arguments={})
 
         self.assertIn("non-existent-instruction", str(context.exception))
 
@@ -39,7 +38,7 @@ class TestDescribeInstanceStatus(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.describe_instance_status")
     def test_happy_path(self, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "running", "Code": 16}}
 
         # Prepare arguments
@@ -47,7 +46,7 @@ class TestDescribeInstanceStatus(unittest.TestCase):
         resolved_args: dict[str, ResolvedInstructionArgument] = {"instance_id": instance_id_arg}
 
         # Execute
-        result = runner._describe_instance_status(resolved_arguments=resolved_args, terminal_handler=None)
+        result = runner._describe_instance_status(resolved_arguments=resolved_args)
 
         # Assert
         mock_describe_instance_status.assert_called_once_with(runner.client, instance_id="i-123456789abcdef")
@@ -56,7 +55,7 @@ class TestDescribeInstanceStatus(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.describe_instance_status")
     def test_raises_when_describe_instance_status_raises(self, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
         mock_describe_instance_status.side_effect = ValueError("Instance not found")
 
         # Prepare arguments
@@ -65,7 +64,7 @@ class TestDescribeInstanceStatus(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(ValueError) as context:
-            runner._describe_instance_status(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._describe_instance_status(resolved_arguments=resolved_args)
 
         self.assertIn("Instance not found", str(context.exception))
         mock_describe_instance_status.assert_called_once()
@@ -76,7 +75,7 @@ class TestStartInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.start_instance")
     def test_happy_path_on_stopped_state(self, mock_start_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "stopped", "Code": 80}}
@@ -90,7 +89,7 @@ class TestStartInstance(unittest.TestCase):
         resolved_args: dict[str, ResolvedInstructionArgument] = {"instance_id": instance_id_arg}
 
         # Execute
-        result = runner._start_instance(resolved_arguments=resolved_args, terminal_handler=None)
+        result = runner._start_instance(resolved_arguments=resolved_args)
 
         # Assert
         mock_describe_instance_status.assert_called_once_with(runner.client, instance_id="i-123456789abcdef")
@@ -101,7 +100,7 @@ class TestStartInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.start_instance")
     def test_interrupt_on_pending_state(self, mock_start_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "pending", "Code": 0}}
@@ -112,7 +111,7 @@ class TestStartInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._start_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._start_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_start_instance.assert_not_called()
@@ -121,7 +120,7 @@ class TestStartInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.start_instance")
     def test_interrupt_on_running_state(self, mock_start_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "running", "Code": 16}}
@@ -132,7 +131,7 @@ class TestStartInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._start_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._start_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_start_instance.assert_not_called()
@@ -141,7 +140,7 @@ class TestStartInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.start_instance")
     def test_interrupt_on_stopping_state(self, mock_start_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "stopping", "Code": 64}}
@@ -152,7 +151,7 @@ class TestStartInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._start_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._start_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_start_instance.assert_not_called()
@@ -163,7 +162,7 @@ class TestStartInstance(unittest.TestCase):
         self, mock_start_instance: Mock, mock_describe_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "shutting-down", "Code": 32}}
@@ -174,7 +173,7 @@ class TestStartInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._start_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._start_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_start_instance.assert_not_called()
@@ -185,7 +184,7 @@ class TestStartInstance(unittest.TestCase):
         self, mock_start_instance: Mock, mock_describe_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "terminated", "Code": 48}}
@@ -196,7 +195,7 @@ class TestStartInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._start_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._start_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_start_instance.assert_not_called()
@@ -207,7 +206,7 @@ class TestStopInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.stop_instance")
     def test_happy_path_on_running_state(self, mock_stop_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "running", "Code": 16}}
@@ -221,7 +220,7 @@ class TestStopInstance(unittest.TestCase):
         resolved_args: dict[str, ResolvedInstructionArgument] = {"instance_id": instance_id_arg}
 
         # Execute
-        result = runner._stop_instance(resolved_arguments=resolved_args, terminal_handler=None)
+        result = runner._stop_instance(resolved_arguments=resolved_args)
 
         # Assert
         mock_describe_instance_status.assert_called_once_with(runner.client, instance_id="i-123456789abcdef")
@@ -232,7 +231,7 @@ class TestStopInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.stop_instance")
     def test_interrupt_on_pending_state(self, mock_stop_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "pending", "Code": 0}}
@@ -243,7 +242,7 @@ class TestStopInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._stop_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._stop_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_stop_instance.assert_not_called()
@@ -252,7 +251,7 @@ class TestStopInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.stop_instance")
     def test_interrupt_on_stopping_state(self, mock_stop_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "stopping", "Code": 64}}
@@ -263,7 +262,7 @@ class TestStopInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._stop_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._stop_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_stop_instance.assert_not_called()
@@ -272,7 +271,7 @@ class TestStopInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.stop_instance")
     def test_interrupt_on_stopped_state(self, mock_stop_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "stopped", "Code": 80}}
@@ -283,7 +282,7 @@ class TestStopInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._stop_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._stop_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_stop_instance.assert_not_called()
@@ -294,7 +293,7 @@ class TestStopInstance(unittest.TestCase):
         self, mock_stop_instance: Mock, mock_describe_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "shutting-down", "Code": 32}}
@@ -305,7 +304,7 @@ class TestStopInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._stop_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._stop_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_stop_instance.assert_not_called()
@@ -314,7 +313,7 @@ class TestStopInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.stop_instance")
     def test_interrupt_on_terminated_state(self, mock_stop_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "terminated", "Code": 48}}
@@ -325,7 +324,7 @@ class TestStopInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._stop_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._stop_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_stop_instance.assert_not_called()
@@ -338,7 +337,7 @@ class TestRebootInstance(unittest.TestCase):
         self, mock_restart_instance: Mock, mock_describe_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "running", "Code": 16}}
@@ -348,7 +347,7 @@ class TestRebootInstance(unittest.TestCase):
         resolved_args: dict[str, ResolvedInstructionArgument] = {"instance_id": instance_id_arg}
 
         # Execute
-        result = runner._reboot_instance(resolved_arguments=resolved_args, terminal_handler=None)
+        result = runner._reboot_instance(resolved_arguments=resolved_args)
 
         # Assert
         mock_describe_instance_status.assert_called_once_with(runner.client, instance_id="i-123456789abcdef")
@@ -359,7 +358,7 @@ class TestRebootInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.restart_instance")
     def test_interrupt_on_pending_state(self, mock_restart_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "pending", "Code": 0}}
@@ -370,7 +369,7 @@ class TestRebootInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._reboot_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._reboot_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_restart_instance.assert_not_called()
@@ -381,7 +380,7 @@ class TestRebootInstance(unittest.TestCase):
         self, mock_restart_instance: Mock, mock_describe_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "stopping", "Code": 64}}
@@ -392,7 +391,7 @@ class TestRebootInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._reboot_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._reboot_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_restart_instance.assert_not_called()
@@ -401,7 +400,7 @@ class TestRebootInstance(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.restart_instance")
     def test_interrupt_on_stopped_state(self, mock_restart_instance: Mock, mock_describe_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "stopped", "Code": 80}}
@@ -412,7 +411,7 @@ class TestRebootInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._reboot_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._reboot_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_restart_instance.assert_not_called()
@@ -423,7 +422,7 @@ class TestRebootInstance(unittest.TestCase):
         self, mock_restart_instance: Mock, mock_describe_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "shutting-down", "Code": 32}}
@@ -434,7 +433,7 @@ class TestRebootInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._reboot_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._reboot_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_restart_instance.assert_not_called()
@@ -445,7 +444,7 @@ class TestRebootInstance(unittest.TestCase):
         self, mock_restart_instance: Mock, mock_describe_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mocks
         mock_describe_instance_status.return_value = {"InstanceState": {"Name": "terminated", "Code": 48}}
@@ -456,7 +455,7 @@ class TestRebootInstance(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(IncompatibleHostStateError):
-            runner._reboot_instance(resolved_arguments=resolved_args, terminal_handler=None)
+            runner._reboot_instance(resolved_arguments=resolved_args)
 
         mock_describe_instance_status.assert_called_once()
         mock_restart_instance.assert_not_called()
@@ -466,7 +465,7 @@ class TestWaitForState(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.poll_for_instance_status")
     def test_happy_path(self, mock_poll_for_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mock
         mock_poll_for_instance_status.return_value = {"InstanceState": {"Name": "running", "Code": 16}}
@@ -476,14 +475,12 @@ class TestWaitForState(unittest.TestCase):
         resolved_args: dict[str, ResolvedInstructionArgument] = {"instance_id": instance_id_arg}
 
         # Execute
-        result = runner._wait_for_state(
-            resolved_arguments=resolved_args, terminal_handler=None, desired_state=Ec2InstanceState.RUNNING
-        )
+        result = runner._wait_for_state(resolved_arguments=resolved_args, desired_state=Ec2InstanceState.RUNNING)
 
         # Assert
         mock_poll_for_instance_status.assert_called_once_with(
             runner.client,
-            terminal_handler=None,
+            display_manager=ANY,
             instance_id="i-123456789abcdef",
             desired_state=Ec2InstanceState.RUNNING,
             timeout_seconds=60,  # default timeout
@@ -493,7 +490,7 @@ class TestWaitForState(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.poll_for_instance_status")
     def test_allows_timeout_override(self, mock_poll_for_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mock
         mock_poll_for_instance_status.return_value = {"InstanceState": {"Name": "stopped", "Code": 80}}
@@ -505,7 +502,6 @@ class TestWaitForState(unittest.TestCase):
         # Execute
         result = runner._wait_for_state(
             resolved_arguments=resolved_args,
-            terminal_handler=None,
             desired_state=Ec2InstanceState.STOPPED,
             timeout_seconds=120,  # custom timeout
         )
@@ -513,7 +509,7 @@ class TestWaitForState(unittest.TestCase):
         # Assert
         mock_poll_for_instance_status.assert_called_once_with(
             runner.client,
-            terminal_handler=None,
+            display_manager=ANY,
             instance_id="i-123456789abcdef",
             desired_state=Ec2InstanceState.STOPPED,
             timeout_seconds=120,  # custom timeout
@@ -523,7 +519,7 @@ class TestWaitForState(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ec2.ec2_instance.poll_for_instance_status")
     def test_raises_on_poll_raises(self, mock_poll_for_instance_status: Mock) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mock to raise an exception
         mock_poll_for_instance_status.side_effect = TimeoutError("Timed out waiting for instance")
@@ -534,9 +530,7 @@ class TestWaitForState(unittest.TestCase):
 
         # Execute & Assert
         with self.assertRaises(TimeoutError) as context:
-            runner._wait_for_state(
-                resolved_arguments=resolved_args, terminal_handler=None, desired_state=Ec2InstanceState.RUNNING
-            )
+            runner._wait_for_state(resolved_arguments=resolved_args, desired_state=Ec2InstanceState.RUNNING)
 
         self.assertIn("Timed out waiting for instance", str(context.exception))
         mock_poll_for_instance_status.assert_called_once()
@@ -545,7 +539,7 @@ class TestWaitForState(unittest.TestCase):
 class TestExecuteInstructions(unittest.TestCase):
     def test_all_instructions_implemented(self) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
         resolved_args: dict[str, ResolvedInstructionArgument] = {}
 
         # Create patch targets for all methods that would be called by execute_instruction
@@ -573,9 +567,7 @@ class TestExecuteInstructions(unittest.TestCase):
                 mocks = [p.start() for p in patches]
                 try:
                     # Execute
-                    runner.execute_instruction(
-                        instruction_name=instruction, resolved_arguments=resolved_args, terminal_handler=None
-                    )
+                    runner.execute_instruction(instruction_name=instruction, resolved_arguments=resolved_args)
 
                     # Assert the correct method was called
                     expected_mock = next(m for m in mocks if m._mock_name == method_name)
@@ -593,14 +585,12 @@ class TestExecuteInstructions(unittest.TestCase):
 
     def test_raise_not_implemented_error_on_unrecognized_instruction(self) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
         resolved_args: dict[str, ResolvedInstructionArgument] = {}
 
         # Execute & Assert
         with self.assertRaises(InstructionNotFoundError) as context:
-            runner.execute_instruction(
-                instruction_name="unknown-instruction", resolved_arguments=resolved_args, terminal_handler=None
-            )
+            runner.execute_instruction(instruction_name="unknown-instruction", resolved_arguments=resolved_args)
 
         self.assertIn("unknown-instruction", str(context.exception))
 
@@ -609,7 +599,7 @@ class TestExecuteInstructions(unittest.TestCase):
         self, mock_poll_for_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mock
         mock_poll_for_instance_status.return_value = {"InstanceState": {"Name": "running", "Code": 16}}
@@ -620,7 +610,7 @@ class TestExecuteInstructions(unittest.TestCase):
 
         # Execute
         runner.execute_instruction(
-            instruction_name=AwsEc2Instruction.WAIT_FOR_RUNNING, resolved_arguments=resolved_args, terminal_handler=None
+            instruction_name=AwsEc2Instruction.WAIT_FOR_RUNNING, resolved_arguments=resolved_args
         )
 
         # Assert that poll_for_instance_status was called with a timeout >= 60 seconds
@@ -642,7 +632,7 @@ class TestExecuteInstructions(unittest.TestCase):
         self, mock_poll_for_instance_status: Mock
     ) -> None:
         # Setup
-        runner = AwsEc2Runner(region_name="us-west-2")
+        runner = AwsEc2Runner(NullDisplay(), region_name="us-west-2")
 
         # Configure mock
         mock_poll_for_instance_status.return_value = {"InstanceState": {"Name": "stopped", "Code": 80}}
@@ -653,7 +643,7 @@ class TestExecuteInstructions(unittest.TestCase):
 
         # Execute
         runner.execute_instruction(
-            instruction_name=AwsEc2Instruction.WAIT_FOR_STOPPED, resolved_arguments=resolved_args, terminal_handler=None
+            instruction_name=AwsEc2Instruction.WAIT_FOR_STOPPED, resolved_arguments=resolved_args
         )
 
         # Assert that poll_for_instance_status was called with a timeout >= 300 seconds (5 minutes)

--- a/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_runner.py
@@ -1,6 +1,7 @@
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.exceptions import InstructionNotFoundError
 from jupyter_deploy.provider.aws.aws_runner import AwsApiRunner, AwsService
 from jupyter_deploy.provider.resolved_argdefs import ResolvedInstructionArgument
@@ -9,12 +10,12 @@ from jupyter_deploy.provider.resolved_resultdefs import ResolvedInstructionResul
 
 class TestAwsApiRunner(unittest.TestCase):
     def test_init_no_region(self) -> None:
-        runner = AwsApiRunner(region_name=None)
+        runner = AwsApiRunner(NullDisplay(), region_name=None)
         self.assertIsNone(runner.region_name)
         self.assertEqual(runner.service_runners, {})
 
     def test_init_with_region(self) -> None:
-        runner = AwsApiRunner(region_name="us-west-2")
+        runner = AwsApiRunner(NullDisplay(), region_name="us-west-2")
         self.assertEqual(runner.region_name, "us-west-2")
         self.assertEqual(runner.service_runners, {})
 
@@ -27,18 +28,16 @@ class TestAwsApiRunner(unittest.TestCase):
         expected_result = {"result_key": Mock(spec=ResolvedInstructionResult)}
         mock_ssm_runner.execute_instruction.return_value = expected_result
 
-        runner = AwsApiRunner(region_name="us-west-2")
+        runner = AwsApiRunner(NullDisplay(), region_name="us-west-2")
         resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
 
         # Execute
-        result = runner.execute_instruction(
-            instruction_name="aws.ssm.command", resolved_arguments=resolved_args, terminal_handler=None
-        )
+        result = runner.execute_instruction(instruction_name="aws.ssm.command", resolved_arguments=resolved_args)
 
         # Assert
-        mock_ssm_runner_class.assert_called_once_with(region_name="us-west-2")
+        mock_ssm_runner_class.assert_called_once_with(ANY, region_name="us-west-2")
         mock_ssm_runner.execute_instruction.assert_called_once_with(
-            instruction_name="command", resolved_arguments=resolved_args, terminal_handler=None
+            instruction_name="command", resolved_arguments=resolved_args
         )
         self.assertEqual(result, expected_result)
 
@@ -51,18 +50,16 @@ class TestAwsApiRunner(unittest.TestCase):
         expected_result = {"result_key": Mock(spec=ResolvedInstructionResult)}
         mock_ec2_runner.execute_instruction.return_value = expected_result
 
-        runner = AwsApiRunner(region_name="us-west-2")
+        runner = AwsApiRunner(NullDisplay(), region_name="us-west-2")
         resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
 
         # Execute
-        result = runner.execute_instruction(
-            instruction_name="aws.ec2.start-instance", resolved_arguments=resolved_args, terminal_handler=None
-        )
+        result = runner.execute_instruction(instruction_name="aws.ec2.start-instance", resolved_arguments=resolved_args)
 
         # Assert
-        mock_ec2_runner_class.assert_called_once_with(region_name="us-west-2")
+        mock_ec2_runner_class.assert_called_once_with(ANY, region_name="us-west-2")
         mock_ec2_runner.execute_instruction.assert_called_once_with(
-            instruction_name="start-instance", resolved_arguments=resolved_args, terminal_handler=None
+            instruction_name="start-instance", resolved_arguments=resolved_args
         )
         self.assertEqual(result, expected_result)
 
@@ -72,21 +69,17 @@ class TestAwsApiRunner(unittest.TestCase):
         mock_ssm_runner = Mock()
         mock_ssm_runner_class.return_value = mock_ssm_runner
 
-        runner = AwsApiRunner(region_name="us-west-2")
+        runner = AwsApiRunner(NullDisplay(), region_name="us-west-2")
         resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
 
         # Execute first instruction
-        runner.execute_instruction(
-            instruction_name="aws.ssm.command1", resolved_arguments=resolved_args, terminal_handler=None
-        )
+        runner.execute_instruction(instruction_name="aws.ssm.command1", resolved_arguments=resolved_args)
 
         # Execute second instruction
-        runner.execute_instruction(
-            instruction_name="aws.ssm.command2", resolved_arguments=resolved_args, terminal_handler=None
-        )
+        runner.execute_instruction(instruction_name="aws.ssm.command2", resolved_arguments=resolved_args)
 
         # Assert
-        mock_ssm_runner_class.assert_called_once_with(region_name="us-west-2")
+        mock_ssm_runner_class.assert_called_once_with(ANY, region_name="us-west-2")
         self.assertEqual(mock_ssm_runner.execute_instruction.call_count, 2)
         self.assertEqual(len(runner.service_runners), 1)
         self.assertIn(AwsService.SSM, runner.service_runners)
@@ -94,20 +87,18 @@ class TestAwsApiRunner(unittest.TestCase):
 
     def test_execute_raise_not_implemented_error_on_unmatches_service(self) -> None:
         # Setup
-        runner = AwsApiRunner(region_name="us-west-2")
+        runner = AwsApiRunner(NullDisplay(), region_name="us-west-2")
         resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
 
         # Execute and Assert
         with self.assertRaises(InstructionNotFoundError) as context:
-            runner.execute_instruction(
-                instruction_name="aws.unknown-service.command", resolved_arguments=resolved_args, terminal_handler=None
-            )
+            runner.execute_instruction(instruction_name="aws.unknown-service.command", resolved_arguments=resolved_args)
 
         self.assertIn("unknown-service", str(context.exception))
 
     def test_execute_raise_value_error_on_invalid_instruction_name(self) -> None:
         # Setup
-        runner = AwsApiRunner(region_name="us-west-2")
+        runner = AwsApiRunner(NullDisplay(), region_name="us-west-2")
         resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
 
         # Test cases for invalid instruction names
@@ -124,8 +115,6 @@ class TestAwsApiRunner(unittest.TestCase):
             with self.subTest(invalid_instruction=invalid_instruction):
                 # Execute and Assert
                 with self.assertRaises(ValueError) as context:
-                    runner.execute_instruction(
-                        instruction_name=invalid_instruction, resolved_arguments=resolved_args, terminal_handler=None
-                    )
+                    runner.execute_instruction(instruction_name=invalid_instruction, resolved_arguments=resolved_args)
 
                 self.assertIn(invalid_instruction, str(context.exception))

--- a/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ssm_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ssm_runner.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.exceptions import (
     HostCommandInstructionError,
     InstructionNotFoundError,
@@ -27,7 +28,7 @@ class TestAwsSsmRunner(unittest.TestCase):
         region_name = "us-west-2"
 
         # Act
-        runner = AwsSsmRunner(region_name=region_name)
+        runner = AwsSsmRunner(NullDisplay(), region_name=region_name)
 
         # Assert
         mock_boto3_client.assert_called_once_with("ssm", region_name=region_name)
@@ -35,14 +36,12 @@ class TestAwsSsmRunner(unittest.TestCase):
 
     def test_aws_ssm_raise_not_implemented_error_on_unmatched_instruction_name(self) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         invalid_instruction = "invalid-instruction"
 
         # Act & Assert
         with self.assertRaises(InstructionNotFoundError) as context:
-            runner.execute_instruction(
-                instruction_name=invalid_instruction, resolved_arguments={}, terminal_handler=None
-            )
+            runner.execute_instruction(instruction_name=invalid_instruction, resolved_arguments={})
 
         self.assertIn(f"aws.ssm.{invalid_instruction}", str(context.exception))
 
@@ -51,7 +50,7 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ssm.ssm_session.describe_instance_information")
     def test_happy_case_calls_describe_return_true_no_console_print(self, mock_describe: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         # Setup mock to return online status
@@ -62,17 +61,17 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
         }
 
         # Act - should not raise
-        runner._verify_ec2_instance_accessible(instance_id, terminal_handler=None)
+        runner._verify_ec2_instance_accessible(instance_id)
 
         # Assert
         mock_describe.assert_called_once_with(runner.client, instance_id=instance_id)
-        # No terminal output when terminal_handler=None and silent_success=True (default)
+        # No terminal output when display_manager=NullDisplay() and silent_success=True (default)
 
     @patch("jupyter_deploy.api.aws.ssm.ssm_session.describe_instance_information")
     def test_happy_case_with_silent_success_false_print_something(self, mock_describe: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
-        terminal_handler = Mock()
+        display_manager = Mock()
+        runner = AwsSsmRunner(display_manager, region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         # Setup mock to return online status
@@ -83,18 +82,18 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
         }
 
         # Act - should not raise
-        runner._verify_ec2_instance_accessible(instance_id, terminal_handler, silent_success=False)
+        runner._verify_ec2_instance_accessible(instance_id, silent_success=False)
 
         # Assert
         mock_describe.assert_called_once_with(runner.client, instance_id=instance_id)
         # Terminal handler info should be called when silent_success=False
-        terminal_handler.info.assert_called_once()
-        self.assertIn(instance_id, terminal_handler.info.mock_calls[0][1][0])
+        display_manager.info.assert_called_once()
+        self.assertIn(instance_id, display_manager.info.mock_calls[0][1][0])
 
     @patch("jupyter_deploy.api.aws.ssm.ssm_session.describe_instance_information")
     def test_ping_status_connection_lost_raises_unreachable_host_error(self, mock_describe: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
         last_ping_date = "2023-01-01T00:00:00.000Z"
 
@@ -107,7 +106,7 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
 
         # Act & Assert - should raise UnreachableHostError
         with self.assertRaises(UnreachableHostError) as context:
-            runner._verify_ec2_instance_accessible(instance_id, terminal_handler=None)
+            runner._verify_ec2_instance_accessible(instance_id)
 
         # Verify error message contains relevant information
         self.assertIn(instance_id, str(context.exception))
@@ -116,7 +115,7 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ssm.ssm_session.describe_instance_information")
     def test_ping_status_inactive_raises_unreachable_host_error(self, mock_describe: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         # Setup mock to return Inactive status
@@ -127,7 +126,7 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
 
         # Act & Assert - should raise UnreachableHostError
         with self.assertRaises(UnreachableHostError) as context:
-            runner._verify_ec2_instance_accessible(instance_id, terminal_handler=None)
+            runner._verify_ec2_instance_accessible(instance_id)
 
         # Verify error message contains instance ID
         self.assertIn(instance_id, str(context.exception))
@@ -135,7 +134,7 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ssm.ssm_session.describe_instance_information")
     def test_missing_ping_status_raises_unreachable_host_error(self, mock_describe: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         # Setup mock to return unknown/empty status
@@ -146,7 +145,7 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
 
         # Act & Assert - should raise UnreachableHostError
         with self.assertRaises(UnreachableHostError) as context:
-            runner._verify_ec2_instance_accessible(instance_id, terminal_handler=None)
+            runner._verify_ec2_instance_accessible(instance_id)
 
         # Verify error message contains instance ID
         self.assertIn(instance_id, str(context.exception))
@@ -154,7 +153,7 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ssm.ssm_session.describe_instance_information")
     def test_bubbles_up_errors_from_api(self, mock_describe: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         # Setup mock to raise an exception
@@ -162,7 +161,7 @@ class TestVerifyEc2InstanceAccessible(unittest.TestCase):
 
         # Act & Assert
         with self.assertRaises(Exception) as context:
-            runner._verify_ec2_instance_accessible(instance_id, terminal_handler=None)
+            runner._verify_ec2_instance_accessible(instance_id)
 
         self.assertEqual(str(context.exception), "API Error")
 
@@ -174,7 +173,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
         self, mock_send_cmd: Mock, mock_verify: Mock
     ) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "some-doc-name"
         instance_id = "i-1234567890abcdef0"
 
@@ -196,12 +195,11 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
         # Verify that SSM agent connection was checked
-        mock_verify.assert_called_once_with(instance_id=instance_id, terminal_handler=None)
+        mock_verify.assert_called_once_with(instance_id=instance_id)
 
         # Update to include default timeout values
         mock_send_cmd.assert_called_once_with(
@@ -220,7 +218,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ssm.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     def test_execute_happy_path_with_parameters(self, mock_send_cmd: Mock, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
         instance_id = "i-1234567890abcdef0"
         commands = ["echo 'Hello World'", "ls -la"]
@@ -247,12 +245,11 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
         # Verify that SSM agent connection was checked
-        mock_verify.assert_called_once_with(instance_id=instance_id, terminal_handler=None)
+        mock_verify.assert_called_once_with(instance_id=instance_id)
 
         # Check that the parameters were passed correctly
         mock_send_cmd.assert_called_once()
@@ -275,7 +272,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ssm.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     def test_execute_happy_path_with_optional_args(self, mock_send_cmd: Mock, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
         instance_id = "i-1234567890abcdef0"
         # Custom timeout values
@@ -303,12 +300,11 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
         # Verify that SSM agent connection was checked
-        mock_verify.assert_called_once_with(instance_id=instance_id, terminal_handler=None)
+        mock_verify.assert_called_once_with(instance_id=instance_id)
 
         # Check that custom timeout values were used
         mock_send_cmd.assert_called_once_with(
@@ -326,7 +322,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ssm.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     def test_execute_cmd_fail_raises_instruction_error(self, mock_send_cmd: Mock, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
         instance_id = "i-1234567890abcdef0"
 
@@ -347,7 +343,6 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
         # Verify error message and attributes
@@ -359,7 +354,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
 
     def test_execute_raise_on_missing_or_invalid_type_instance_id(self) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
 
         # Case 1: Missing instance_id
@@ -372,7 +367,6 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments_missing,
-                terminal_handler=None,
             )
 
         self.assertIn("instance_id", str(context.exception))
@@ -390,12 +384,11 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments_invalid_type,
-                terminal_handler=None,
             )
 
     def test_execute_raise_on_missing_or_invalid_type_doc_name(self) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         # Case 1: Missing document_name
@@ -408,7 +401,6 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments_missing,
-                terminal_handler=None,
             )
 
         self.assertIn("document_name", str(context.exception))
@@ -424,14 +416,13 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments_invalid_type,
-                terminal_handler=None,
             )
 
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     @patch("jupyter_deploy.api.aws.ssm.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     def test_execute_raise_when_api_handler_raise(self, mock_send_cmd: Mock, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
         instance_id = "i-1234567890abcdef0"
 
@@ -450,12 +441,11 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
         self.assertEqual(str(context.exception), "API Error")
         # Verify that SSM agent connection was checked
-        mock_verify.assert_called_once_with(instance_id=instance_id, terminal_handler=None)
+        mock_verify.assert_called_once_with(instance_id=instance_id)
 
         mock_send_cmd.assert_called_once_with(
             runner.client,
@@ -468,7 +458,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_execute_raise_when_verification_fails(self, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
         instance_id = "i-1234567890abcdef0"
 
@@ -485,17 +475,16 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
         # Verify that SSM agent connection was checked
-        mock_verify.assert_called_once_with(instance_id=instance_id, terminal_handler=None)
+        mock_verify.assert_called_once_with(instance_id=instance_id)
 
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     @patch("jupyter_deploy.api.aws.ssm.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     def test_execute_includes_response_code_in_results(self, mock_send_cmd: Mock, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
         instance_id = "i-1234567890abcdef0"
 
@@ -515,7 +504,6 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
@@ -527,7 +515,7 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
     @patch("jupyter_deploy.api.aws.ssm.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     def test_execute_includes_non_zero_response_code(self, mock_send_cmd: Mock, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
         instance_id = "i-1234567890abcdef0"
 
@@ -549,14 +537,13 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     @patch("jupyter_deploy.api.aws.ssm.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     def test_execute_defaults_response_code_to_zero_when_missing(self, mock_send_cmd: Mock, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         document_name = "AWS-RunShellScript"
         instance_id = "i-1234567890abcdef0"
 
@@ -576,7 +563,6 @@ class TestSendCmdToOneInstanceAndWaitSync(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert - Should default to 0 when ResponseCode is missing
@@ -592,7 +578,7 @@ class TestStartSession(unittest.TestCase):
         self, mock_verify_tools: Mock, mock_verify_ec2: Mock, mock_run_cmd: Mock
     ) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         target_id = "i-1234567890abcdef0"
 
         # Mock successful verifications
@@ -610,13 +596,12 @@ class TestStartSession(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.START_SESSION,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
         # Verify that all required checks were performed
         mock_verify_tools.assert_called_once()
-        mock_verify_ec2.assert_called_once_with(instance_id=target_id, terminal_handler=None, silent_success=False)
+        mock_verify_ec2.assert_called_once_with(instance_id=target_id, silent_success=False)
 
         # Verify that the session command was executed with the correct target
         mock_run_cmd.assert_called_once()
@@ -630,7 +615,7 @@ class TestStartSession(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.verify_utils.verify_tools_installation")
     def test_stops_on_missing_tool_installations(self, mock_verify_tools: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         target_id = "i-1234567890abcdef0"
 
         # Mock failed tool verification
@@ -645,7 +630,6 @@ class TestStartSession(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.START_SESSION,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
         # Verify that the verification was called but no further processing happened
@@ -655,7 +639,7 @@ class TestStartSession(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.verify_utils.verify_tools_installation")
     def test_stops_on_ssm_agent_not_connected(self, mock_verify_tools: Mock, mock_verify_ec2: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         target_id = "i-1234567890abcdef0"
 
         # Mock successful tools verification but failed EC2 connection
@@ -670,12 +654,11 @@ class TestStartSession(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.START_SESSION,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
         # Verify that both verifications were called but no further processing
         mock_verify_tools.assert_called_once()
-        mock_verify_ec2.assert_called_once_with(instance_id=target_id, terminal_handler=None, silent_success=False)
+        mock_verify_ec2.assert_called_once_with(instance_id=target_id, silent_success=False)
 
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.cmd_utils.run_cmd_and_pipe_to_terminal")
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
@@ -684,7 +667,7 @@ class TestStartSession(unittest.TestCase):
         self, mock_verify_tools: Mock, mock_verify_ec2: Mock, mock_run_cmd: Mock
     ) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         target_id = "i-1234567890abcdef0"
 
         # Mock successful verifications
@@ -703,7 +686,6 @@ class TestStartSession(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.START_SESSION,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
         # Verify that session command was executed but detected the error
@@ -716,7 +698,7 @@ class TestStartSession(unittest.TestCase):
         self, mock_verify_tools: Mock, mock_verify_ec2: Mock, mock_run_cmd: Mock
     ) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         target_id = "i-1234567890abcdef0"
 
         # Mock successful verifications
@@ -735,7 +717,6 @@ class TestStartSession(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.START_SESSION,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
         # Verify that session command was executed but detected timeout
@@ -757,7 +738,7 @@ class TestExecuteInstructions(unittest.TestCase):
         mock_verify_ec2: Mock,
     ) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
 
         # Setup mocks for all possible instructions
         mock_verify_ec2.return_value = True
@@ -805,7 +786,7 @@ class TestExecuteInstructions(unittest.TestCase):
 
             # Each enum instruction should be implemented in the runner
             result = runner.execute_instruction(
-                instruction_name=instruction, resolved_arguments=base_resolved_arguments, terminal_handler=None
+                instruction_name=instruction, resolved_arguments=base_resolved_arguments
             )
 
             # Simple verification that the instruction was executed correctly
@@ -823,7 +804,7 @@ class TestExecuteInstructions(unittest.TestCase):
 
     def test_raise_not_implemented_error_on_unrecognized_instruction(self) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         invalid_instruction = "invalid-instruction"
 
         resolved_arguments: dict[str, ResolvedInstructionArgument] = {
@@ -834,7 +815,8 @@ class TestExecuteInstructions(unittest.TestCase):
         # Act & Assert
         with self.assertRaises(InstructionNotFoundError) as context:
             runner.execute_instruction(
-                instruction_name=invalid_instruction, resolved_arguments=resolved_arguments, terminal_handler=None
+                instruction_name=invalid_instruction,
+                resolved_arguments=resolved_arguments,
             )
 
         self.assertIn(f"aws.ssm.{invalid_instruction}", str(context.exception))
@@ -845,7 +827,7 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_uses_aws_run_shell_script_by_default(self, mock_verify: Mock, mock_send_cmd: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         mock_send_cmd.return_value = {
@@ -863,7 +845,6 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
@@ -881,7 +862,7 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_passes_commands_parameter(self, mock_verify: Mock, mock_send_cmd: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
         commands = ["df", "-h"]
 
@@ -900,7 +881,6 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
         runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
@@ -912,7 +892,7 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_returns_stdout_and_stderr(self, mock_verify: Mock, mock_send_cmd: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         mock_send_cmd.return_value = {
@@ -930,7 +910,6 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
@@ -942,7 +921,7 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_handles_failed_commands(self, mock_verify: Mock, mock_send_cmd: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         mock_send_cmd.return_value = {
@@ -963,7 +942,6 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
         # Verify error attributes contain stderr content
@@ -975,7 +953,7 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_raises_when_verification_fails(self, mock_verify: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         mock_verify.side_effect = UnreachableHostError(f"SSM agent on instance '{instance_id}' is not running")
@@ -990,16 +968,15 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
-        mock_verify.assert_called_once_with(instance_id=instance_id, terminal_handler=None)
+        mock_verify.assert_called_once_with(instance_id=instance_id)
 
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_includes_response_code_in_results(self, mock_verify: Mock, mock_send_cmd: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         mock_send_cmd.return_value = {
@@ -1018,7 +995,6 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert
@@ -1030,7 +1006,7 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_raises_instruction_error_on_failure(self, mock_verify: Mock, mock_send_cmd: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         # Simulate command failure with exit code 1
@@ -1051,14 +1027,13 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
             runner.execute_instruction(
                 instruction_name=AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC,
                 resolved_arguments=resolved_arguments,
-                terminal_handler=None,
             )
 
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.AwsSsmRunner._verify_ec2_instance_accessible")
     def test_defaults_response_code_to_zero_when_missing(self, mock_verify: Mock, mock_send_cmd: Mock) -> None:
         # Arrange
-        runner = AwsSsmRunner(region_name="us-west-2")
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
         instance_id = "i-1234567890abcdef0"
 
         # Simulate response without ResponseCode (backward compatibility)
@@ -1077,7 +1052,6 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
         result = runner.execute_instruction(
             instruction_name=AwsSsmInstruction.SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC,
             resolved_arguments=resolved_arguments,
-            terminal_handler=None,
         )
 
         # Assert - Should default to 0 when ResponseCode is missing

--- a/libs/jupyter-deploy/tests/unit/provider/test_instruction_runner_factory.py
+++ b/libs/jupyter-deploy/tests/unit/provider/test_instruction_runner_factory.py
@@ -3,10 +3,11 @@ import sys
 import unittest
 from collections.abc import Generator
 from contextlib import contextmanager
-from unittest.mock import Mock, patch
+from unittest.mock import ANY, Mock, patch
 
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
+from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.provider import instruction_runner_factory
 from jupyter_deploy.provider.enum import ProviderType
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
@@ -69,7 +70,9 @@ class TestInstructionRunnerFactory(unittest.TestCase):
             InstructionRunnerFactory = instruction_runner_factory.InstructionRunnerFactory
             InstructionRunnerFactory._provider_runner_map = {}
 
-            runner = InstructionRunnerFactory.get_provider_instruction_runner("aws", self.mock_outputs_handler)
+            runner = InstructionRunnerFactory.get_provider_instruction_runner(
+                "aws", self.mock_outputs_handler, NullDisplay()
+            )
 
             # Verify
             self.mock_get_declared_output_def.assert_called_once_with("aws_region", StrTemplateOutputDefinition)
@@ -78,7 +81,9 @@ class TestInstructionRunnerFactory(unittest.TestCase):
             self.assertEqual(
                 {ProviderType.AWS: self.mock_aws_api_runner}, InstructionRunnerFactory._provider_runner_map
             )
-            self.mock_aws_api_runner_cls.assert_called_once_with(region_name="us-west-2")
+            # Verify the runner was called with display_manager and region_name
+            # Note: ANY is used for display_manager since it's a NullDisplay() instance
+            self.mock_aws_api_runner_cls.assert_called_once_with(display_manager=ANY, region_name="us-west-2")
 
     def test_aws_provider_raises_if_output_provider_cannot_get_the_region(self) -> None:
         # Setup
@@ -91,7 +96,7 @@ class TestInstructionRunnerFactory(unittest.TestCase):
             InstructionRunnerFactory = instruction_runner_factory.InstructionRunnerFactory
             InstructionRunnerFactory._provider_runner_map = {}
 
-            InstructionRunnerFactory.get_provider_instruction_runner("aws", mock_outputs_handler)
+            InstructionRunnerFactory.get_provider_instruction_runner("aws", mock_outputs_handler, NullDisplay())
 
             self.assertEqual("Region not found", str(context.exception))
             self.mock_get_declared_output_def.assert_called_once_with("aws_region", StrTemplateOutputDefinition)
@@ -104,10 +109,14 @@ class TestInstructionRunnerFactory(unittest.TestCase):
             InstructionRunnerFactory._provider_runner_map = {}
 
             # First call
-            first_result = InstructionRunnerFactory.get_provider_instruction_runner("aws", self.mock_outputs_handler)
+            first_result = InstructionRunnerFactory.get_provider_instruction_runner(
+                "aws", self.mock_outputs_handler, NullDisplay()
+            )
 
             # Second call with same output handler
-            second_result = InstructionRunnerFactory.get_provider_instruction_runner("aws", self.mock_outputs_handler)
+            second_result = InstructionRunnerFactory.get_provider_instruction_runner(
+                "aws", self.mock_outputs_handler, NullDisplay()
+            )
 
             # Verify
             self.assertEqual(first_result, second_result)
@@ -129,10 +138,14 @@ class TestInstructionRunnerFactory(unittest.TestCase):
             InstructionRunnerFactory._provider_runner_map = {}
 
             # First call
-            first_result = InstructionRunnerFactory.get_provider_instruction_runner("aws", self.mock_outputs_handler)
+            first_result = InstructionRunnerFactory.get_provider_instruction_runner(
+                "aws", self.mock_outputs_handler, NullDisplay()
+            )
 
             # Second call with same output handler
-            second_result = InstructionRunnerFactory.get_provider_instruction_runner("aws", mock_outputs_handler2)
+            second_result = InstructionRunnerFactory.get_provider_instruction_runner(
+                "aws", mock_outputs_handler2, NullDisplay()
+            )
 
             # Verify
             self.assertEqual(first_result, second_result)
@@ -152,6 +165,6 @@ class TestInstructionRunnerFactory(unittest.TestCase):
             InstructionRunnerFactory = instruction_runner_factory.InstructionRunnerFactory
             InstructionRunnerFactory._provider_runner_map = {}
 
-            InstructionRunnerFactory.get_provider_instruction_runner("onpremises", mock_outputs_handler)
+            InstructionRunnerFactory.get_provider_instruction_runner("onpremises", mock_outputs_handler, NullDisplay())
             self.mock_aws_api_runner_cls.assert_not_called()
             self.mock_get_declared_output_def.assert_not_called()

--- a/libs/jupyter-deploy/tests/unit/provider/test_manifest_command_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/test_manifest_command_runner.py
@@ -120,7 +120,7 @@ class TestManifestCommandRunner(unittest.TestCase):
             return_value=mock_runner,
         ):
             runner = ManifestCommandRunner(
-                terminal_handler=console_mock,
+                display_manager=console_mock,
                 output_handler=output_handler_mock,
                 variable_handler=variable_handler_mock,
             )
@@ -135,11 +135,11 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
 
         # Assert
-        self.assertEqual(runner._terminal_handler, console_mock)
+        self.assertEqual(runner._display_manager, console_mock)
         self.assertEqual(runner._output_handler, output_handler_mock)
 
     @patch("jupyter_deploy.provider.manifest_command_runner.InstructionRunnerFactory.get_provider_instruction_runner")
@@ -166,7 +166,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
 
@@ -204,7 +204,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
 
@@ -259,7 +259,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
 
@@ -268,8 +268,12 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Assert
         # Verify that the factory was called with the correct API names
-        mock_get_provider_instruction_runner.assert_any_call("hr.questions.ask-nicely", output_handler_mock)
-        mock_get_provider_instruction_runner.assert_any_call("life.celebration.create-event", output_handler_mock)
+        mock_get_provider_instruction_runner.assert_any_call(
+            "hr.questions.ask-nicely", output_handler_mock, console_mock
+        )
+        mock_get_provider_instruction_runner.assert_any_call(
+            "life.celebration.create-event", output_handler_mock, console_mock
+        )
         self.assertEqual(mock_get_provider_instruction_runner.call_count, 2)
 
     @patch("jupyter_deploy.provider.manifest_command_runner.InstructionRunnerFactory.get_provider_instruction_runner")
@@ -291,7 +295,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
 
@@ -336,7 +340,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
 
@@ -388,7 +392,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
 
@@ -425,7 +429,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
 
@@ -466,7 +470,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
         self.assertTrue(success)
@@ -510,7 +514,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=variable_handler_mock
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=variable_handler_mock
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
         self.assertTrue(success)
@@ -548,7 +552,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=variable_handler_mock
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=variable_handler_mock
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
         self.assertTrue(success)
@@ -595,7 +599,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=variable_handler_mock
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=variable_handler_mock
         )
         success, results = runner.run_command_sequence(cmd, mock_cliparam_defs)
 
@@ -624,7 +628,7 @@ class TestManifestCommandRunner(unittest.TestCase):
 
         # Act & Assert - exception should bubble up
         runner = ManifestCommandRunner(
-            terminal_handler=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
+            display_manager=console_mock, output_handler=output_handler_mock, variable_handler=Mock()
         )
         with self.assertRaises(InstructionError):
             runner.run_command_sequence(cmd, mock_cliparam_defs)


### PR DESCRIPTION
This PR cleans up the separation between display and core logic.

It makes class names more consistent and intuitive, makes arguments more consistent, and update the `CLAUDE.md` with the architecture guidelines. 

Closes: #156

### User experience
- add a spinner for the last phase of `jd config` (saving the plan)
- no change otherwise

### Implementation
- rename `TerminalHandler` > `DisplayManager`: the previous name was misleading, the display is aimed to be more generic than a terminal (e.g. for future possible use cases where core method are called by a `fastapi` server for a UI)
- makes `DisplayManager` arguments mandatory rather than optional to remove a bunch of `if` guards
- add a no-op `NullDisplay` that is the equivalent of a `> /dev/null` (bins all the logs) - we can use it in the future for a `--quiet`/`-q` mode if needed.

### Testing
- tested a few commands manually
- ran full E2E tests

### Captures
**jd config**
https://github.com/user-attachments/assets/93dd7d98-c2c2-4e5b-a7c5-0c9d3ccbf950