### PR TITLE
chore: temporarily bypass `pypi-test` in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
 
   prod-pypi-publish:
     name: Publish to PyPI
-    needs: [test-pypi-install, build]
+    needs: [build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
Hot fix for repeated failures in `pypi-test` stage of `jupyter-deploy-tf-aws-ec2-base`.

See https://github.com/jupyter-infra/jupyter-deploy/actions/runs/22312571327/job/64548568566

```
PyPI is down for maintenance or is having an outage.

This is affecting several of our services, including our web interface.
If you are trying to install a package, you should be able to pip install packages without problem.
```