### PR TITLE
fix: plugin coverage

### DIFF
--- a/.github/utils/get_modified_dirs.py
+++ b/.github/utils/get_modified_dirs.py
@@ -6,6 +6,7 @@ import sys
 LIB_PATHS = [
     "libs/jupyter-deploy",
     "libs/jupyter-deploy-tf-aws-ec2-base",
+    "libs/pytest-jupyter-deploy",
     "images/uvbase",
 ]
 

--- a/libs/pytest-jupyter-deploy/pyproject.toml
+++ b/libs/pytest-jupyter-deploy/pyproject.toml
@@ -74,6 +74,26 @@ ignore = [
 # Allow lazy imports in tests (common pattern for imports after mocks)
 "tests/**/*.py" = ["PLC0415"]
 
+[tool.pytest.ini_options]
+addopts = "--cov=pytest_jupyter_deploy --cov-report=term-missing --cov-report=xml --cov-report=html -p pytester"
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["pytest_jupyter_deploy"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "pass",
+    "raise ImportError",
+]
+fail_under = 4
+show_missing = true
+
 [tool.mypy]
 warn_return_any = true
 warn_unused_configs = true
@@ -88,6 +108,7 @@ workspace = true
 [dependency-groups]
 dev = [
     "mypy>=1.15.0",
+    "pytest-cov>=6.1.1",
     "ruff>=0.11.8",
     "yamllint>=1.35.0",
     "types-pexpect>=4.9.0",

--- a/uv.lock
+++ b/uv.lock
@@ -796,6 +796,7 @@ ui = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-pexpect" },
     { name = "types-pyyaml" },
@@ -818,6 +819,7 @@ provides-extras = ["ui"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.15.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "ruff", specifier = ">=0.11.8" },
     { name = "types-pexpect", specifier = ">=4.9.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },


### PR DESCRIPTION
This PR fixes another issue with the `plugin-jupyter-deploy` CI (missing `pytest-cov` dev dependency, missing release script).

Follows: #173 #172 
Related to: #134 