### PR TITLE
feat: s3-only store

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -21,7 +21,7 @@ values:
   source: output
   source-key: persisting_resources
 project-store:
-  store-type: s3-ddb
+  store-type: s3-only
 services:
 - jupyter
 - traefik

--- a/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
@@ -22,6 +22,7 @@ from jupyter_deploy.exceptions import (
     InvalidProjectPathError,
     InvalidProviderCredentialsError,
     InvalidServiceError,
+    InvalidStoreTypeError,
     InvalidVariablesDotYamlError,
     JupyterDeployError,
     LogCleanupError,
@@ -135,6 +136,12 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         console.print(f":x: {e}", style="bold red")
         console.line()
         console.print(f"Available services: {', '.join(e.valid_services)}")
+        raise typer.Exit(code=1) from None
+
+    except InvalidStoreTypeError as e:
+        console.print(f":x: {e}", style="bold red")
+        console.line()
+        console.print(f"Available store types: {', '.join(e.valid_store_types)}")
         raise typer.Exit(code=1) from None
 
     except (UnreachableHostError, IncompatibleHostStateError) as e:

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_store_access.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_store_access.py
@@ -9,10 +9,23 @@ from jupyter_deploy.engine.terraform.tf_constants import (
     TF_INIT_CMD,
     TF_INIT_MIGRATE_CMD_OPTIONS,
 )
-from jupyter_deploy.exceptions import ProjectStoreAccessConfigurationError
+from jupyter_deploy.enum import StoreType
+from jupyter_deploy.exceptions import InvalidStoreTypeError, ProjectStoreAccessConfigurationError
 from jupyter_deploy.provider.store.store_manager import StoreInfo
 
-_BACKEND_TEMPLATE = """\
+
+class TerraformStoreAccessManager(EngineStoreAccessManager):
+    _BACKEND_TEMPLATE = """\
+terraform {{
+  backend "s3" {{
+    bucket         = "{store_id}"
+    key            = "{project_id}/terraform.tfstate"
+    region         = "{region}"
+  }}
+}}
+"""
+
+    _BACKEND_TEMPLATE_WITH_LOCK = """\
 terraform {{
   backend "s3" {{
     bucket         = "{store_id}"
@@ -23,17 +36,24 @@ terraform {{
 }}
 """
 
-
-class TerraformStoreAccessManager(EngineStoreAccessManager):
     def __init__(self, engine_dir_path: Path) -> None:
         self.engine_dir_path = engine_dir_path
+
+    @staticmethod
+    def _get_backend_template(store_type: StoreType) -> str:
+        if store_type == StoreType.S3_ONLY:
+            return TerraformStoreAccessManager._BACKEND_TEMPLATE
+        if store_type == StoreType.S3_DDB:
+            return TerraformStoreAccessManager._BACKEND_TEMPLATE_WITH_LOCK
+        raise InvalidStoreTypeError(store_type, [t.value for t in StoreType])
 
     def is_configured(self) -> bool:
         return (self.engine_dir_path / TF_BACKEND_FILENAME).exists()
 
     def configure(self, store_info: StoreInfo, project_id: str, display_manager: DisplayManager) -> None:
         backend_path = self.engine_dir_path / TF_BACKEND_FILENAME
-        content = _BACKEND_TEMPLATE.format(
+        template = self._get_backend_template(store_info.store_type)
+        content = template.format(
             store_id=store_info.store_id,
             project_id=project_id,
             region=store_info.location,

--- a/libs/jupyter-deploy/jupyter_deploy/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/enum.py
@@ -153,6 +153,26 @@ class JupyterDeployTool(str, Enum):
         raise ValueError(f"No tool found for '{target_str}'")
 
 
+class StoreType(str, Enum):
+    """Project store types."""
+
+    S3_ONLY = "s3-only"
+    S3_DDB = "s3-ddb"
+
+    @classmethod
+    def from_string(cls, value: str) -> "StoreType":
+        """Return enum from string value, ignoring case.
+
+        Raises:
+            ValueError: If no matching enum value is found.
+        """
+        value_lower = value.lower()
+        for member in cls:
+            if member.value.lower() == value_lower:
+                return member
+        raise ValueError(f"Unknown store type: '{value}'")
+
+
 class ProviderType(str, Enum):
     """Cloud provider types."""
 

--- a/libs/jupyter-deploy/jupyter_deploy/exceptions.py
+++ b/libs/jupyter-deploy/jupyter_deploy/exceptions.py
@@ -392,6 +392,20 @@ class LogCleanupError(JupyterDeployError, Exception):
 # ============================================================================
 
 
+class InvalidStoreTypeError(JupyterDeployError, ValueError):
+    """Raised when a manifest declares an unrecognized project store type.
+
+    Attributes:
+        store_type: The invalid store type string
+        valid_store_types: List of valid store type values
+    """
+
+    def __init__(self, store_type: str, valid_store_types: list[str]) -> None:
+        self.store_type = store_type
+        self.valid_store_types = valid_store_types
+        super().__init__(f"Invalid store type: '{store_type}'")
+
+
 class ProjectStoreNotFoundError(JupyterDeployError, RuntimeError):
     """Raised when no project store is found.
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/config_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/config_handler.py
@@ -4,6 +4,7 @@ from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.engine.supervised_execution import CompletionContext, DisplayManager
 from jupyter_deploy.engine.terraform import tf_config
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
+from jupyter_deploy.enum import StoreType
 from jupyter_deploy.exceptions import InvalidPresetError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.provider.store.store_manager import StoreInfo
@@ -89,18 +90,18 @@ class ConfigHandler(BaseProjectHandler):
         """
         return self._handler.reset_recorded_secrets()
 
-    def ensure_store(self, store_type: str | None = None, store_id: str | None = None) -> StoreInfo | None:
+    def ensure_store(self, store_type: StoreType | None = None, store_id: str | None = None) -> StoreInfo | None:
         """Ensure the remote project store exists, creating it if necessary.
 
         Args:
-            store_type: Store type (e.g., "s3-ddb"). Inferred from manifest if not provided.
+            store_type: Store type. Inferred from manifest if not provided.
             store_id: Store identifier (e.g., bucket name). Discovered from account if not provided.
 
         Returns:
             StoreInfo if the store was ensured, None if project store is not configured.
         """
         if store_type is None and self.project_manifest.project_store is not None:
-            store_type = self.project_manifest.project_store.store_type
+            store_type = self.project_manifest.project_store.get_store_type()
 
         if not store_type:
             self.display_manager.warning("No project store type configured. Skipping store setup.")

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/up_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/up_handler.py
@@ -9,6 +9,7 @@ from jupyter_deploy.engine.terraform import tf_up
 from jupyter_deploy.engine.terraform.tf_constants import TF_ENGINE_DIR
 from jupyter_deploy.engine.terraform.tf_outputs import TerraformOutputsHandler
 from jupyter_deploy.engine.terraform.tf_store_access import TerraformStoreAccessManager
+from jupyter_deploy.enum import StoreType
 from jupyter_deploy.exceptions import ProjectIdNotAvailableError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.provider.store.store_manager_factory import StoreManagerFactory
@@ -75,7 +76,7 @@ class UpHandler(BaseProjectHandler):
         """
         return self._handler.apply(config_file_path, auto_approve)
 
-    def push_to_store(self, store_type: str | None = None, store_id: str | None = None) -> None:
+    def push_to_store(self, store_type: StoreType | None = None, store_id: str | None = None) -> None:
         """Push the project to the remote store.
 
         No-op if store is not specified as argument or declared in the manifest.
@@ -89,7 +90,7 @@ class UpHandler(BaseProjectHandler):
             ProjectStoreNotFoundError: If no project store is found in the account.
         """
         if store_type is None and self.project_manifest.project_store is not None:
-            store_type = self.project_manifest.project_store.store_type
+            store_type = self.project_manifest.project_store.get_store_type()
 
         if not store_type:
             self.display_manager.warning("No project store type configured. Skipping store push.")

--- a/libs/jupyter-deploy/jupyter_deploy/manifest.py
+++ b/libs/jupyter-deploy/jupyter_deploy/manifest.py
@@ -3,8 +3,15 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from jupyter_deploy.engine.enum import EngineType
-from jupyter_deploy.enum import InstructionArgumentSource, ResultSource, TransformType, UpdateSource, ValueSource
-from jupyter_deploy.exceptions import CommandNotImplementedError, InvalidServiceError
+from jupyter_deploy.enum import (
+    InstructionArgumentSource,
+    ResultSource,
+    StoreType,
+    TransformType,
+    UpdateSource,
+    ValueSource,
+)
+from jupyter_deploy.exceptions import CommandNotImplementedError, InvalidServiceError, InvalidStoreTypeError
 
 
 class JupyterDeployTemplateV1(BaseModel):
@@ -213,6 +220,17 @@ class JupyterDeploySupervisedExecutionV1(BaseModel):
 class JupyterDeployProjectStoreV1(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
     store_type: str = Field(alias="store-type")
+
+    def get_store_type(self) -> StoreType:
+        """Return the store type as an enum.
+
+        Raises:
+            InvalidStoreTypeError: If the store type is not recognized.
+        """
+        try:
+            return StoreType.from_string(self.store_type)
+        except ValueError:
+            raise InvalidStoreTypeError(self.store_type, [t.value for t in StoreType]) from None
 
 
 class JupyterDeployManifestV1(BaseModel):

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/store/s3_dynamodb_store.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/store/s3_dynamodb_store.py
@@ -1,98 +1,40 @@
 from __future__ import annotations
 
-import uuid
-from datetime import UTC, datetime
-from pathlib import Path
-
 import boto3
 import botocore.exceptions
 from mypy_boto3_dynamodb.client import DynamoDBClient
-from mypy_boto3_s3.client import S3Client
 
 from jupyter_deploy.api.aws.dynamodb import dynamodb_table
-from jupyter_deploy.api.aws.s3 import s3_bucket, s3_object, s3_sync
-from jupyter_deploy.api.aws.sts import sts_identity
 from jupyter_deploy.engine.supervised_execution import DisplayManager
-from jupyter_deploy.exceptions import ProjectStoreNotFoundError
+from jupyter_deploy.enum import StoreType
 from jupyter_deploy.provider.aws.aws_error_handler import aws_error_context_manager
 from jupyter_deploy.provider.aws.store.constants import (
-    STORE_BUCKET_NAME_PREFIX,
     STORE_DDB_TABLE_NAME,
     STORE_TAG_SOURCE_KEY,
     STORE_TAG_SOURCE_VALUE,
     STORE_TAG_VERSION_KEY,
 )
-from jupyter_deploy.provider.store.store_manager import ProjectSummary, StoreInfo, StoreManager, SyncResult
+from jupyter_deploy.provider.aws.store.s3_store import S3StoreManager
+from jupyter_deploy.provider.store.store_manager import StoreInfo
 
 
-class S3DynamoDbTableStoreManager(StoreManager):
-    """StoreManager implementation backed by S3 and DynamoDB.
+class S3DynamoDbTableStoreManager(S3StoreManager):
+    """StoreManager backed by S3 and DynamoDB.
 
-    The S3 bucket acts as the project store for the jupyter-deploy project dir, which includes
-    all the files that are not gitignored. In the case of terraform, it includes
-    the terraform state.
-
-    The DynamoDB table acts as the lock state table preventing concurrent updates.
+    Extends S3StoreManager with a DynamoDB lock table for terraform state locking.
     """
 
+    _store_type = StoreType.S3_DDB
+
     def __init__(self, region: str, bucket_name: str | None = None) -> None:
-        self._region = region
-        self._bucket_name = bucket_name
-        self._s3_client: S3Client = boto3.client("s3", region_name=region)
+        super().__init__(region, bucket_name)
         self._dynamodb_client: DynamoDBClient = boto3.client("dynamodb", region_name=region)
 
-    @staticmethod
-    def resolve_lead_region() -> str:
-        """Resolve the partition lead region from the caller's AWS credentials."""
-        sts_client = boto3.client("sts")
-        return sts_identity.get_partition_lead_region(sts_client)
-
-    def find_store(self) -> StoreInfo:
-        with aws_error_context_manager():
-            bucket_name = self._bucket_name
-            if not bucket_name:
-                matched = s3_bucket.find_buckets_by_tag(
-                    self._s3_client, STORE_TAG_SOURCE_KEY, STORE_TAG_SOURCE_VALUE, stop_at_first_match=True
-                )
-                bucket_name = matched[0].get("Name") if matched else None
-
-            if not bucket_name:
-                raise ProjectStoreNotFoundError("No S3 bucket project store found in your AWS account.")
-
-            self._bucket_name = bucket_name
-            return StoreInfo(store_type="s3-ddb", store_id=bucket_name, location=self._region)
-
     def ensure_store(self, display_manager: DisplayManager) -> StoreInfo:
+        store_info = super().ensure_store(display_manager)
+
         with aws_error_context_manager():
-            bucket_name = self._bucket_name
-            bucket_created = False
             ddb_table_created = False
-
-            if not bucket_name:
-                display_manager.info("Looking for existing projects store in your AWS account...")
-                matched = s3_bucket.find_buckets_by_tag(
-                    self._s3_client, STORE_TAG_SOURCE_KEY, STORE_TAG_SOURCE_VALUE, stop_at_first_match=True
-                )
-                bucket_name = matched[0].get("Name") if matched else None
-
-            if bucket_name:
-                display_manager.info(f"Found existing S3 bucket projects store: {bucket_name}")
-                self._bucket_name = bucket_name
-            else:
-                # Random suffix prevents bucket name sniping attacks. 20 hex chars = 80 bits
-                # of entropy from os.urandom (CSPRNG); birthday collision at ~2^40 (~1 trillion).
-                # Total name length: 24 (prefix) + 1 (dash) + 20 (suffix) = 45 chars (S3 max: 63).
-                bucket_name = f"{STORE_BUCKET_NAME_PREFIX}-{uuid.uuid4().hex[:20]}"
-                display_manager.info(f"Creating S3 bucket projects store: {bucket_name}")
-                tags = {
-                    STORE_TAG_SOURCE_KEY: STORE_TAG_SOURCE_VALUE,
-                    STORE_TAG_VERSION_KEY: "1",
-                }
-                s3_bucket.create_bucket(self._s3_client, bucket_name, self._region, tags)
-                self._bucket_name = bucket_name
-                bucket_created = True
-
-            # Ensure DynamoDB lock table exists
             try:
                 display_manager.info("Looking for existing dynamoDB table...")
                 dynamodb_table.get_table_by_name(self._dynamodb_client, STORE_DDB_TABLE_NAME)
@@ -109,90 +51,8 @@ class S3DynamoDbTableStoreManager(StoreManager):
                 dynamodb_table.wait_for_table_active(self._dynamodb_client, STORE_DDB_TABLE_NAME)
                 ddb_table_created = True
 
-            if bucket_created:
-                display_manager.success(f"S3 project store created: {self._bucket_name}")
             if ddb_table_created:
                 display_manager.success(f"State lock DynamoDB table created: {STORE_DDB_TABLE_NAME}")
-            if bucket_created or ddb_table_created:
                 display_manager.line()
-            return StoreInfo(store_type="s3-ddb", store_id=self._bucket_name, location=self._region)
 
-    def push(self, project_path: Path, project_id: str, display_manager: DisplayManager) -> SyncResult:
-        if not self._bucket_name:
-            raise ProjectStoreNotFoundError
-
-        with aws_error_context_manager():
-            # Scope the project snapshot under a "project/" subdirectory so it doesn't overlap
-            # with engine state (e.g. terraform.tfstate) stored under the root prefix.
-            # The sync deletes stale remote objects, so without this separation it would delete
-            # the engine state files, which are gitignored and therefore absent from the local
-            # file walk.
-            prefix = f"{project_id}/project/"
-            gitignore_path = project_path / ".gitignore"
-
-            display_manager.info(f"Updating remote store: {self._bucket_name}, prefix: {prefix}")
-            result = s3_sync.sync_to_remote(
-                self._s3_client,
-                self._bucket_name,
-                prefix,
-                project_path,
-                gitignore_path if gitignore_path.exists() else None,
-            )
-
-            display_manager.success(
-                f"Updated project store: {result.uploaded} uploaded, "
-                f"{result.deleted} deleted, {result.unchanged} unchanged"
-            )
-            return SyncResult(uploaded=result.uploaded, deleted=result.deleted, unchanged=result.unchanged)
-
-    def pull(self, project_id: str, dest_path: Path, display_manager: DisplayManager) -> SyncResult:
-        if not self._bucket_name:
-            raise ProjectStoreNotFoundError
-
-        with aws_error_context_manager():
-            prefix = f"{project_id}/project/"
-
-            display_manager.info(f"Pulling project from s3://{self._bucket_name}/{prefix} to {dest_path.absolute()}")
-            result = s3_sync.sync_from_remote(self._s3_client, self._bucket_name, prefix, dest_path)
-
-            display_manager.success(f"Pull complete: {result.uploaded} files downloaded")
-            return SyncResult(uploaded=result.uploaded, deleted=result.deleted, unchanged=result.unchanged)
-
-    def list_projects(self, display_manager: DisplayManager) -> list[ProjectSummary]:
-        if not self._bucket_name:
-            raise ProjectStoreNotFoundError
-
-        with aws_error_context_manager():
-            display_manager.info(f"Listing projects in projects store: {self._bucket_name}")
-            prefixes = s3_bucket.list_top_level_prefixes(self._s3_client, self._bucket_name)
-            summaries: list[ProjectSummary] = []
-
-            for prefix_name in prefixes:
-                objects = s3_object.list_objects(self._s3_client, self._bucket_name, f"{prefix_name}/")
-                last_modified = (
-                    max(obj["LastModified"] for obj in objects) if objects else datetime.min.replace(tzinfo=UTC)
-                )
-                summaries.append(
-                    ProjectSummary(
-                        project_id=prefix_name,
-                        last_modified=last_modified,
-                        file_count=len(objects),
-                    )
-                )
-
-            return summaries
-
-    def delete_project(self, project_id: str, display_manager: DisplayManager) -> None:
-        if not self._bucket_name:
-            raise ProjectStoreNotFoundError
-
-        with aws_error_context_manager():
-            display_manager.info(f"Deleting project '{project_id}' from projects store: {self._bucket_name}")
-            objects = s3_object.list_objects(self._s3_client, self._bucket_name, f"{project_id}/")
-            if objects:
-                display_manager.info(f"Found {len(objects)} for the project in projects store: {self._bucket_name}")
-                keys = [obj["Key"] for obj in objects]
-                s3_object.delete_objects(self._s3_client, self._bucket_name, keys)
-            display_manager.success(
-                f"Deleted {len(objects)} for project '{project_id}' in projects store: {self._bucket_name}"
-            )
+        return store_info

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/store/s3_store.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/store/s3_store.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import boto3
+from mypy_boto3_s3.client import S3Client
+
+from jupyter_deploy.api.aws.s3 import s3_bucket, s3_object, s3_sync
+from jupyter_deploy.api.aws.sts import sts_identity
+from jupyter_deploy.engine.supervised_execution import DisplayManager
+from jupyter_deploy.enum import StoreType
+from jupyter_deploy.exceptions import ProjectStoreNotFoundError
+from jupyter_deploy.provider.aws.aws_error_handler import aws_error_context_manager
+from jupyter_deploy.provider.aws.store.constants import (
+    STORE_BUCKET_NAME_PREFIX,
+    STORE_TAG_SOURCE_KEY,
+    STORE_TAG_SOURCE_VALUE,
+    STORE_TAG_VERSION_KEY,
+)
+from jupyter_deploy.provider.store.store_manager import ProjectSummary, StoreInfo, StoreManager, SyncResult
+
+
+class S3StoreManager(StoreManager):
+    """StoreManager implementation backed by S3 only (no state locking)."""
+
+    _store_type = StoreType.S3_ONLY
+
+    def __init__(self, region: str, bucket_name: str | None = None) -> None:
+        self._region = region
+        self._bucket_name = bucket_name
+        self._s3_client: S3Client = boto3.client("s3", region_name=region)
+
+    @staticmethod
+    def resolve_lead_region() -> str:
+        """Resolve the partition lead region from the caller's AWS credentials."""
+        sts_client = boto3.client("sts")
+        return sts_identity.get_partition_lead_region(sts_client)
+
+    def find_store(self) -> StoreInfo:
+        with aws_error_context_manager():
+            bucket_name = self._bucket_name
+            if not bucket_name:
+                matched = s3_bucket.find_buckets_by_tag(
+                    self._s3_client, STORE_TAG_SOURCE_KEY, STORE_TAG_SOURCE_VALUE, stop_at_first_match=True
+                )
+                bucket_name = matched[0].get("Name") if matched else None
+
+            if not bucket_name:
+                raise ProjectStoreNotFoundError("No S3 bucket project store found in your AWS account.")
+
+            self._bucket_name = bucket_name
+            return StoreInfo(store_type=self._store_type, store_id=bucket_name, location=self._region)
+
+    def ensure_store(self, display_manager: DisplayManager) -> StoreInfo:
+        with aws_error_context_manager():
+            bucket_name = self._bucket_name
+
+            if not bucket_name:
+                display_manager.info("Looking for existing projects store in your AWS account...")
+                matched = s3_bucket.find_buckets_by_tag(
+                    self._s3_client, STORE_TAG_SOURCE_KEY, STORE_TAG_SOURCE_VALUE, stop_at_first_match=True
+                )
+                bucket_name = matched[0].get("Name") if matched else None
+
+            if bucket_name:
+                display_manager.info(f"Found existing S3 bucket projects store: {bucket_name}")
+                self._bucket_name = bucket_name
+            else:
+                # Random suffix prevents bucket name sniping attacks. 20 hex chars = 80 bits
+                # of entropy from os.urandom (CSPRNG); birthday collision at ~2^40 (~1 trillion).
+                # Total name length: 24 (prefix) + 1 (dash) + 20 (suffix) = 45 chars (S3 max: 63).
+                bucket_name = f"{STORE_BUCKET_NAME_PREFIX}-{uuid.uuid4().hex[:20]}"
+                display_manager.info(f"Creating S3 bucket projects store: {bucket_name}")
+                tags = {
+                    STORE_TAG_SOURCE_KEY: STORE_TAG_SOURCE_VALUE,
+                    STORE_TAG_VERSION_KEY: "1",
+                }
+                s3_bucket.create_bucket(self._s3_client, bucket_name, self._region, tags)
+                self._bucket_name = bucket_name
+                display_manager.success(f"S3 project store created: {self._bucket_name}")
+                display_manager.line()
+
+            return StoreInfo(store_type=self._store_type, store_id=self._bucket_name, location=self._region)
+
+    def push(self, project_path: Path, project_id: str, display_manager: DisplayManager) -> SyncResult:
+        if not self._bucket_name:
+            raise ProjectStoreNotFoundError
+
+        with aws_error_context_manager():
+            # Scope the project snapshot under a "project/" subdirectory so it doesn't overlap
+            # with engine state (e.g. terraform.tfstate) stored under the root prefix.
+            # The sync deletes stale remote objects, so without this separation it would delete
+            # the engine state files, which are gitignored and therefore absent from the local
+            # file walk.
+            prefix = f"{project_id}/project/"
+            gitignore_path = project_path / ".gitignore"
+
+            display_manager.info(f"Updating remote store: {self._bucket_name}, prefix: {prefix}")
+            result = s3_sync.sync_to_remote(
+                self._s3_client,
+                self._bucket_name,
+                prefix,
+                project_path,
+                gitignore_path if gitignore_path.exists() else None,
+            )
+
+            display_manager.success(
+                f"Updated project store: {result.uploaded} uploaded, "
+                f"{result.deleted} deleted, {result.unchanged} unchanged"
+            )
+            return SyncResult(uploaded=result.uploaded, deleted=result.deleted, unchanged=result.unchanged)
+
+    def pull(self, project_id: str, dest_path: Path, display_manager: DisplayManager) -> SyncResult:
+        if not self._bucket_name:
+            raise ProjectStoreNotFoundError
+
+        with aws_error_context_manager():
+            prefix = f"{project_id}/project/"
+
+            display_manager.info(f"Pulling project from s3://{self._bucket_name}/{prefix} to {dest_path.absolute()}")
+            result = s3_sync.sync_from_remote(self._s3_client, self._bucket_name, prefix, dest_path)
+
+            display_manager.success(f"Pull complete: {result.uploaded} files downloaded")
+            return SyncResult(uploaded=result.uploaded, deleted=result.deleted, unchanged=result.unchanged)
+
+    def list_projects(self, display_manager: DisplayManager) -> list[ProjectSummary]:
+        if not self._bucket_name:
+            raise ProjectStoreNotFoundError
+
+        with aws_error_context_manager():
+            display_manager.info(f"Listing projects in projects store: {self._bucket_name}")
+            prefixes = s3_bucket.list_top_level_prefixes(self._s3_client, self._bucket_name)
+            summaries: list[ProjectSummary] = []
+
+            for prefix_name in prefixes:
+                objects = s3_object.list_objects(self._s3_client, self._bucket_name, f"{prefix_name}/")
+                last_modified = (
+                    max(obj["LastModified"] for obj in objects) if objects else datetime.min.replace(tzinfo=UTC)
+                )
+                summaries.append(
+                    ProjectSummary(
+                        project_id=prefix_name,
+                        last_modified=last_modified,
+                        file_count=len(objects),
+                    )
+                )
+
+            return summaries
+
+    def delete_project(self, project_id: str, display_manager: DisplayManager) -> None:
+        if not self._bucket_name:
+            raise ProjectStoreNotFoundError
+
+        with aws_error_context_manager():
+            display_manager.info(f"Deleting project '{project_id}' from projects store: {self._bucket_name}")
+            objects = s3_object.list_objects(self._s3_client, self._bucket_name, f"{project_id}/")
+            if objects:
+                display_manager.info(f"Found {len(objects)} for the project in projects store: {self._bucket_name}")
+                keys = [obj["Key"] for obj in objects]
+                s3_object.delete_objects(self._s3_client, self._bucket_name, keys)
+            display_manager.success(
+                f"Deleted {len(objects)} for project '{project_id}' in projects store: {self._bucket_name}"
+            )

--- a/libs/jupyter-deploy/jupyter_deploy/provider/store/store_manager.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/store/store_manager.py
@@ -7,12 +7,13 @@ from pathlib import Path
 from pydantic import BaseModel
 
 from jupyter_deploy.engine.supervised_execution import DisplayManager
+from jupyter_deploy.enum import StoreType
 
 
 class StoreInfo(BaseModel):
     """Information about a project store."""
 
-    store_type: str
+    store_type: StoreType
     store_id: str
     location: str
 

--- a/libs/jupyter-deploy/jupyter_deploy/provider/store/store_manager_factory.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/store/store_manager_factory.py
@@ -1,3 +1,4 @@
+from jupyter_deploy.enum import StoreType
 from jupyter_deploy.provider.store.store_manager import StoreManager
 
 
@@ -8,17 +9,24 @@ class StoreManagerFactory:
     """
 
     @staticmethod
-    def get_manager(store_type: str, store_id: str | None = None) -> StoreManager:
+    def get_manager(store_type: StoreType, store_id: str | None = None) -> StoreManager:
         """Return a StoreManager for the given store type.
 
         Args:
-            store_type: The type of store (e.g., "s3-ddb").
+            store_type: The type of store.
             store_id: Optional store identifier (e.g., bucket name).
 
         Raises:
             NotImplementedError if the store type is not recognized.
         """
-        if store_type == "s3-ddb":
+        if store_type == StoreType.S3_ONLY:
+            # do NOT move imports to top level
+            from jupyter_deploy.provider.aws.store.s3_store import S3StoreManager
+
+            partition_lead_region = S3StoreManager.resolve_lead_region()
+            return S3StoreManager(region=partition_lead_region, bucket_name=store_id)
+
+        if store_type == StoreType.S3_DDB:
             # do NOT move imports to top level
             from jupyter_deploy.provider.aws.store.s3_dynamodb_store import S3DynamoDbTableStoreManager
 

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_store_access.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_store_access.py
@@ -6,7 +6,8 @@ from unittest.mock import Mock, patch
 
 from jupyter_deploy.engine.terraform.tf_constants import TF_BACKEND_FILENAME, TF_INIT_CMD, TF_INIT_MIGRATE_CMD_OPTIONS
 from jupyter_deploy.engine.terraform.tf_store_access import TerraformStoreAccessManager
-from jupyter_deploy.exceptions import ProjectStoreAccessConfigurationError
+from jupyter_deploy.enum import StoreType
+from jupyter_deploy.exceptions import InvalidStoreTypeError, ProjectStoreAccessConfigurationError
 from jupyter_deploy.provider.store.store_manager import StoreInfo
 
 
@@ -19,7 +20,7 @@ class TestTerraformStoreAccessManager(unittest.TestCase):
             engine_dir_path=self.engine_dir,
         )
         self.store_info = StoreInfo(
-            store_type="s3-ddb",
+            store_type=StoreType.S3_DDB,
             store_id="jupyter-deploy-abc123",
             location="us-west-2",
         )
@@ -35,7 +36,7 @@ class TestTerraformStoreAccessManager(unittest.TestCase):
         self.assertTrue(self.manager.is_configured())
 
     @patch("jupyter_deploy.engine.terraform.tf_store_access.cmd_utils.run_cmd_and_capture_output")
-    def test_configure_writes_backend_file(self, mock_run: Mock) -> None:
+    def test_configure_writes_backend_file_with_lock(self, mock_run: Mock) -> None:
         display = Mock()
         self.manager.configure(self.store_info, "tf-aws-ec2-base-dep1", display)
 
@@ -47,8 +48,21 @@ class TestTerraformStoreAccessManager(unittest.TestCase):
         self.assertIn('backend "s3"', content)
 
     @patch("jupyter_deploy.engine.terraform.tf_store_access.cmd_utils.run_cmd_and_capture_output")
+    def test_configure_writes_backend_file_without_lock(self, mock_run: Mock) -> None:
+        store_info = StoreInfo(store_type=StoreType.S3_ONLY, store_id="jupyter-deploy-abc123", location="us-west-2")
+        display = Mock()
+        self.manager.configure(store_info, "tf-aws-ec2-base-dep1", display)
+
+        content = (self.engine_dir / TF_BACKEND_FILENAME).read_text()
+        self.assertIn('bucket         = "jupyter-deploy-abc123"', content)
+        self.assertIn('key            = "tf-aws-ec2-base-dep1/terraform.tfstate"', content)
+        self.assertIn('region         = "us-west-2"', content)
+        self.assertNotIn("dynamodb_table", content)
+        self.assertIn('backend "s3"', content)
+
+    @patch("jupyter_deploy.engine.terraform.tf_store_access.cmd_utils.run_cmd_and_capture_output")
     def test_configure_uses_store_info_location(self, mock_run: Mock) -> None:
-        store_info = StoreInfo(store_type="s3-ddb", store_id="bucket-1", location="eu-west-1")
+        store_info = StoreInfo(store_type=StoreType.S3_DDB, store_id="bucket-1", location="eu-west-1")
         display = Mock()
         self.manager.configure(store_info, "proj-1", display)
 
@@ -89,3 +103,26 @@ class TestTerraformStoreAccessManager(unittest.TestCase):
 
     def test_unconfigure_noop(self) -> None:
         self.manager.unconfigure()  # should not raise
+
+
+class TestGetBackendTemplate(unittest.TestCase):
+    def test_s3_only_returns_template_without_dynamodb(self) -> None:
+        template = TerraformStoreAccessManager._get_backend_template(StoreType.S3_ONLY)
+
+        self.assertNotIn("dynamodb_table", template)
+        self.assertIn("backend", template)
+
+    def test_s3_ddb_returns_template_with_dynamodb(self) -> None:
+        template = TerraformStoreAccessManager._get_backend_template(StoreType.S3_DDB)
+
+        self.assertIn("dynamodb_table", template)
+        self.assertIn("backend", template)
+
+    def test_all_store_types_are_mapped(self) -> None:
+        for store_type in StoreType:
+            template = TerraformStoreAccessManager._get_backend_template(store_type)
+            self.assertIn("backend", template)
+
+    def test_raises_for_invalid_store_type(self) -> None:
+        with self.assertRaises(InvalidStoreTypeError):
+            TerraformStoreAccessManager._get_backend_template("not-a-store-type")  # type: ignore[arg-type]

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_config_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_config_handler.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import ANY, Mock, patch
 
 from jupyter_deploy.engine.supervised_execution import NullDisplay
+from jupyter_deploy.enum import StoreType
 from jupyter_deploy.exceptions import InvalidPresetError
 from jupyter_deploy.handlers.project.config_handler import ConfigHandler
 from jupyter_deploy.manifest import JupyterDeployManifestV1, JupyterDeployProjectStoreV1
@@ -430,9 +431,9 @@ class TestConfigHandler(unittest.TestCase):
         mock_tf_handler.return_value = tf_mock_handler_instance
 
         handler = ConfigHandler(display_manager=NullDisplay())
-        handler.ensure_store(store_type="gcs", store_id="my-bucket")
+        handler.ensure_store(store_type=StoreType.S3_DDB, store_id="my-bucket")
 
-        mock_store_factory.get_manager.assert_called_once_with(store_type="gcs", store_id="my-bucket")
+        mock_store_factory.get_manager.assert_called_once_with(store_type=StoreType.S3_DDB, store_id="my-bucket")
         mock_store_manager.ensure_store.assert_called_once()
 
     @patch("jupyter_deploy.handlers.project.config_handler.StoreManagerFactory")

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_up_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_up_handler.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
 from jupyter_deploy.engine.supervised_execution import NullDisplay
+from jupyter_deploy.enum import StoreType
 from jupyter_deploy.exceptions import ProjectIdNotAvailableError, ProjectStoreAccessConfigurationError
 from jupyter_deploy.handlers.project.up_handler import UpHandler
 from jupyter_deploy.manifest import JupyterDeployManifestV1, JupyterDeployProjectStoreV1
@@ -278,9 +279,9 @@ class TestUpHandlerPushToStore(unittest.TestCase):
         mock_output_def = StrTemplateOutputDefinition(output_name="deployment_id", value="dep-001")
         mock_outputs_cls.return_value.get_declared_output_def.return_value = mock_output_def
 
-        handler.push_to_store(store_type="gcs", store_id="my-bucket")
+        handler.push_to_store(store_type=StoreType.S3_DDB, store_id="my-bucket")
 
-        mock_store_factory.get_manager.assert_called_once_with(store_type="gcs", store_id="my-bucket")
+        mock_store_factory.get_manager.assert_called_once_with(store_type=StoreType.S3_DDB, store_id="my-bucket")
 
     @patch("jupyter_deploy.handlers.project.up_handler.TerraformOutputsHandler")
     @patch("jupyter_deploy.engine.terraform.tf_up.TerraformUpHandler")

--- a/libs/jupyter-deploy/tests/unit/provider/aws/store/test_s3_dynamodb_store.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/store/test_s3_dynamodb_store.py
@@ -1,136 +1,44 @@
-import re
 import unittest
-from datetime import UTC, datetime
-from pathlib import Path
 from typing import Any, cast
 from unittest.mock import Mock, patch
 
 import botocore.exceptions
-from mypy_boto3_s3.type_defs import ObjectTypeDef
 
-from jupyter_deploy.api.aws.s3.s3_sync import S3SyncResult
 from jupyter_deploy.engine.supervised_execution import NullDisplay
-from jupyter_deploy.exceptions import ProjectStoreNotFoundError, ProviderPermissionError
+from jupyter_deploy.enum import StoreType
+from jupyter_deploy.exceptions import ProviderPermissionError
 from jupyter_deploy.provider.aws.store.s3_dynamodb_store import S3DynamoDbTableStoreManager
+from jupyter_deploy.provider.aws.store.s3_store import S3StoreManager
+from jupyter_deploy.provider.store.store_manager import StoreInfo
 
-
-def _obj(key: str, size: int, last_modified: datetime) -> ObjectTypeDef:
-    return {
-        "Key": key,
-        "Size": size,
-        "LastModified": last_modified,
-        "ETag": "",
-        "ChecksumAlgorithm": [],
-        "ChecksumType": "FULL_OBJECT",
-        "StorageClass": "STANDARD",
-        "Owner": {"DisplayName": "", "ID": ""},
-        "RestoreStatus": {},  # type: ignore[typeddict-item]
-    }
-
-
-class TestResolveLeadRegion(unittest.TestCase):
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.sts_identity")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_delegates_to_sts_identity(self, mock_boto3: Mock, mock_sts_identity: Mock) -> None:
-        mock_sts_client = Mock()
-        mock_boto3.client.return_value = mock_sts_client
-        mock_sts_identity.get_partition_lead_region.return_value = "us-east-1"
-
-        result = S3DynamoDbTableStoreManager.resolve_lead_region()
-
-        self.assertEqual(result, "us-east-1")
-        mock_boto3.client.assert_called_once_with("sts")
-        mock_sts_identity.get_partition_lead_region.assert_called_once_with(mock_sts_client)
+_S3_MODULE = "jupyter_deploy.provider.aws.store.s3_store"
+_DDB_MODULE = "jupyter_deploy.provider.aws.store.s3_dynamodb_store"
 
 
 class TestFindStore(unittest.TestCase):
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_discovers_existing_bucket(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+    @patch(f"{_S3_MODULE}.s3_bucket")
+    @patch(f"{_S3_MODULE}.boto3")
+    @patch(f"{_DDB_MODULE}.boto3")
+    def test_returns_s3_ddb_store_type(self, mock_ddb_boto3: Mock, mock_s3_boto3: Mock, mock_s3_bucket: Mock) -> None:
         mock_s3_bucket.find_buckets_by_tag.return_value = [{"Name": "existing-bucket"}]
         provider = S3DynamoDbTableStoreManager(region="us-east-1")
 
         result = provider.find_store()
 
-        self.assertEqual(result.store_id, "existing-bucket")
-        self.assertEqual(result.store_type, "s3-ddb")
-        self.assertEqual(result.location, "us-east-1")
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_when_no_bucket_found(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = []
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        with self.assertRaises(ProjectStoreNotFoundError):
-            provider.find_store()
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_uses_provided_bucket_name(self, mock_boto3: Mock) -> None:
-        provider = S3DynamoDbTableStoreManager(region="us-west-2", bucket_name="my-bucket")
-
-        result = provider.find_store()
-
-        self.assertEqual(result.store_id, "my-bucket")
-        self.assertEqual(result.location, "us-west-2")
+        self.assertEqual(result.store_type, StoreType.S3_DDB)
 
 
 class TestEnsureStore(unittest.TestCase):
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_discovers_existing_bucket(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = [{"Name": "existing-bucket"}]
-        mock_ddb.get_table_by_name.return_value = {"Table": {"TableStatus": "ACTIVE"}}
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        result = provider.ensure_store(NullDisplay())
-
-        self.assertEqual(result.store_id, "existing-bucket")
-        self.assertEqual(result.store_type, "s3-ddb")
-        self.assertEqual(result.location, "us-east-1")
-        mock_s3_bucket.find_buckets_by_tag.assert_called_once_with(
-            mock_boto3.client.return_value, "Source", "jupyter-deploy-cli", stop_at_first_match=True
-        )
-        mock_s3_bucket.create_bucket.assert_not_called()
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_creates_bucket_when_not_found(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = []
-        mock_ddb.get_table_by_name.return_value = {"Table": {"TableStatus": "ACTIVE"}}
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        result = provider.ensure_store(NullDisplay())
-
-        mock_s3_bucket.create_bucket.assert_called_once()
-        self.assertTrue(result.store_id.startswith("jupyter-deploy-projects-"))
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_generated_bucket_name_is_valid_s3_name(
-        self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock
+    @patch(f"{_DDB_MODULE}.dynamodb_table")
+    @patch.object(S3StoreManager, "ensure_store")
+    @patch(f"{_DDB_MODULE}.boto3")
+    @patch(f"{_S3_MODULE}.boto3")
+    def test_creates_ddb_table_when_not_found(
+        self, mock_s3_boto3: Mock, mock_ddb_boto3: Mock, mock_parent_ensure: Mock, mock_ddb: Mock
     ) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = []
-        mock_ddb.get_table_by_name.return_value = {"Table": {"TableStatus": "ACTIVE"}}
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        result = provider.ensure_store(NullDisplay())
-
-        # S3 bucket names: 3-63 chars, lowercase alphanumeric and hyphens,
-        # must start/end with letter or number.
-        # ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-        s3_bucket_pattern = re.compile(r"^[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]$")
-        self.assertRegex(result.store_id, s3_bucket_pattern)
-        self.assertLessEqual(len(result.store_id), 63)
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_creates_ddb_table_when_not_found(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = [{"Name": "existing-bucket"}]
+        mock_parent_ensure.return_value = StoreInfo(
+            store_type=StoreType.S3_DDB, store_id="bucket", location="us-east-1"
+        )
         error_response = cast(Any, {"Error": {"Code": "ResourceNotFoundException", "Message": "Table not found"}})
         mock_ddb.get_table_by_name.side_effect = botocore.exceptions.ClientError(error_response, "DescribeTable")
         provider = S3DynamoDbTableStoreManager(region="us-east-1")
@@ -140,46 +48,33 @@ class TestEnsureStore(unittest.TestCase):
         mock_ddb.create_lock_table.assert_called_once()
         mock_ddb.wait_for_table_active.assert_called_once()
 
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_bucket_creation_failure(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = []
-        mock_s3_bucket.create_bucket.side_effect = RuntimeError("creation failed")
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        with self.assertRaises(RuntimeError):
-            provider.ensure_store(NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_uses_provided_bucket_name(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_ddb.get_table_by_name.return_value = {"Table": {"TableStatus": "ACTIVE"}}
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="my-bucket")
-
-        result = provider.ensure_store(NullDisplay())
-
-        self.assertEqual(result.store_id, "my-bucket")
-        mock_s3_bucket.find_buckets_by_tag.assert_not_called()
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_s3_lookup_failure(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.side_effect = botocore.exceptions.ClientError(
-            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListBuckets"
+    @patch(f"{_DDB_MODULE}.dynamodb_table")
+    @patch.object(S3StoreManager, "ensure_store")
+    @patch(f"{_DDB_MODULE}.boto3")
+    @patch(f"{_S3_MODULE}.boto3")
+    def test_finds_existing_ddb_table(
+        self, mock_s3_boto3: Mock, mock_ddb_boto3: Mock, mock_parent_ensure: Mock, mock_ddb: Mock
+    ) -> None:
+        mock_parent_ensure.return_value = StoreInfo(
+            store_type=StoreType.S3_DDB, store_id="bucket", location="us-east-1"
         )
+        mock_ddb.get_table_by_name.return_value = {"Table": {"TableStatus": "ACTIVE"}}
         provider = S3DynamoDbTableStoreManager(region="us-east-1")
 
-        with self.assertRaises(ProviderPermissionError):
-            provider.ensure_store(NullDisplay())
+        provider.ensure_store(NullDisplay())
 
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_ddb_lookup_failure(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = [{"Name": "existing-bucket"}]
+        mock_ddb.create_lock_table.assert_not_called()
+
+    @patch(f"{_DDB_MODULE}.dynamodb_table")
+    @patch.object(S3StoreManager, "ensure_store")
+    @patch(f"{_DDB_MODULE}.boto3")
+    @patch(f"{_S3_MODULE}.boto3")
+    def test_raises_on_ddb_lookup_failure(
+        self, mock_s3_boto3: Mock, mock_ddb_boto3: Mock, mock_parent_ensure: Mock, mock_ddb: Mock
+    ) -> None:
+        mock_parent_ensure.return_value = StoreInfo(
+            store_type=StoreType.S3_DDB, store_id="bucket", location="us-east-1"
+        )
         mock_ddb.get_table_by_name.side_effect = botocore.exceptions.ClientError(
             cast(Any, {"Error": {"Code": "AccessDeniedException", "Message": "Forbidden"}}), "DescribeTable"
         )
@@ -188,24 +83,16 @@ class TestEnsureStore(unittest.TestCase):
         with self.assertRaises(ProviderPermissionError):
             provider.ensure_store(NullDisplay())
 
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_s3_create_failure(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = []
-        mock_s3_bucket.create_bucket.side_effect = botocore.exceptions.ClientError(
-            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "CreateBucket"
+    @patch(f"{_DDB_MODULE}.dynamodb_table")
+    @patch.object(S3StoreManager, "ensure_store")
+    @patch(f"{_DDB_MODULE}.boto3")
+    @patch(f"{_S3_MODULE}.boto3")
+    def test_raises_on_ddb_create_failure(
+        self, mock_s3_boto3: Mock, mock_ddb_boto3: Mock, mock_parent_ensure: Mock, mock_ddb: Mock
+    ) -> None:
+        mock_parent_ensure.return_value = StoreInfo(
+            store_type=StoreType.S3_DDB, store_id="bucket", location="us-east-1"
         )
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        with self.assertRaises(ProviderPermissionError):
-            provider.ensure_store(NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.dynamodb_table")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_ddb_create_failure(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_ddb: Mock) -> None:
-        mock_s3_bucket.find_buckets_by_tag.return_value = [{"Name": "existing-bucket"}]
         error_response = cast(Any, {"Error": {"Code": "ResourceNotFoundException", "Message": "Table not found"}})
         mock_ddb.get_table_by_name.side_effect = botocore.exceptions.ClientError(error_response, "DescribeTable")
         mock_ddb.create_lock_table.side_effect = botocore.exceptions.ClientError(
@@ -216,189 +103,18 @@ class TestEnsureStore(unittest.TestCase):
         with self.assertRaises(ProviderPermissionError):
             provider.ensure_store(NullDisplay())
 
-
-class TestPush(unittest.TestCase):
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_sync")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_syncs_project_to_remote(self, mock_boto3: Mock, mock_sync: Mock) -> None:
-        mock_sync.sync_to_remote.return_value = S3SyncResult(uploaded=3, deleted=1, unchanged=5)
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        with patch.object(Path, "exists", return_value=True):
-            result = provider.push(Path("/project"), "my-project", NullDisplay())
-
-        self.assertEqual(result.uploaded, 3)
-        self.assertEqual(result.deleted, 1)
-        self.assertEqual(result.unchanged, 5)
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_when_store_not_initialized(self, mock_boto3: Mock) -> None:
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        with self.assertRaises(ProjectStoreNotFoundError):
-            provider.push(Path("/project"), "my-project", NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_sync")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_sync_failure(self, mock_boto3: Mock, mock_sync: Mock) -> None:
-        mock_sync.sync_to_remote.side_effect = RuntimeError("upload failed")
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        with patch.object(Path, "exists", return_value=False), self.assertRaises(RuntimeError):
-            provider.push(Path("/project"), "my-project", NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_sync")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_sync_to_remote_permission_error(self, mock_boto3: Mock, mock_sync: Mock) -> None:
-        mock_sync.sync_to_remote.side_effect = botocore.exceptions.ClientError(
-            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "PutObject"
-        )
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        with patch.object(Path, "exists", return_value=False), self.assertRaises(ProviderPermissionError):
-            provider.push(Path("/project"), "my-project", NullDisplay())
-
-
-class TestPull(unittest.TestCase):
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_sync")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_syncs_from_remote(self, mock_boto3: Mock, mock_sync: Mock) -> None:
-        mock_sync.sync_from_remote.return_value = S3SyncResult(uploaded=5, deleted=0, unchanged=0)
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        result = provider.pull("my-project", Path("/dest"), NullDisplay())
-
-        self.assertEqual(result.uploaded, 5)
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_when_store_not_initialized(self, mock_boto3: Mock) -> None:
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        with self.assertRaises(ProjectStoreNotFoundError):
-            provider.pull("my-project", Path("/dest"), NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_sync")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_sync_from_remote_permission_error(self, mock_boto3: Mock, mock_sync: Mock) -> None:
-        mock_sync.sync_from_remote.side_effect = botocore.exceptions.ClientError(
-            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "GetObject"
-        )
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        with self.assertRaises(ProviderPermissionError):
-            provider.pull("my-project", Path("/dest"), NullDisplay())
-
-
-class TestListProjects(unittest.TestCase):
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_object")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_lists_projects(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_s3_object: Mock) -> None:
-        now = datetime.now(tz=UTC)
-        mock_s3_bucket.list_top_level_prefixes.return_value = ["project-a", "project-b"]
-        mock_s3_object.list_objects.side_effect = [
-            [_obj("project-a/f.txt", 10, now)],
-            [],
-        ]
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        result = provider.list_projects(NullDisplay())
-
-        self.assertEqual(len(result), 2)
-        self.assertEqual(result[0].project_id, "project-a")
-        self.assertEqual(result[0].file_count, 1)
-        self.assertEqual(result[1].project_id, "project-b")
-        self.assertEqual(result[1].file_count, 0)
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_when_store_not_initialized(self, mock_boto3: Mock) -> None:
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        with self.assertRaises(ProjectStoreNotFoundError):
-            provider.list_projects(NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_list_prefixes_permission_error(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
-        mock_s3_bucket.list_top_level_prefixes.side_effect = botocore.exceptions.ClientError(
-            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListObjectsV2"
-        )
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        with self.assertRaises(ProviderPermissionError):
-            provider.list_projects(NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_object")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_bucket")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_list_objects_permission_error(
-        self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_s3_object: Mock
+    @patch(f"{_DDB_MODULE}.dynamodb_table")
+    @patch.object(S3StoreManager, "ensure_store")
+    @patch(f"{_DDB_MODULE}.boto3")
+    @patch(f"{_S3_MODULE}.boto3")
+    def test_returns_store_info_from_parent(
+        self, mock_s3_boto3: Mock, mock_ddb_boto3: Mock, mock_parent_ensure: Mock, mock_ddb: Mock
     ) -> None:
-        mock_s3_bucket.list_top_level_prefixes.return_value = ["project-a"]
-        mock_s3_object.list_objects.side_effect = botocore.exceptions.ClientError(
-            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListObjectsV2"
-        )
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
+        expected = StoreInfo(store_type=StoreType.S3_DDB, store_id="my-bucket", location="us-west-2")
+        mock_parent_ensure.return_value = expected
+        mock_ddb.get_table_by_name.return_value = {"Table": {"TableStatus": "ACTIVE"}}
+        provider = S3DynamoDbTableStoreManager(region="us-west-2")
 
-        with self.assertRaises(ProviderPermissionError):
-            provider.list_projects(NullDisplay())
+        result = provider.ensure_store(NullDisplay())
 
-
-class TestDeleteProject(unittest.TestCase):
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_object")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_deletes_project_objects(self, mock_boto3: Mock, mock_s3_object: Mock) -> None:
-        now = datetime.now(tz=UTC)
-        mock_s3_object.list_objects.return_value = [
-            _obj("proj/a.txt", 10, now),
-            _obj("proj/b.txt", 20, now),
-        ]
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        provider.delete_project("proj", NullDisplay())
-
-        mock_s3_object.delete_objects.assert_called_once()
-        call_args = mock_s3_object.delete_objects.call_args
-        keys = call_args[1]["keys"] if "keys" in call_args[1] else call_args[0][2]
-        self.assertEqual(keys, ["proj/a.txt", "proj/b.txt"])
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_object")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_handles_empty_project(self, mock_boto3: Mock, mock_s3_object: Mock) -> None:
-        mock_s3_object.list_objects.return_value = []
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        provider.delete_project("proj", NullDisplay())
-
-        mock_s3_object.delete_objects.assert_not_called()
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_when_store_not_initialized(self, mock_boto3: Mock) -> None:
-        provider = S3DynamoDbTableStoreManager(region="us-east-1")
-
-        with self.assertRaises(ProjectStoreNotFoundError):
-            provider.delete_project("proj", NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_object")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_list_objects_permission_error(self, mock_boto3: Mock, mock_s3_object: Mock) -> None:
-        mock_s3_object.list_objects.side_effect = botocore.exceptions.ClientError(
-            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListObjectsV2"
-        )
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        with self.assertRaises(ProviderPermissionError):
-            provider.delete_project("proj", NullDisplay())
-
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.s3_object")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_raises_on_delete_objects_permission_error(self, mock_boto3: Mock, mock_s3_object: Mock) -> None:
-        now = datetime.now(tz=UTC)
-        mock_s3_object.list_objects.return_value = [_obj("proj/a.txt", 10, now)]
-        mock_s3_object.delete_objects.side_effect = botocore.exceptions.ClientError(
-            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "DeleteObjects"
-        )
-        provider = S3DynamoDbTableStoreManager(region="us-east-1", bucket_name="bucket")
-
-        with self.assertRaises(ProviderPermissionError):
-            provider.delete_project("proj", NullDisplay())
+        self.assertEqual(result, expected)

--- a/libs/jupyter-deploy/tests/unit/provider/aws/store/test_s3_store.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/store/test_s3_store.py
@@ -1,0 +1,370 @@
+import re
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import Mock, patch
+
+import botocore.exceptions
+from mypy_boto3_s3.type_defs import ObjectTypeDef
+
+from jupyter_deploy.api.aws.s3.s3_sync import S3SyncResult
+from jupyter_deploy.engine.supervised_execution import NullDisplay
+from jupyter_deploy.enum import StoreType
+from jupyter_deploy.exceptions import ProjectStoreNotFoundError, ProviderPermissionError
+from jupyter_deploy.provider.aws.store.s3_store import S3StoreManager
+
+_MODULE = "jupyter_deploy.provider.aws.store.s3_store"
+
+
+def _obj(key: str, size: int, last_modified: datetime) -> ObjectTypeDef:
+    return {
+        "Key": key,
+        "Size": size,
+        "LastModified": last_modified,
+        "ETag": "",
+        "ChecksumAlgorithm": [],
+        "ChecksumType": "FULL_OBJECT",
+        "StorageClass": "STANDARD",
+        "Owner": {"DisplayName": "", "ID": ""},
+        "RestoreStatus": {},  # type: ignore[typeddict-item]
+    }
+
+
+class TestResolveLeadRegion(unittest.TestCase):
+    @patch(f"{_MODULE}.sts_identity")
+    @patch(f"{_MODULE}.boto3")
+    def test_delegates_to_sts_identity(self, mock_boto3: Mock, mock_sts_identity: Mock) -> None:
+        mock_sts_client = Mock()
+        mock_boto3.client.return_value = mock_sts_client
+        mock_sts_identity.get_partition_lead_region.return_value = "us-east-1"
+
+        result = S3StoreManager.resolve_lead_region()
+
+        self.assertEqual(result, "us-east-1")
+        mock_boto3.client.assert_called_once_with("sts")
+        mock_sts_identity.get_partition_lead_region.assert_called_once_with(mock_sts_client)
+
+    @patch(f"{_MODULE}.sts_identity")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_sts_failure(self, mock_boto3: Mock, mock_sts_identity: Mock) -> None:
+        mock_sts_identity.get_partition_lead_region.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "GetCallerIdentity"
+        )
+
+        with self.assertRaises(botocore.exceptions.ClientError):
+            S3StoreManager.resolve_lead_region()
+
+
+class TestFindStore(unittest.TestCase):
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_discovers_existing_bucket(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.return_value = [{"Name": "existing-bucket"}]
+        provider = S3StoreManager(region="us-east-1")
+
+        result = provider.find_store()
+
+        self.assertEqual(result.store_id, "existing-bucket")
+        self.assertEqual(result.store_type, StoreType.S3_ONLY)
+        self.assertEqual(result.location, "us-east-1")
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_when_no_bucket_found(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.return_value = []
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(ProjectStoreNotFoundError):
+            provider.find_store()
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_permission_error(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListBuckets"
+        )
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(ProviderPermissionError):
+            provider.find_store()
+
+    @patch(f"{_MODULE}.boto3")
+    def test_uses_provided_bucket_name(self, mock_boto3: Mock) -> None:
+        provider = S3StoreManager(region="us-west-2", bucket_name="my-bucket")
+
+        result = provider.find_store()
+
+        self.assertEqual(result.store_id, "my-bucket")
+        self.assertEqual(result.location, "us-west-2")
+
+
+class TestEnsureStore(unittest.TestCase):
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_discovers_existing_bucket(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.return_value = [{"Name": "existing-bucket"}]
+        provider = S3StoreManager(region="us-east-1")
+
+        result = provider.ensure_store(NullDisplay())
+
+        self.assertEqual(result.store_id, "existing-bucket")
+        self.assertEqual(result.store_type, StoreType.S3_ONLY)
+        self.assertEqual(result.location, "us-east-1")
+        mock_s3_bucket.find_buckets_by_tag.assert_called_once_with(
+            mock_boto3.client.return_value, "Source", "jupyter-deploy-cli", stop_at_first_match=True
+        )
+        mock_s3_bucket.create_bucket.assert_not_called()
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_creates_bucket_when_not_found(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.return_value = []
+        provider = S3StoreManager(region="us-east-1")
+
+        result = provider.ensure_store(NullDisplay())
+
+        mock_s3_bucket.create_bucket.assert_called_once()
+        self.assertTrue(result.store_id.startswith("jupyter-deploy-projects-"))
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_generated_bucket_name_is_valid_s3_name(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.return_value = []
+        provider = S3StoreManager(region="us-east-1")
+
+        result = provider.ensure_store(NullDisplay())
+
+        s3_bucket_pattern = re.compile(r"^[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]$")
+        self.assertRegex(result.store_id, s3_bucket_pattern)
+        self.assertLessEqual(len(result.store_id), 63)
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_bucket_creation_failure(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.return_value = []
+        mock_s3_bucket.create_bucket.side_effect = RuntimeError("creation failed")
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(RuntimeError):
+            provider.ensure_store(NullDisplay())
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_uses_provided_bucket_name(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        provider = S3StoreManager(region="us-east-1", bucket_name="my-bucket")
+
+        result = provider.ensure_store(NullDisplay())
+
+        self.assertEqual(result.store_id, "my-bucket")
+        mock_s3_bucket.find_buckets_by_tag.assert_not_called()
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_s3_lookup_failure(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListBuckets"
+        )
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(ProviderPermissionError):
+            provider.ensure_store(NullDisplay())
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_s3_create_failure(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.find_buckets_by_tag.return_value = []
+        mock_s3_bucket.create_bucket.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "CreateBucket"
+        )
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(ProviderPermissionError):
+            provider.ensure_store(NullDisplay())
+
+
+class TestPush(unittest.TestCase):
+    @patch(f"{_MODULE}.s3_sync")
+    @patch(f"{_MODULE}.boto3")
+    def test_syncs_project_to_remote(self, mock_boto3: Mock, mock_sync: Mock) -> None:
+        mock_sync.sync_to_remote.return_value = S3SyncResult(uploaded=3, deleted=1, unchanged=5)
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        with patch.object(Path, "exists", return_value=True):
+            result = provider.push(Path("/project"), "my-project", NullDisplay())
+
+        self.assertEqual(result.uploaded, 3)
+        self.assertEqual(result.deleted, 1)
+        self.assertEqual(result.unchanged, 5)
+
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_when_store_not_initialized(self, mock_boto3: Mock) -> None:
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(ProjectStoreNotFoundError):
+            provider.push(Path("/project"), "my-project", NullDisplay())
+
+    @patch(f"{_MODULE}.s3_sync")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_sync_failure(self, mock_boto3: Mock, mock_sync: Mock) -> None:
+        mock_sync.sync_to_remote.side_effect = RuntimeError("upload failed")
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        with patch.object(Path, "exists", return_value=False), self.assertRaises(RuntimeError):
+            provider.push(Path("/project"), "my-project", NullDisplay())
+
+    @patch(f"{_MODULE}.s3_sync")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_sync_to_remote_permission_error(self, mock_boto3: Mock, mock_sync: Mock) -> None:
+        mock_sync.sync_to_remote.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "PutObject"
+        )
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        with patch.object(Path, "exists", return_value=False), self.assertRaises(ProviderPermissionError):
+            provider.push(Path("/project"), "my-project", NullDisplay())
+
+
+class TestPull(unittest.TestCase):
+    @patch(f"{_MODULE}.s3_sync")
+    @patch(f"{_MODULE}.boto3")
+    def test_syncs_from_remote(self, mock_boto3: Mock, mock_sync: Mock) -> None:
+        mock_sync.sync_from_remote.return_value = S3SyncResult(uploaded=5, deleted=0, unchanged=0)
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        result = provider.pull("my-project", Path("/dest"), NullDisplay())
+
+        self.assertEqual(result.uploaded, 5)
+
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_when_store_not_initialized(self, mock_boto3: Mock) -> None:
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(ProjectStoreNotFoundError):
+            provider.pull("my-project", Path("/dest"), NullDisplay())
+
+    @patch(f"{_MODULE}.s3_sync")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_sync_from_remote_permission_error(self, mock_boto3: Mock, mock_sync: Mock) -> None:
+        mock_sync.sync_from_remote.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "GetObject"
+        )
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        with self.assertRaises(ProviderPermissionError):
+            provider.pull("my-project", Path("/dest"), NullDisplay())
+
+
+class TestListProjects(unittest.TestCase):
+    @patch(f"{_MODULE}.s3_object")
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_lists_projects(self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_s3_object: Mock) -> None:
+        now = datetime.now(tz=UTC)
+        mock_s3_bucket.list_top_level_prefixes.return_value = ["project-a", "project-b"]
+        mock_s3_object.list_objects.side_effect = [
+            [_obj("project-a/f.txt", 10, now)],
+            [],
+        ]
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        result = provider.list_projects(NullDisplay())
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].project_id, "project-a")
+        self.assertEqual(result[0].file_count, 1)
+        self.assertEqual(result[1].project_id, "project-b")
+        self.assertEqual(result[1].file_count, 0)
+
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_when_store_not_initialized(self, mock_boto3: Mock) -> None:
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(ProjectStoreNotFoundError):
+            provider.list_projects(NullDisplay())
+
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_list_prefixes_permission_error(self, mock_boto3: Mock, mock_s3_bucket: Mock) -> None:
+        mock_s3_bucket.list_top_level_prefixes.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListObjectsV2"
+        )
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        with self.assertRaises(ProviderPermissionError):
+            provider.list_projects(NullDisplay())
+
+    @patch(f"{_MODULE}.s3_object")
+    @patch(f"{_MODULE}.s3_bucket")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_list_objects_permission_error(
+        self, mock_boto3: Mock, mock_s3_bucket: Mock, mock_s3_object: Mock
+    ) -> None:
+        mock_s3_bucket.list_top_level_prefixes.return_value = ["project-a"]
+        mock_s3_object.list_objects.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListObjectsV2"
+        )
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        with self.assertRaises(ProviderPermissionError):
+            provider.list_projects(NullDisplay())
+
+
+class TestDeleteProject(unittest.TestCase):
+    @patch(f"{_MODULE}.s3_object")
+    @patch(f"{_MODULE}.boto3")
+    def test_deletes_project_objects(self, mock_boto3: Mock, mock_s3_object: Mock) -> None:
+        now = datetime.now(tz=UTC)
+        mock_s3_object.list_objects.return_value = [
+            _obj("proj/a.txt", 10, now),
+            _obj("proj/b.txt", 20, now),
+        ]
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        provider.delete_project("proj", NullDisplay())
+
+        mock_s3_object.delete_objects.assert_called_once()
+        call_args = mock_s3_object.delete_objects.call_args
+        keys = call_args[1]["keys"] if "keys" in call_args[1] else call_args[0][2]
+        self.assertEqual(keys, ["proj/a.txt", "proj/b.txt"])
+
+    @patch(f"{_MODULE}.s3_object")
+    @patch(f"{_MODULE}.boto3")
+    def test_handles_empty_project(self, mock_boto3: Mock, mock_s3_object: Mock) -> None:
+        mock_s3_object.list_objects.return_value = []
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        provider.delete_project("proj", NullDisplay())
+
+        mock_s3_object.delete_objects.assert_not_called()
+
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_when_store_not_initialized(self, mock_boto3: Mock) -> None:
+        provider = S3StoreManager(region="us-east-1")
+
+        with self.assertRaises(ProjectStoreNotFoundError):
+            provider.delete_project("proj", NullDisplay())
+
+    @patch(f"{_MODULE}.s3_object")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_list_objects_permission_error(self, mock_boto3: Mock, mock_s3_object: Mock) -> None:
+        mock_s3_object.list_objects.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "ListObjectsV2"
+        )
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        with self.assertRaises(ProviderPermissionError):
+            provider.delete_project("proj", NullDisplay())
+
+    @patch(f"{_MODULE}.s3_object")
+    @patch(f"{_MODULE}.boto3")
+    def test_raises_on_delete_objects_permission_error(self, mock_boto3: Mock, mock_s3_object: Mock) -> None:
+        now = datetime.now(tz=UTC)
+        mock_s3_object.list_objects.return_value = [_obj("proj/a.txt", 10, now)]
+        mock_s3_object.delete_objects.side_effect = botocore.exceptions.ClientError(
+            cast(Any, {"Error": {"Code": "AccessDenied", "Message": "Forbidden"}}), "DeleteObjects"
+        )
+        provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
+
+        with self.assertRaises(ProviderPermissionError):
+            provider.delete_project("proj", NullDisplay())

--- a/libs/jupyter-deploy/tests/unit/provider/store/test_store_manager_factory.py
+++ b/libs/jupyter-deploy/tests/unit/provider/store/test_store_manager_factory.py
@@ -1,35 +1,53 @@
 import unittest
 from unittest.mock import Mock, patch
 
+from jupyter_deploy.enum import StoreType
 from jupyter_deploy.provider.aws.store.s3_dynamodb_store import S3DynamoDbTableStoreManager
+from jupyter_deploy.provider.aws.store.s3_store import S3StoreManager
 from jupyter_deploy.provider.store.store_manager_factory import StoreManagerFactory
 
 
 class TestStoreManagerFactory(unittest.TestCase):
+    @patch.object(S3StoreManager, "resolve_lead_region", return_value="us-east-1")
+    @patch("jupyter_deploy.provider.aws.store.s3_store.boto3")
+    def test_returns_s3_only_provider(self, mock_boto3: Mock, mock_resolve: Mock) -> None:
+        provider = StoreManagerFactory.get_manager(StoreType.S3_ONLY, store_id="my-bucket")
+
+        self.assertIsInstance(provider, S3StoreManager)
+        self.assertNotIsInstance(provider, S3DynamoDbTableStoreManager)
+
     @patch.object(S3DynamoDbTableStoreManager, "resolve_lead_region", return_value="us-east-1")
+    @patch("jupyter_deploy.provider.aws.store.s3_store.boto3")
     @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_returns_s3_provider(self, mock_boto3: Mock, mock_resolve: Mock) -> None:
-        provider = StoreManagerFactory.get_manager("s3-ddb", store_id="my-bucket")
+    def test_returns_s3_ddb_provider(self, mock_ddb_boto3: Mock, mock_s3_boto3: Mock, mock_resolve: Mock) -> None:
+        provider = StoreManagerFactory.get_manager(StoreType.S3_DDB, store_id="my-bucket")
 
         self.assertIsInstance(provider, S3DynamoDbTableStoreManager)
 
     def test_raises_for_unknown_store_type(self) -> None:
-        with self.assertRaises(NotImplementedError) as ctx:
-            StoreManagerFactory.get_manager("gcs")
+        with self.assertRaises(ValueError):
+            StoreType.from_string("gcs")
 
-        self.assertIn("gcs", str(ctx.exception))
-
-    @patch.object(S3DynamoDbTableStoreManager, "resolve_lead_region", return_value="us-east-1")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
-    def test_s3_provider_receives_store_id(self, mock_boto3: Mock, mock_resolve: Mock) -> None:
-        provider = StoreManagerFactory.get_manager("s3-ddb", store_id="custom-bucket")
+    @patch.object(S3StoreManager, "resolve_lead_region", return_value="us-east-1")
+    @patch("jupyter_deploy.provider.aws.store.s3_store.boto3")
+    def test_s3_only_provider_receives_store_id(self, mock_boto3: Mock, mock_resolve: Mock) -> None:
+        provider = StoreManagerFactory.get_manager(StoreType.S3_ONLY, store_id="custom-bucket")
 
         self.assertEqual(provider._bucket_name, "custom-bucket")  # type: ignore[attr-defined]
 
-    @patch.object(S3DynamoDbTableStoreManager, "resolve_lead_region", return_value="us-east-1")
-    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
+    @patch.object(S3StoreManager, "resolve_lead_region", return_value="us-east-1")
+    @patch("jupyter_deploy.provider.aws.store.s3_store.boto3")
     def test_resolves_region_and_passes_to_constructor(self, mock_boto3: Mock, mock_resolve: Mock) -> None:
-        provider = StoreManagerFactory.get_manager("s3-ddb")
+        provider = StoreManagerFactory.get_manager(StoreType.S3_ONLY)
 
         mock_resolve.assert_called_once()
         self.assertEqual(provider._region, "us-east-1")  # type: ignore[attr-defined]
+
+    @patch.object(S3DynamoDbTableStoreManager, "resolve_lead_region", return_value="cn-north-1")
+    @patch("jupyter_deploy.provider.aws.store.s3_store.boto3")
+    @patch("jupyter_deploy.provider.aws.store.s3_dynamodb_store.boto3")
+    def test_s3_ddb_resolves_region(self, mock_ddb_boto3: Mock, mock_s3_boto3: Mock, mock_resolve: Mock) -> None:
+        provider = StoreManagerFactory.get_manager(StoreType.S3_DDB)
+
+        mock_resolve.assert_called_once()
+        self.assertEqual(provider._region, "cn-north-1")  # type: ignore[attr-defined]

--- a/libs/jupyter-deploy/tests/unit/test_manifest.py
+++ b/libs/jupyter-deploy/tests/unit/test_manifest.py
@@ -5,6 +5,8 @@ from typing import Any
 import yaml
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.enum import StoreType
+from jupyter_deploy.exceptions import InvalidStoreTypeError
 from jupyter_deploy.manifest import (
     InvalidServiceError,
     JupyterDeployManifestV1,
@@ -129,6 +131,22 @@ class TestJupyterDeployProjectStoreV1(unittest.TestCase):
     def test_has_project_store_false(self) -> None:
         manifest = self._make_manifest()
         self.assertFalse(manifest.has_project_store())
+
+    def test_get_store_type_s3_only(self) -> None:
+        project_store = JupyterDeployProjectStoreV1(**{"store-type": "s3-only"})  # type: ignore
+        self.assertEqual(project_store.get_store_type(), StoreType.S3_ONLY)
+
+    def test_get_store_type_s3_ddb(self) -> None:
+        project_store = JupyterDeployProjectStoreV1(**{"store-type": "s3-ddb"})  # type: ignore
+        self.assertEqual(project_store.get_store_type(), StoreType.S3_DDB)
+
+    def test_get_store_type_invalid_raises(self) -> None:
+        project_store = JupyterDeployProjectStoreV1(**{"store-type": "gcs"})  # type: ignore
+        with self.assertRaises(InvalidStoreTypeError) as ctx:
+            project_store.get_store_type()
+        self.assertEqual(ctx.exception.store_type, "gcs")
+        self.assertIn("s3-only", ctx.exception.valid_store_types)
+        self.assertIn("s3-ddb", ctx.exception.valid_store_types)
 
     def test_compute_project_id(self) -> None:
         manifest = self._make_manifest()


### PR DESCRIPTION
This PR adds a second `store-type: s3-only`, which does not use the dynamoDB-based lock mechanism to prevent concurrent changes in the terraform state. It switches the base template to use this store mechanism, effectively storing the terraform state and project details only on the account S3 bucket.

This is necessary because the lock caused usability friction with no real benefit for a typical jupyter-deploy user. The more advanced case remain possible by specifying `store-type: s3-ddb`.

Closes: #166 

### User experience
- no change, this is invisible to the user, `jupyter-deploy` manages the remote-state on its own

### Implementation
- add an `S3StoreManager` class mapping to `store-type: s3-only`
- change `S3DynamoDbTableStoreManager` class to extend `S3StoreManager`
- add handling for both `StoreType` in `StoreManagerFactory`
- add a `StoreType` enum and a corresponding `InvalidStoreTypeError`, w/ handling in the cli decorator
- add handling for `store-type: s3-only` in `TerraformStoreAccessManager` to generate the appropriate `backend.tf`

### Testing
- tested manually against existing deployment
- delete the DDB table in the account, switched instance with `jd config --instance-type t3.xlarge` & `jd up` again