### PR TITLE
Revert "chore: temporarily bypass `pypi-test` in release (#162)"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
 
   prod-pypi-publish:
     name: Publish to PyPI
-    needs: [build]
+    needs: [test-pypi-install, build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
This reverts commit c57254544ad372799e684549065dcdeb18c362b6.