### PR TITLE
fix: improve error handling

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -181,6 +181,9 @@ commands:
   - result-name: server.errors
     source: result
     source-key: '[0].StandardErrorContent'
+  - result-name: server.logs.returncode
+    source: result
+    source-key: '[0].ResponseCode'
 - cmd: server.exec
   sequence:
   - api-name: aws.ssm.wait-command-sync
@@ -236,21 +239,10 @@ commands:
     - api-attribute: action
       source: cli
       source-key: action
-  - api-name: aws.ssm.wait-command-sync
-    arguments:
-    - api-attribute: document_name
-      source: output
-      source-key: auth_check_document
-    - api-attribute: instance_id
-      source: output
-      source-key: instance_id
-    - api-attribute: category
-      source: cli
-      source-key: category
   updates:
   - variable-name: oauth_allowed_usernames
     source: result
-    source-key: '[1].StandardOutputContent'
+    source-key: '[0].StandardOutputContent'
     transform: comma-separated-str-to-list-str
 - cmd: users.remove
   sequence:
@@ -268,21 +260,10 @@ commands:
     - api-attribute: action
       source: cli
       source-key: action
-  - api-name: aws.ssm.wait-command-sync
-    arguments:
-    - api-attribute: document_name
-      source: output
-      source-key: auth_check_document
-    - api-attribute: instance_id
-      source: output
-      source-key: instance_id
-    - api-attribute: category
-      source: cli
-      source-key: category
   updates:
   - variable-name: oauth_allowed_usernames
     source: result
-    source-key: '[1].StandardOutputContent'
+    source-key: '[0].StandardOutputContent'
     transform: comma-separated-str-to-list-str
 - cmd: users.set
   sequence:
@@ -300,21 +281,10 @@ commands:
     - api-attribute: action
       source: cli
       source-key: action
-  - api-name: aws.ssm.wait-command-sync
-    arguments:
-    - api-attribute: document_name
-      source: output
-      source-key: auth_check_document
-    - api-attribute: instance_id
-      source: output
-      source-key: instance_id
-    - api-attribute: category
-      source: cli
-      source-key: category
   updates:
   - variable-name: oauth_allowed_usernames
     source: result
-    source-key: '[1].StandardOutputContent'
+    source-key: '[0].StandardOutputContent'
     transform: comma-separated-str-to-list-str
 - cmd: users.list
   sequence:
@@ -350,21 +320,10 @@ commands:
     - api-attribute: action
       source: cli
       source-key: action
-  - api-name: aws.ssm.wait-command-sync
-    arguments:
-    - api-attribute: document_name
-      source: output
-      source-key: auth_check_document
-    - api-attribute: instance_id
-      source: output
-      source-key: instance_id
-    - api-attribute: category
-      source: cli
-      source-key: category
   updates:
   - variable-name: oauth_allowed_teams
     source: result
-    source-key: '[1].StandardOutputContent'
+    source-key: '[0].StandardOutputContent'
     transform: comma-separated-str-to-list-str
 - cmd: teams.remove
   sequence:
@@ -382,21 +341,10 @@ commands:
     - api-attribute: action
       source: cli
       source-key: action
-  - api-name: aws.ssm.wait-command-sync
-    arguments:
-    - api-attribute: document_name
-      source: output
-      source-key: auth_check_document
-    - api-attribute: instance_id
-      source: output
-      source-key: instance_id
-    - api-attribute: category
-      source: cli
-      source-key: category
   updates:
   - variable-name: oauth_allowed_teams
     source: result
-    source-key: '[1].StandardOutputContent'
+    source-key: '[0].StandardOutputContent'
     transform: comma-separated-str-to-list-str
 - cmd: teams.set
   sequence:
@@ -414,21 +362,10 @@ commands:
     - api-attribute: action
       source: cli
       source-key: action
-  - api-name: aws.ssm.wait-command-sync
-    arguments:
-    - api-attribute: document_name
-      source: output
-      source-key: auth_check_document
-    - api-attribute: instance_id
-      source: output
-      source-key: instance_id
-    - api-attribute: category
-      source: cli
-      source-key: category
   updates:
   - variable-name: oauth_allowed_teams
     source: result
-    source-key: '[1].StandardOutputContent'
+    source-key: '[0].StandardOutputContent'
     transform: comma-separated-str-to-list-str
 - cmd: teams.list
   sequence:
@@ -461,21 +398,10 @@ commands:
     - api-attribute: organization
       source: cli
       source-key: organization
-  - api-name: aws.ssm.wait-command-sync
-    arguments:
-    - api-attribute: document_name
-      source: output
-      source-key: auth_check_document
-    - api-attribute: instance_id
-      source: output
-      source-key: instance_id
-    - api-attribute: category
-      source: cli
-      source-key: category
   updates:
   - variable-name: oauth_allowed_org
     source: result
-    source-key: '[1].StandardOutputContent'
+    source-key: '[0].StandardOutputContent'
 - cmd: organization.unset
   sequence:
   - api-name: aws.ssm.wait-command-sync
@@ -486,21 +412,10 @@ commands:
     - api-attribute: instance_id
       source: output
       source-key: instance_id
-  - api-name: aws.ssm.wait-command-sync
-    arguments:
-    - api-attribute: document_name
-      source: output
-      source-key: auth_check_document
-    - api-attribute: instance_id
-      source: output
-      source-key: instance_id
-    - api-attribute: category
-      source: cli
-      source-key: category
   updates:
   - variable-name: oauth_allowed_org
     source: result
-    source-key: '[1].StandardOutputContent'
+    source-key: '[0].StandardOutputContent'
 - cmd: organization.get
   sequence:
   - api-name: aws.ssm.wait-command-sync

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/get-auth.sh
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/get-auth.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Return code handling:
+# - Uses 'set -e' but should always succeed for valid inputs
+# - Exits 0 on success after outputting the requested entity list
+# - Exits non-zero (1) only if invalid entity type provided
+# - This is a query command: successfully retrieving the value (even if empty) exits 0
 set -e
 
 # Script to read the file containing the authorized GitHub entities (users, teams, orgs)

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/get-status.sh
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/get-status.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+# Return code handling:
+# - Uses 'set +e' (not 'set -e') to allow check-status-internal.sh to return semantic exit codes
+# - check-status-internal.sh returns codes like 0=IN_SERVICE, 10=INITIALIZING, 20=STOPPED, etc.
+# - This script maps those codes to status strings and always exits 0
+# - Exiting 0 is correct: successfully querying the status (even if status is bad) is not an error
+# - Would only exit non-zero if the query itself failed (e.g., permission denied)
 set +e
 
 sh /usr/local/bin/check-status-internal.sh >/dev/null

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/update-auth.sh
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/update-auth.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Return code handling:
+# - Uses 'set -e' to fail fast if any command fails
+# - If script exits non-zero, SSM marks the command as Failed
+# - CLI error handler catches HostCommandInstructionError and displays stdout/stderr
+# - Currently, jd exits with code 1 (generic error) regardless of the underlying exit code
 set -e
 
 # Script to update the file containing the list of authorized GitHub entities (users, teams, orgs)
@@ -266,8 +271,8 @@ sed -i "s/^AUTHED_USERS_CONTENT=.*/AUTHED_USERS_CONTENT=${AUTHED_USERS_CONTENT}/
 sed -i "s/^AUTHED_ORG_CONTENT=.*/AUTHED_ORG_CONTENT=${AUTHED_ORG_CONTENT}/" /opt/docker/.env
 sed -i "s/^AUTHED_TEAMS_CONTENT=.*/AUTHED_TEAMS_CONTENT=${AUTHED_TEAMS_CONTENT}/" /opt/docker/.env
 
-# The oauth sidecar vends cookies stored on user's webbrowser. 
-# Such cookies are opaque to the users, they are encrypted with a secret string. 
+# The oauth sidecar vends cookies stored on user's webbrowser.
+# Such cookies are opaque to the users, they are encrypted with a secret string.
 # When we remove a user from the allowlist, we need to invalidate the cookie/session immediately.
 # We update the cookie secret. Note that this action invalidates all sessions/cookies.
 if [ "$REFRESH_OAUTH_COOKIE" = true ]; then
@@ -279,9 +284,24 @@ fi
 if [ "$AUTH_CHANGED" = true ]; then
     log_message "Recreating OAuth container to apply changes..."
     cd /opt/docker
-    OUTPUT=$(docker compose up -d oauth 2>&1)
+    # Use --wait to ensure oauth container is ready before returning
+    # This prevents 404 errors from rapid successive auth mutations
+    OUTPUT=$(docker compose up -d oauth --wait --wait-timeout 30 2>&1)
     log_message "Docker compose output:"
     log_message "$OUTPUT"
+    log_message "OAuth container restart complete."
 else
     log_message "No changes detected, no need to restart oauth container."
+fi
+
+# Output the updated state for the modified entity type to stdout.
+# This is consumed by the manifest runner to update the corresponding terraform variable,
+# keeping terraform state in sync with the live system state.
+# The user does not see this output; they use the list/get commands to query state.
+if [ "$ENTITY_TYPE" == "org" ]; then
+    echo "$AUTHED_ORG_CONTENT"
+elif [ "$ENTITY_TYPE" == "users" ]; then
+    echo "$AUTHED_USERS_CONTENT"
+elif [ "$ENTITY_TYPE" == "teams" ]; then
+    echo "$AUTHED_TEAMS_CONTENT"
 fi

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/update-server.sh
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/update-server.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+# Return code handling:
+# - Uses 'set -e' to fail fast if any command fails
+# - If script exits non-zero, SSM marks the command as Failed
+# - CLI error handler catches HostCommandInstructionError and displays stdout/stderr
+# - Currently, jd exits with code 1 (generic error) regardless of the underlying exit code
 set -e
 
 # Script to control the Jupyter server container and related services

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-compose.yml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-compose.yml.tftpl
@@ -88,6 +88,12 @@ services:
         tag: "docker.oauth"
     depends_on:
       - fluent-bit
+    healthcheck:
+      test: ["CMD", "/bin/oauth2-proxy", "--version"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
     volumes:
       - ./static:/var/www/static:ro
     labels:

--- a/libs/jupyter-deploy/jupyter_deploy/api/aws/ssm/ssm_session.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/aws/ssm/ssm_session.py
@@ -1,15 +1,21 @@
 from mypy_boto3_ssm import SSMClient
 from mypy_boto3_ssm.type_defs import DescribeInstanceInformationRequestTypeDef, InstanceInformationTypeDef
 
+from jupyter_deploy.exceptions import UnreachableHostError
+
 
 def describe_instance_information(ssm_client: SSMClient, instance_id: str) -> InstanceInformationTypeDef:
-    """Call SSM:DescribeInstanceInformation, return the result."""
+    """Call SSM:DescribeInstanceInformation, return the result.
+
+    Raises:
+        UnreachableHostError: If the instance information is not available (instance stopped or SSM agent not running)
+    """
 
     request: DescribeInstanceInformationRequestTypeDef = {"Filters": [{"Key": "InstanceIds", "Values": [instance_id]}]}
     response = ssm_client.describe_instance_information(**request)
     information_list = response["InstanceInformationList"]
 
     if not information_list:
-        raise ValueError("SSM:DescribeInstanceInformation returned an empty list")
+        raise UnreachableHostError(f"Instance '{instance_id}' is not reporting to SSM")
 
     return information_list[0]

--- a/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
@@ -7,6 +7,7 @@ import typer
 from rich.console import Console
 
 from jupyter_deploy.exceptions import (
+    CommandNotImplementedError,
     ConfigurationError,
     DownAutoApproveRequiredError,
     HostCommandInstructionError,
@@ -19,6 +20,7 @@ from jupyter_deploy.exceptions import (
     InvalidManifestError,
     InvalidPresetError,
     InvalidProjectPathError,
+    InvalidProviderCredentialsError,
     InvalidServiceError,
     InvalidVariablesDotYamlError,
     JupyterDeployError,
@@ -27,6 +29,7 @@ from jupyter_deploy.exceptions import (
     ManifestNotFoundError,
     OpenWebBrowserError,
     OutputNotFoundError,
+    ProviderPermissionError,
     ReadConfigurationError,
     ReadManifestError,
     SupervisedExecutionError,
@@ -80,7 +83,25 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
     except InvalidManifestError as e:
         console.print(f":x: {e}", style="bold red")
         console.line()
-        console.print(":bulb: Check your manifest.yaml file for syntax errors or missing required fields")
+        console.print(":bulb: Review your manifest.yaml file for syntax errors or missing required fields")
+        raise typer.Exit(code=1) from None
+
+    except CommandNotImplementedError as e:
+        console.print(f":x: {e}", style="bold red")
+        raise typer.Exit(code=1) from None
+
+    except InvalidProviderCredentialsError as e:
+        console.print(f":x: {e}", style="bold red")
+        if e.original_message:
+            console.line()
+            console.print(e.original_message, style="dim")
+        raise typer.Exit(code=1) from None
+
+    except ProviderPermissionError as e:
+        console.print(f":x: {e}", style="bold red")
+        if e.original_message:
+            console.line()
+            console.print(e.original_message, style="dim")
         raise typer.Exit(code=1) from None
 
     except ToolRequiredError as e:
@@ -114,9 +135,14 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
 
     except (UnreachableHostError, IncompatibleHostStateError) as e:
         console.print(f":x: {e}", style="bold red")
+        console.line()
         if e.hint:
-            console.line()
+            # Use the specific hint if provided (e.g., from IncompatibleHostStateError)
             console.print(f":bulb: {e.hint}")
+        else:
+            # Generic hint for accessibility issues (e.g., UnreachableHostError with no hint)
+            console.print(":bulb: verify that your host is running: [bold cyan]jd host status[/]")
+            console.print(":wrench: or try restarting it: [bold cyan]jd host restart[/]")
         raise typer.Exit(code=1) from None
 
     except HostCommandInstructionError as e:
@@ -135,13 +161,13 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
     except InvalidVariablesDotYamlError as e:
         console.print(f":x: {e}", style="bold red")
         console.line()
-        console.print(":bulb: Check your variables.yaml file for syntax errors")
+        console.print(":bulb: Review your variables.yaml file for syntax errors")
         raise typer.Exit(code=1) from None
 
     except LogNotFoundError as e:
         console.print(f":x: {e}", style="bold red")
         console.line()
-        console.print(":bulb: Use [bold cyan]jd history list[/] to see available logs")
+        console.print(":bulb: To see available logs: [bold cyan]jd history list CMD[/]")
         raise typer.Exit(code=1) from None
 
     except (

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -168,7 +168,7 @@ def logs(
         handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Fetching logs..."):
-            logs, err_logs = handler.get_server_logs(service=service, extra=extra)
+            logs, err_logs, returncode = handler.get_server_logs(service=service, extra=extra)
 
         if logs:
             console.rule("stdout")
@@ -182,6 +182,13 @@ def logs(
             console.rule("stderr")
             console.print(err_logs)
             console.rule()
+
+        # Note: the command runner SHOULD raise a HostCommandInstructionError instead of returning
+        # a non-zero error code. Such HostCommandInstructionError would be caught and handled by
+        # the error context manager so that users do not see a long, unhelpful stack trace.
+        # However, just in case the instruction runner setup is incorrect, handle it here as well.
+        if returncode != 0:
+            raise typer.Exit(code=returncode)
 
 
 @servers_app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})

--- a/libs/jupyter-deploy/jupyter_deploy/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/enum.py
@@ -151,3 +151,22 @@ class JupyterDeployTool(str, Enum):
                 return source
 
         raise ValueError(f"No tool found for '{target_str}'")
+
+
+class ProviderType(str, Enum):
+    """Cloud provider types."""
+
+    AWS = "AWS"
+
+    @classmethod
+    def from_string(cls, value: str) -> "ProviderType":
+        """Return enum from string value, ignoring case.
+
+        Raises:
+            ValueError: If no matching enum value is found.
+        """
+        value_lower = value.lower()
+        for member in cls:
+            if member.value.lower() == value_lower:
+                return member
+        raise ValueError(f"Unknown provider type: {value}")

--- a/libs/jupyter-deploy/jupyter_deploy/exceptions.py
+++ b/libs/jupyter-deploy/jupyter_deploy/exceptions.py
@@ -5,6 +5,8 @@ across interfaces (CLI, API, etc.), while also preserving their original excepti
 types (ValueError, RuntimeError, etc.) for backwards compatibility.
 """
 
+from jupyter_deploy.enum import ProviderType
+
 
 class JupyterDeployError(Exception):
     """Base exception for all jupyter-deploy errors."""
@@ -21,6 +23,18 @@ class ManifestNotFoundError(JupyterDeployError, FileNotFoundError):
     """Raised when manifest file is missing or project cannot be found."""
 
     pass
+
+
+class CommandNotImplementedError(JupyterDeployError, NotImplementedError):
+    """Raised when a command is not found in the project manifest.
+
+    Attributes:
+        command_name: The name of the command that was not found
+    """
+
+    def __init__(self, command_name: str) -> None:
+        self.command_name = command_name
+        super().__init__(f"Command '{command_name}' is not implemented in this template.")
 
 
 class ReadManifestError(JupyterDeployError, OSError):
@@ -192,6 +206,39 @@ class InstructionError(JupyterDeployError, RuntimeError):
     """Base exception for instruction execution errors."""
 
     pass
+
+
+class InvalidProviderCredentialsError(InstructionError, RuntimeError):
+    """Raised when provider credentials are missing or invalid.
+
+    Attributes:
+        provider_name: Cloud provider type
+        original_message: Original error message from the provider SDK
+    """
+
+    def __init__(self, provider_name: ProviderType, original_message: str) -> None:
+        self.provider_name = provider_name
+        self.original_message = original_message
+        super().__init__(f"Invalid or missing {provider_name.value} credentials")
+
+
+class ProviderPermissionError(InstructionError, RuntimeError):
+    """Raised when operation is denied due to insufficient permissions.
+
+    Attributes:
+        provider_name: Cloud provider type
+        operation: The operation that was attempted (e.g., 'ec2:StartInstance')
+        original_message: Original error message from the provider SDK
+    """
+
+    def __init__(self, provider_name: ProviderType, operation: str | None, original_message: str) -> None:
+        self.provider_name = provider_name
+        self.operation = operation
+        self.original_message = original_message
+        if operation:
+            super().__init__(f"Permission error for {provider_name.value} operation: {operation}")
+        else:
+            super().__init__(f"Permission error for {provider_name.value} operation")
 
 
 class InteractiveSessionError(InstructionError, RuntimeError):

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
@@ -90,8 +90,8 @@ class ServerHandler(BaseProjectHandler):
             },
         )
 
-    def get_server_logs(self, service: str, extra: list[str]) -> tuple[str, str]:
-        """Sends a logs command to the host for the service, return the stdout, stderr."""
+    def get_server_logs(self, service: str, extra: list[str]) -> tuple[str, str, int]:
+        """Sends a logs command to the host for the service, return the stdout, stderr, and exit code."""
         command = self.project_manifest.get_command("server.logs")
         validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
         runner = cmd_runner.ManifestCommandRunner(
@@ -109,7 +109,8 @@ class ServerHandler(BaseProjectHandler):
         )
         stdout = runner.get_result_value(command, "server.logs", str)
         stderr = runner.get_result_value(command, "server.errors", str)
-        return stdout, stderr
+        returncode = runner.get_result_value_with_fallback(command, "server.logs.returncode", int, 0)
+        return stdout, stderr, returncode
 
     def exec_command(self, service: str, command_args: list[str]) -> tuple[str, str, int]:
         """Execute a command inside a service container, return the stdout, stderr, and exit code."""

--- a/libs/jupyter-deploy/jupyter_deploy/manifest.py
+++ b/libs/jupyter-deploy/jupyter_deploy/manifest.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.enum import InstructionArgumentSource, ResultSource, TransformType, UpdateSource, ValueSource
-from jupyter_deploy.exceptions import InvalidServiceError
+from jupyter_deploy.exceptions import CommandNotImplementedError, InvalidServiceError
 
 
 class JupyterDeployTemplateV1(BaseModel):
@@ -240,12 +240,11 @@ class JupyterDeployManifestV1(BaseModel):
         """Return the command details.
 
         Raises:
-            NotImplementedError if the manifest has no declared command.
-            NotImplementedError if the command is not found.
+            CommandNotImplementedError if the command is not found in the manifest.
         """
         command = next((cmd for cmd in (self.commands or []) if cmd.cmd == cmd_name), None)
         if not command:
-            raise NotImplementedError(f"No implementation found for command: {cmd_name}")
+            raise CommandNotImplementedError(cmd_name)
         return command
 
     def get_services(self) -> list[str]:

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_runner.py
@@ -1,7 +1,14 @@
 from enum import Enum
 
+import botocore.exceptions
+
 from jupyter_deploy.engine.supervised_execution import DisplayManager
-from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.enum import ProviderType
+from jupyter_deploy.exceptions import (
+    InstructionNotFoundError,
+    InvalidProviderCredentialsError,
+    ProviderPermissionError,
+)
 from jupyter_deploy.provider.aws.aws_ec2_runner import AwsEc2Runner
 from jupyter_deploy.provider.aws.aws_ssm_runner import AwsSsmRunner
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
@@ -63,9 +70,79 @@ class AwsApiRunner(InstructionRunner):
         instruction_name: str,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
     ) -> dict[str, ResolvedInstructionResult]:
-        service_name, sub_instruction_name = AwsApiRunner._get_service_and_sub_instruction_name(instruction_name)
-        service_runner = self._get_service_runner(service_name)
-        return service_runner.execute_instruction(
-            instruction_name=sub_instruction_name,
-            resolved_arguments=resolved_arguments,
-        )
+        try:
+            service_name, sub_instruction_name = AwsApiRunner._get_service_and_sub_instruction_name(instruction_name)
+            service_runner = self._get_service_runner(service_name)
+            return service_runner.execute_instruction(
+                instruction_name=sub_instruction_name,
+                resolved_arguments=resolved_arguments,
+            )
+        except botocore.exceptions.NoCredentialsError as e:
+            raise InvalidProviderCredentialsError(
+                provider_name=ProviderType.AWS,
+                original_message=str(e),
+            ) from e
+        except botocore.exceptions.PartialCredentialsError as e:
+            raise InvalidProviderCredentialsError(
+                provider_name=ProviderType.AWS,
+                original_message=str(e),
+            ) from e
+        except botocore.exceptions.ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_message = e.response.get("Error", {}).get("Message", str(e))
+
+            # Permission-related error codes
+            # Sources:
+            # - UnauthorizedOperation: EC2 API
+            #   (docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html)
+            # - AccessDenied, AccessDeniedException, NotAuthorized, OptInRequired: Common across AWS services
+            #   (observed in practice, need specific documentation)
+            permission_error_codes = {
+                "AccessDenied",
+                "AccessDeniedException",
+                "NotAuthorized",
+                "UnauthorizedOperation",
+                "OptInRequired",
+            }
+
+            if error_code in permission_error_codes:
+                # Extract operation from request metadata
+                operation = e.operation_name if hasattr(e, "operation_name") else None
+                raise ProviderPermissionError(
+                    provider_name=ProviderType.AWS,
+                    operation=operation,
+                    original_message=error_message,
+                ) from e
+
+            # Credential-related error codes
+            # Sources:
+            # - ExpiredToken, InvalidIdentityToken : STS API
+            #   (docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
+            #   (docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
+            # - AuthFailure, IncompleteSignature, InvalidClientTokenId, MissingAuthenticationToken
+            #   MissingAuthenticationToken: EC2 API
+            #  (docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html)
+            # - AuthorizationHeaderMalformed, AuthorizationQueryParametersError: S3 Error Responses
+            #   (docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html)
+            # - ExpiredTokenException: EKS Error Responses
+            #   (https://docs.aws.amazon.com/eks/latest/APIReference/CommonErrors.html)
+            credential_error_codes = {
+                "ExpiredToken",
+                "InvalidIdentityToken",
+                "AuthFailure",
+                "IncompleteSignature",
+                "InvalidClientTokenId",
+                "MissingAuthenticationToken",
+                "AuthorizationHeaderMalformed",
+                "AuthorizationQueryParametersError",
+                "ExpiredTokenException",
+            }
+
+            if error_code in credential_error_codes:
+                raise InvalidProviderCredentialsError(
+                    provider_name=ProviderType.AWS,
+                    original_message=error_message,
+                ) from e
+
+            # For other ClientErrors, re-raise
+            raise

--- a/libs/jupyter-deploy/tests/unit/api/aws/ssm/test_ssm_session.py
+++ b/libs/jupyter-deploy/tests/unit/api/aws/ssm/test_ssm_session.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import botocore.exceptions
 
 from jupyter_deploy.api.aws.ssm.ssm_session import describe_instance_information
+from jupyter_deploy.exceptions import UnreachableHostError
 
 
 class TestDescribeInstanceInformation(unittest.TestCase):
@@ -41,15 +42,15 @@ class TestDescribeInstanceInformation(unittest.TestCase):
         self.assertEqual(result, instance_info)
 
     def test_empty_instance_information_list(self) -> None:
-        """Test that describe_instance_information raises ValueError when no information is available."""
+        """Test that describe_instance_information raises UnreachableHostError when no information is available."""
         # Setup
         self.mock_ssm_client.describe_instance_information.return_value = {"InstanceInformationList": []}
 
         # Execute & Assert
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(UnreachableHostError) as context:
             describe_instance_information(self.mock_ssm_client, self.instance_id)
 
-        self.assertEqual(str(context.exception), "SSM:DescribeInstanceInformation returned an empty list")
+        self.assertIn("not reporting to SSM", str(context.exception))
         self.mock_ssm_client.describe_instance_information.assert_called_once_with(
             Filters=[{"Key": "InstanceIds", "Values": [self.instance_id]}]
         )

--- a/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
@@ -588,7 +588,7 @@ class TestServerLogsCmd(unittest.TestCase):
 
         mock_console = Mock()
         mock_console_class.return_value = mock_console
-        mock_handler_fns["get_server_logs"].return_value = "some-logs", "some-errors"
+        mock_handler_fns["get_server_logs"].return_value = "some-logs", "some-errors", 0
 
         # Execute
         runner = CliRunner()
@@ -665,7 +665,7 @@ class TestServerLogsCmd(unittest.TestCase):
         # Set up the console mock
         mock_console = Mock()
         mock_console_class.return_value = mock_console
-        mock_handler_fns["get_server_logs"].return_value = "", ""
+        mock_handler_fns["get_server_logs"].return_value = "", "", 0
 
         mock_spinner = Mock()
         mock_spinner.__enter__ = Mock(return_value=None)

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_server_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_server_handler.py
@@ -473,15 +473,17 @@ class TestServerHandler(unittest.TestCase):
 
         mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
         mock_cmd_runner_fns["get_result_value"].side_effect = ["some\nlogs", "some\nerrors"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 0
         mock_cmd_runner_class.return_value = mock_cmd_runner
 
         # Act
         handler = ServerHandler(display_manager=NullDisplay())
-        logs, error_logs = handler.get_server_logs("oauth", ["-n", "200"])
+        logs, error_logs, returncode = handler.get_server_logs("oauth", ["-n", "200"])
 
         # Assert results
         self.assertEqual(logs, "some\nlogs")
         self.assertEqual(error_logs, "some\nerrors")
+        self.assertEqual(returncode, 0)
 
         # Verify
         mock_cmd_runner_class.assert_called_once()
@@ -492,6 +494,7 @@ class TestServerHandler(unittest.TestCase):
         self.assertEqual(mock_cmd_runner_class.call_args[1]["variable_handler"], mock_variable_handler)
         self.assertEqual(mock_cmd_runner_fns["get_result_value"].mock_calls[0][1][1], "server.logs")
         self.assertEqual(mock_cmd_runner_fns["get_result_value"].mock_calls[1][1][1], "server.errors")
+        mock_cmd_runner_fns["get_result_value_with_fallback"].assert_called_once()
 
         # Check CLI parameters
         cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]


### PR DESCRIPTION
This PR improve UX when SDK-based commands error out by catching common problems: a/ stale, missing or invalid credentials, b/ permission error, c/ instance not mapped by SSM (host stopped), d/ command not declared in manifest

Also in this PR:
- improve mutate auth logic: avoids duplicate commands, ensure that oauth container is updated
- capture retcode of `jd server logs` target command

### User experience
- show concise error w/o lengthy stack trace, and hint on how to resolve it

### Implementation
- add `CommandNotImplementedError`, `InvalidProviderCredentialsError`, `ProviderPermissionError` and corresponding handling in error decorator
- add `--wait` to `update-auth.sh` script on `docker compose oauth` call
- print effective allowed auth entities (users, teams, org) in `update-auth.sh` & use in handler to update terraform state
- remove unnecessary subsequent `get-auth.sh` call via `SSM:SendCommand`

### Testing
- run access, service and host E2E tests
- tested manually

### Screenshots
**Offline host**
<img width="457" height="143" alt="Screenshot 2026-02-18 at 7 34 20 PM" src="https://github.com/user-attachments/assets/9075accd-041d-4039-a1cb-f1fe522f11b9" />

**Permission error**
<img width="924" height="73" alt="Screenshot 2026-02-18 at 7 36 20 PM" src="https://github.com/user-attachments/assets/23ae6d9d-eced-4381-9a07-bf98717124ab" />

**Missing credentials error**
<img width="433" height="57" alt="Screenshot 2026-02-18 at 7 37 00 PM" src="https://github.com/user-attachments/assets/8b473da9-09e6-4c21-bda5-c97f83b09c8a" />

