### PR TITLE
feat: ci config utils

### DIFF
--- a/justfile
+++ b/justfile
@@ -523,3 +523,28 @@ test-e2e-ci project_dir="sandbox-e2e-ci" test_filter="" options="":
 # Setup GitHub OAuth for the base template
 auth-setup-base project_dir display="${DISPLAY:-}":
     @just auth-setup {{project_dir}} "{{display}}"
+
+# --- CI infrastructure commands ---
+
+# Export local auth state to Secrets Manager
+auth-export ci_dir="sandbox-ci":
+    uv run python scripts/sync_auth_state.py export {{ci_dir}}
+
+# Import auth state from Secrets Manager
+auth-import ci_dir="sandbox-ci":
+    uv run python scripts/ci_restore.py {{ci_dir}}
+    uv run python scripts/sync_auth_state.py import {{ci_dir}}
+
+# Check local auth state cookie expiry (no AWS access needed)
+auth-check:
+    uv run python scripts/sync_auth_state.py check
+
+# Generate .env for base template E2E tests from deployed project + CI infrastructure
+# Reads variables from the project, OAuth creds from CI, and accepts user options
+# Usage: just env-setup-base <project-dir> [ci-dir] [oauth-app-num] [options]
+# Options: comma-separated key=value pairs (same format as test-e2e options)
+# Quote options containing [] values (zsh treats brackets as glob patterns)
+# Example: just env-setup-base sandbox-e2e sandbox-ci 4 user=botuser,safe-user=realuser
+# Example: just env-setup-base sandbox-e2e sandbox-ci 4 'allowed-teams=[team1],user=botuser'
+env-setup-base project_dir ci_dir="sandbox-ci" oauth_app_num="1" options="":
+    uv run python scripts/env_setup_base.py {{project_dir}} {{ci_dir}} {{oauth_app_num}} "{{options}}"

--- a/justfile
+++ b/justfile
@@ -526,13 +526,16 @@ auth-setup-base project_dir display="${DISPLAY:-}":
 
 # --- CI infrastructure commands ---
 
+# Discover and restore CI project from S3 store
+ci-restore ci_dir="sandbox-ci":
+    uv run python scripts/ci_restore.py {{ci_dir}}
+
 # Export local auth state to Secrets Manager
 auth-export ci_dir="sandbox-ci":
     uv run python scripts/sync_auth_state.py export {{ci_dir}}
 
-# Import auth state from Secrets Manager
+# Import auth state from Secrets Manager (run ci-restore first)
 auth-import ci_dir="sandbox-ci":
-    uv run python scripts/ci_restore.py {{ci_dir}}
     uv run python scripts/sync_auth_state.py import {{ci_dir}}
 
 # Check local auth state cookie expiry (no AWS access needed)

--- a/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "mypy-boto3-s3",
     "mypy-boto3-dynamodb",
     "mypy-boto3-sts",
+    "mypy-boto3-secretsmanager",
 ]
 
 [project.license]

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/configurations/env.example
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/configurations/env.example
@@ -1,0 +1,67 @@
+# E2E Test Environment for the base template (tf-aws-ec2-base)
+#
+# Copy to <repo-root>/.env and fill in values, or use:
+#   just env-setup-base <project-dir> <ci-dir> <options>
+# to auto-populate from a deployed project and CI infrastructure.
+#
+# Variables are grouped by source:
+#   [from-project]  Read from deployed project via `jd show -v <var>`
+#   [from-ci]       Fetched from CI infrastructure (SSM/Secrets Manager)
+#   [user]          Must be provided manually
+
+# ==============================================================================
+# TEST CONTAINER BUILD CONFIGURATION
+# ==============================================================================
+
+# Leave blank — the justfile populates them automatically
+HOST_UID=
+HOST_GID=
+E2E_DOCKERFILE=
+
+# ==============================================================================
+# JUPYTER DEPLOYMENT CONFIGURATION
+# ==============================================================================
+
+# [from-project] Domain configuration
+JD_E2E_VAR_DOMAIN=example.com
+JD_E2E_VAR_SUBDOMAIN=test-e2e
+JD_E2E_VAR_EMAIL=test@example.com
+
+# [from-ci] OAuth app credentials (fetched from CI SSM/Secrets Manager)
+JD_E2E_VAR_OAUTH_APP_CLIENT_ID=00000aaaaa11111bbbbb
+JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET=00000aaaaa11111bbbbb22222ccccc
+
+# [from-project] Access control
+JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES=["username1", "username2"]
+JD_E2E_VAR_OAUTH_ALLOWED_ORG=your-org-name
+JD_E2E_VAR_OAUTH_ALLOWED_TEAMS=[]
+
+# ==============================================================================
+# TEST CONFIGURATION
+# ==============================================================================
+
+# --- USERS TESTS ---
+# [user] GitHub username the browser is logged in as
+JD_E2E_USER=
+# [user] Trusted GitHub username the browser is NOT logged in as
+JD_E2E_SAFE_USER=
+
+# --- ORG AND TEAM TESTS ---
+# [user] GitHub organization the logged user belongs to
+JD_E2E_ORG=
+# [user] Organization the logged user does NOT belong to
+JD_E2E_SAFE_ORG=
+# [user] GitHub team the logged user belongs to
+JD_E2E_TEAM=
+# [user] Team the logged user does NOT belong to
+JD_E2E_SAFE_TEAM=
+
+# --- CONFIG CHANGE TESTS ---
+# [user] Larger instance type for upgrade tests (e.g., t3.xlarge)
+JD_E2E_LARGER_INSTANCE=
+# [user] Larger log retention days for config tests (e.g., 365)
+JD_E2E_LARGER_LOG_RETENTION_DAYS=
+# [user] CPU instance type for swap tests (e.g., t3.medium)
+JD_E2E_CPU_INSTANCE=
+# [user] GPU instance type for GPU tests (e.g., g6.xlarge)
+JD_E2E_GPU_INSTANCE=

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_application.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_application.py
@@ -25,11 +25,12 @@ def test_application_simple_python(
     notebook_dir = Path(__file__).parent / "notebooks"
     notebook_path = notebook_dir / "application_simple.ipynb"
 
-    # Upload the notebook
-    upload_notebook(e2e_deployment, notebook_path, "e2e-test/application_simple.ipynb")
+    # Upload the notebook (returns a unique path to avoid jupyter-server-documents
+    # Y-doc room collisions between test runs — see issue.md)
+    server_path = upload_notebook(e2e_deployment, notebook_path, "e2e-test/application_simple.ipynb")
 
     # Run the notebook in the UI
-    run_notebook_in_jupyterlab(github_oauth_app.page, "e2e-test/application_simple.ipynb", timeout_ms=120000)
+    run_notebook_in_jupyterlab(github_oauth_app.page, server_path, timeout_ms=120000)
 
     # Clean up - delete the notebook
-    delete_notebook(e2e_deployment, "e2e-test/application_simple.ipynb")
+    delete_notebook(e2e_deployment, server_path)

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_projects.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_projects.py
@@ -4,6 +4,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import boto3
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 
 
@@ -19,6 +20,21 @@ def _get_store_type(e2e_deployment: EndToEndDeployment) -> str:
     store_type = result.stdout.strip()
     assert store_type and store_type != "N/A", f"Expected a valid store type, got '{store_type}'"
     return store_type
+
+
+def _get_output(e2e_deployment: EndToEndDeployment, output_name: str) -> str:
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "show", "-o", output_name, "--text"])
+    value = result.stdout.strip()
+    assert value and value != "N/A", f"Expected a valid value for output '{output_name}', got '{value}'"
+    return value
+
+
+def _fetch_secret(secret_arn: str) -> str:
+    """Fetch a secret value from AWS Secrets Manager."""
+    region = secret_arn.split(":")[3]
+    client = boto3.client("secretsmanager", region_name=region)
+    response = client.get_secret_value(SecretId=secret_arn)
+    return response["SecretString"]
 
 
 def test_projects_list_contains_deployed_project(e2e_deployment: EndToEndDeployment) -> None:
@@ -69,21 +85,34 @@ def test_projects_show_returns_deployed_project_details(e2e_deployment: EndToEnd
     assert "last-modified:" in output, f"Expected last-modified in output. Got: {output}"
     assert "file-count:" in output, f"Expected file-count in output. Got: {output}"
 
+    # Variables from variables.yaml should be included in the output
+    var_lines = [line for line in output.splitlines() if line.startswith("var:")]
+    assert len(var_lines) > 0, f"Expected at least one var: line in output. Got: {output}"
+
 
 def test_restore_project_and_config(e2e_deployment: EndToEndDeployment) -> None:
     """Test that a project can be restored and reconfigured.
 
     This test:
     1. Ensures deployment exists
-    2. Gets project ID and store type from deployed project
-    3. Restores the project to a temp directory via jd init --restore-project
-    4. Verifies jd show --info succeeds on the restored project
-    5. Verifies jd config --skip-verify succeeds on the restored project
+    2. Gets project ID, store type, and secret ARN from deployed project
+    3. Fetches the OAuth client secret from AWS Secrets Manager
+    4. Restores the project to a temp directory via jd init --restore-project
+    5. Verifies jd show --info succeeds on the restored project
+    6. Verifies jd config --skip-verify succeeds, passing the secret value
+       (sensitive variables are masked in the stored variables.yaml since #171,
+       so they must be re-supplied on restore — see issue #XX)
     """
     e2e_deployment.ensure_deployed()
 
     project_id = _get_project_id(e2e_deployment)
     store_type = _get_store_type(e2e_deployment)
+
+    # Fetch the OAuth client secret from AWS Secrets Manager before restoring.
+    # The stored variables.yaml has this value masked (****) since feat: mask secrets (#171),
+    # so we need to re-supply it to jd config after restore.
+    secret_arn = _get_output(e2e_deployment, "secret_arn")
+    oauth_client_secret = _fetch_secret(secret_arn)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         restore_dir = Path(tmpdir) / "restored"
@@ -116,9 +145,16 @@ def test_restore_project_and_config(e2e_deployment: EndToEndDeployment) -> None:
         assert "Store Type" in result.stdout, "Restored project should show Store Type"
         assert "Store ID" in result.stdout, "Restored project should show Store ID"
 
-        # Verify jd config --skip-verify works on restored project
+        # Verify jd config --skip-verify works on restored project.
+        # Pass the OAuth client secret explicitly since it's masked in variables.yaml.
         result = subprocess.run(
-            ["jupyter-deploy", "config", "--skip-verify"],
+            [
+                "jupyter-deploy",
+                "config",
+                "--skip-verify",
+                "--oauth-app-client-secret",
+                oauth_client_secret,
+            ],
             capture_output=True,
             text=True,
             cwd=str(restore_dir),

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -721,7 +721,7 @@ def show(
         )
         raise typer.Exit(code=1)
 
-    console = Console()
+    console = Console(emoji=False, highlight=False)
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
         handler = ShowHandler()
 
@@ -730,7 +730,7 @@ def show(
             var_value, var_description = handler.get_variable_str_value_and_description(variable)
             display_text = var_description if description else var_value
             if text:
-                console.print(display_text)
+                console.out(display_text)
             else:
                 console.print(f"[bold cyan]{display_text}[/]")
             return
@@ -740,7 +740,7 @@ def show(
             out_value, out_description = handler.get_output_str_value_and_description(output)
             display_text = out_description if description else out_value
             if text:
-                console.print(display_text)
+                console.out(display_text)
             else:
                 console.print(f"[bold cyan]{display_text}[/]")
             return
@@ -749,7 +749,7 @@ def show(
         if template_name:
             result = handler.get_template_name()
             if text:
-                console.print(result)
+                console.out(result)
             else:
                 console.print(f"[bold cyan]{result}[/]")
             return
@@ -757,7 +757,7 @@ def show(
         if template_version:
             result = handler.get_template_version()
             if text:
-                console.print(result)
+                console.out(result)
             else:
                 console.print(f"[bold cyan]{result}[/]")
             return
@@ -765,7 +765,7 @@ def show(
         if template_engine:
             result = handler.get_template_engine()
             if text:
-                console.print(result)
+                console.out(result)
             else:
                 console.print(f"[bold cyan]{result}[/]")
             return
@@ -774,7 +774,7 @@ def show(
         if project_id:
             result = handler.get_project_id()
             if text:
-                console.print(result)
+                console.out(result)
             else:
                 console.print(f"[bold cyan]{result}[/]")
             return
@@ -783,7 +783,7 @@ def show(
             resolved = handler.get_resolved_store_type()
             result = "N/A" if resolved is None else resolved.value
             if text:
-                console.print(result)
+                console.out(result)
             else:
                 console.print(f"[bold cyan]{result}[/]")
             return
@@ -792,7 +792,7 @@ def show(
             resolved_id = handler.get_resolved_store_id()
             result = "N/A" if resolved_id is None else resolved_id
             if text:
-                console.print(result)
+                console.out(result)
             else:
                 console.print(f"[bold cyan]{result}[/]")
             return
@@ -802,7 +802,7 @@ def show(
             if variables and not info and not outputs:
                 names = handler.list_variable_names()
                 if text:
-                    console.print(",".join(names))
+                    console.out(",".join(names))
                 else:
                     for name in names:
                         console.print(f"[bold cyan]{name}[/]")
@@ -810,7 +810,7 @@ def show(
             if outputs and not info and not variables:
                 names = handler.list_output_names()
                 if text:
-                    console.print(",".join(names))
+                    console.out(",".join(names))
                 else:
                     for name in names:
                         console.print(f"[bold cyan]{name}[/]")
@@ -834,7 +834,7 @@ def show(
 
             info_table = Table(show_header=True, header_style="bold magenta")
             info_table.add_column("Property", style="cyan", no_wrap=True)
-            info_table.add_column("Value", style="white")
+            info_table.add_column("Value", style="white", overflow="fold")
 
             info_table.add_row("Project Path", str(handler.project_path))
             info_table.add_row("Engine", handler.get_template_engine())
@@ -864,7 +864,7 @@ def show(
 
             variables_table = Table(show_header=True, header_style="bold magenta")
             variables_table.add_column("Variable Name", style="cyan", no_wrap=True)
-            variables_table.add_column("Assigned Value", style="white")
+            variables_table.add_column("Assigned Value", style="white", overflow="fold")
             variables_table.add_column("Description", style="dim")
 
             for var_name, var_def in all_variables.items():
@@ -893,7 +893,7 @@ def show(
 
                 output_table = Table(show_header=True, header_style="bold magenta")
                 output_table.add_column("Output Name", style="cyan", no_wrap=True)
-                output_table.add_column("Value", style="white")
+                output_table.add_column("Value", style="white", overflow="fold")
                 output_table.add_column("Description", style="dim")
 
                 for out_name, out_def in all_outputs.items():

--- a/libs/jupyter-deploy/jupyter_deploy/cli/projects_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/projects_app.py
@@ -101,7 +101,7 @@ def show_project(
     ] = False,
 ) -> None:
     """Show details of a specific project in a remote store."""
-    console = Console()
+    console = Console(emoji=False, highlight=False)
     with handle_cli_errors(console):
         display_manager = SimpleDisplayManager(console=console, pass_through=False)
         handler = ProjectsHandler(display_manager=display_manager, store_type=store_type, store_id=store_id)
@@ -117,6 +117,9 @@ def show_project(
             console.print(f"engine: {project.engine or 'N/A'}")
             console.print(f"last-modified: {project.last_modified.strftime('%Y-%m-%d %H:%M:%S')}")
             console.print(f"file-count: {project.file_count}")
+            if project.variables:
+                for var_name, var_value in sorted(project.variables.items()):
+                    console.print(f"var:{var_name}: {var_value}")
         else:
             table = Table(show_header=True, header_style="bold magenta")
             table.add_column("Property", style="cyan", no_wrap=True)
@@ -130,6 +133,15 @@ def show_project(
             table.add_row("Last Modified", project.last_modified.strftime("%Y-%m-%d %H:%M:%S"))
             table.add_row("Files", str(project.file_count))
             console.print(table)
+
+            if project.variables:
+                console.line()
+                var_table = Table(show_header=True, header_style="bold magenta")
+                var_table.add_column("Variable", style="cyan", no_wrap=True)
+                var_table.add_column("Value", style="white")
+                for var_name, var_value in sorted(project.variables.items()):
+                    var_table.add_row(var_name, str(var_value))
+                console.print(var_table)
 
 
 @projects_app.command("delete")

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
@@ -169,7 +169,14 @@ class TerraformConfigHandler(EngineConfigHandler):
             # then the preset values may take precedence over the values specified
             # in variables.yaml, which is not desirable.
             filtered_preset_path = self.tf_variables_handler.create_filtered_preset_file(base_preset_path)
-            plan_cmds.append(f"-var-file={filtered_preset_path.absolute()}")
+
+            # The filtered preset is only written when it has remaining lines
+            # (i.e. not all defaults were overridden by user config). After a
+            # store restore, user-assigned values may cover every preset default,
+            # leaving the file uncreated — skip the -var-file to avoid a
+            # terraform "Failed to read variables file" error.
+            if filtered_preset_path.exists():
+                plan_cmds.append(f"-var-file={filtered_preset_path.absolute()}")
 
         # 2.4/ pass variable overrides
         if variable_overrides:

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/store/s3_store.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/store/s3_store.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import boto3
 from mypy_boto3_s3.client import S3Client
 
 from jupyter_deploy.api.aws.s3 import s3_bucket, s3_object, s3_sync
 from jupyter_deploy.api.aws.sts import sts_identity
-from jupyter_deploy.constants import MANIFEST_FILENAME
+from jupyter_deploy.constants import MANIFEST_FILENAME, VARIABLES_FILENAME
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import StoreType
 from jupyter_deploy.exceptions import ProjectNotFoundInStoreError, ProjectStoreNotFoundError
@@ -161,6 +162,16 @@ class S3StoreManager(StoreManager):
             except self._s3_client.exceptions.NoSuchKey:
                 pass
 
+            # Try to read variables from the remote variables.yaml
+            variables: dict[str, Any] | None = None
+            try:
+                variables_content = s3_object.get_object_content(
+                    self._s3_client, bucket, f"{project_id}/project/{VARIABLES_FILENAME}"
+                )
+                variables = self._safe_parse_variables(variables_content)
+            except self._s3_client.exceptions.NoSuchKey:
+                pass
+
             return ProjectDetails(
                 project_id=project_id,
                 last_modified=last_modified,
@@ -168,6 +179,7 @@ class S3StoreManager(StoreManager):
                 template_name=manifest.template.name if manifest else None,
                 template_version=manifest.template.version if manifest else None,
                 engine=manifest.template.engine if manifest else None,
+                variables=variables,
             )
 
     def list_projects(self, display_manager: DisplayManager) -> list[ProjectSummary]:

--- a/libs/jupyter-deploy/jupyter_deploy/provider/store/store_manager.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/store/store_manager.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import BaseModel, ValidationError
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
 
+from jupyter_deploy.constants import MASKED_SECRET_VALUE
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import StoreType
 from jupyter_deploy.manifest import JupyterDeployManifest
+from jupyter_deploy.variables_config import JupyterDeployVariablesConfigV1
 
 
 class StoreInfo(BaseModel):
@@ -36,6 +39,7 @@ class ProjectDetails(ProjectSummary):
     template_name: str | None = None
     template_version: str | None = None
     engine: str | None = None
+    variables: dict[str, Any] | None = None
 
 
 class SyncResult(BaseModel):
@@ -133,3 +137,31 @@ class StoreManager(ABC):
             return JupyterDeployManifest(**data)
         except ValidationError:
             return None
+
+    @staticmethod
+    def _safe_parse_variables(content: str) -> dict[str, Any] | None:
+        """Parse variables YAML and return a flat dict of variable names to values.
+
+        Sensitive values are masked. Returns None if the content cannot be parsed.
+        """
+        try:
+            data = yaml.safe_load(content)
+        except (ParserError, ScannerError):
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        try:
+            config = JupyterDeployVariablesConfigV1(**data)
+        except ValidationError:
+            return None
+
+        variables: dict[str, Any] = {}
+        variables.update(config.required)
+        for key in config.required_sensitive:
+            variables[key] = MASKED_SECRET_VALUE
+        # Overrides take precedence over defaults
+        for key, value in config.defaults.items():
+            variables[key] = config.overrides.get(key, value)
+        return variables

--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -41,6 +41,7 @@ aws = [
     "mypy-boto3-s3>=1.38.0",
     "mypy-boto3-dynamodb>=1.38.0",
     "mypy-boto3-sts>=1.38.0",
+    "mypy-boto3-secretsmanager>=1.38.0",
 ]
 
 [tool.uv.sources]

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_projects.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_projects.py
@@ -154,6 +154,7 @@ class TestProjectsShowCommand(unittest.TestCase):
             template_name="base-template",
             template_version="1.2.0",
             engine="terraform",
+            variables={"region": "us-east-1", "instance_type": "t3.medium"},
         )
         mock_handler_cls.return_value = mock_handler
 
@@ -167,6 +168,10 @@ class TestProjectsShowCommand(unittest.TestCase):
         self.assertIn("base-template", result.output)
         self.assertIn("1.2.0", result.output)
         self.assertIn("terraform", result.output)
+        self.assertIn("region", result.output)
+        self.assertIn("us-east-1", result.output)
+        self.assertIn("instance_type", result.output)
+        self.assertIn("t3.medium", result.output)
 
     @patch(_HANDLER)
     def test_show_project_text_mode(self, mock_handler_cls: Mock) -> None:
@@ -179,6 +184,7 @@ class TestProjectsShowCommand(unittest.TestCase):
             template_name="base-template",
             template_version="1.2.0",
             engine="terraform",
+            variables={"region": "us-east-1", "secret_key": "****"},
         )
         mock_handler_cls.return_value = mock_handler
 
@@ -192,6 +198,8 @@ class TestProjectsShowCommand(unittest.TestCase):
         self.assertIn("template-version: 1.2.0", result.output)
         self.assertIn("engine: terraform", result.output)
         self.assertIn("file-count: 10", result.output)
+        self.assertIn("var:region: us-east-1", result.output)
+        self.assertIn("var:secret_key: ****", result.output)
 
     @patch(_HANDLER)
     def test_show_project_text_mode_none_fields(self, mock_handler_cls: Mock) -> None:

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_show.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_show.py
@@ -1128,6 +1128,166 @@ class TestShowCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Cannot use multiple query flags", result.output)
 
+    # Emoji preservation tests
+
+    @patch("jupyter_deploy.cli.app.ShowHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_command_output_text_preserves_emoji_codes(
+        self, mock_project_ctx_manager: Mock, mock_show_handler_cls: Mock
+    ) -> None:
+        """Test that --output --text preserves literal :secret: in ARN-like values."""
+        mock_project_ctx_manager.side_effect = TestShowCommand.mock_project_dir
+
+        mock_show_handler_instance, mock_show_fns = self.get_mock_show_handler()
+        mock_show_fns["get_output_str_value_and_description"].return_value = (
+            "arn:aws:secretsmanager:us-east-1:123456:secret:my-secret",
+            "A secret ARN",
+        )
+        mock_show_handler_cls.return_value = mock_show_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["show", "-o", "secret_arn", "--text"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(":secret:", result.output)
+        self.assertNotIn("\u3299", result.output)  # ㊙ emoji replacement
+
+    @patch("jupyter_deploy.cli.app.ShowHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_command_output_rich_preserves_emoji_codes(
+        self, mock_project_ctx_manager: Mock, mock_show_handler_cls: Mock
+    ) -> None:
+        """Test that --output without --text also preserves literal :secret: in values."""
+        mock_project_ctx_manager.side_effect = TestShowCommand.mock_project_dir
+
+        mock_show_handler_instance, mock_show_fns = self.get_mock_show_handler()
+        mock_show_fns["get_output_str_value_and_description"].return_value = (
+            "arn:aws:secretsmanager:us-east-1:123456:secret:my-secret",
+            "A secret ARN",
+        )
+        mock_show_handler_cls.return_value = mock_show_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["show", "-o", "secret_arn"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(":secret:", result.output)
+        self.assertNotIn("\u3299", result.output)
+
+    @patch("jupyter_deploy.cli.app.ShowHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_command_variable_text_preserves_emoji_codes(
+        self, mock_project_ctx_manager: Mock, mock_show_handler_cls: Mock
+    ) -> None:
+        """Test that --variable --text preserves literal :secret: in values."""
+        mock_project_ctx_manager.side_effect = TestShowCommand.mock_project_dir
+
+        mock_show_handler_instance, mock_show_fns = self.get_mock_show_handler()
+        mock_show_fns["get_variable_str_value_and_description"].return_value = (
+            "arn:aws:secretsmanager:us-east-1:123456:secret:my-var",
+            "A secret variable",
+        )
+        mock_show_handler_cls.return_value = mock_show_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["show", "-v", "secret_var", "--text"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(":secret:", result.output)
+        self.assertNotIn("\u3299", result.output)
+
+    @patch("jupyter_deploy.cli.app.ShowHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_command_variable_rich_preserves_emoji_codes(
+        self, mock_project_ctx_manager: Mock, mock_show_handler_cls: Mock
+    ) -> None:
+        """Test that --variable without --text also preserves literal :secret: in values."""
+        mock_project_ctx_manager.side_effect = TestShowCommand.mock_project_dir
+
+        mock_show_handler_instance, mock_show_fns = self.get_mock_show_handler()
+        mock_show_fns["get_variable_str_value_and_description"].return_value = (
+            "arn:aws:secretsmanager:us-east-1:123456:secret:my-var",
+            "A secret variable",
+        )
+        mock_show_handler_cls.return_value = mock_show_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["show", "-v", "secret_var"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(":secret:", result.output)
+        self.assertNotIn("\u3299", result.output)
+
+    # Emoji preservation in tables
+
+    @patch("jupyter_deploy.cli.app.ShowHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_outputs_table_preserves_emoji_codes(
+        self, mock_project_ctx_manager: Mock, mock_show_handler_cls: Mock
+    ) -> None:
+        """Test that outputs table preserves literal :secret: in ARN-like values."""
+        mock_project_ctx_manager.side_effect = TestShowCommand.mock_project_dir
+
+        mock_show_handler_instance, mock_show_fns = self.get_mock_show_handler()
+
+        mock_output = Mock()
+        mock_output.value = "a:secret:b"
+        mock_output.description = "desc"
+
+        mock_show_fns["get_full_outputs"].return_value = {"x": mock_output}
+        mock_show_handler_cls.return_value = mock_show_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["show", "--outputs"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(":secret:", result.output)
+        self.assertNotIn("\u3299", result.output)
+
+    @patch("jupyter_deploy.cli.app.ShowHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_variables_table_preserves_emoji_codes(
+        self, mock_project_ctx_manager: Mock, mock_show_handler_cls: Mock
+    ) -> None:
+        """Test that variables table preserves literal :secret: in values."""
+        mock_project_ctx_manager.side_effect = TestShowCommand.mock_project_dir
+
+        mock_show_handler_instance, mock_show_fns = self.get_mock_show_handler()
+
+        mock_var = Mock()
+        mock_var.sensitive = False
+        mock_var.assigned_value = "a:secret:b"
+        mock_var.get_cli_description = Mock(return_value="desc")
+
+        mock_show_fns["get_full_variables"].return_value = {"x": mock_var}
+        mock_show_handler_cls.return_value = mock_show_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["show", "--variables"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(":secret:", result.output)
+        self.assertNotIn("\u3299", result.output)
+
+    @patch("jupyter_deploy.cli.app.ShowHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_info_table_preserves_emoji_codes(
+        self, mock_project_ctx_manager: Mock, mock_show_handler_cls: Mock
+    ) -> None:
+        """Test that info table preserves literal emoji-like patterns in values."""
+        mock_project_ctx_manager.side_effect = TestShowCommand.mock_project_dir
+
+        mock_show_handler_instance, mock_show_fns = self.get_mock_show_handler()
+        mock_show_fns["get_template_name"].return_value = "my:secret:template"
+        mock_show_handler_cls.return_value = mock_show_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["show", "--info"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn(":secret:", result.output)
+        self.assertNotIn("\u3299", result.output)
+
     # Info table store type and store ID tests
 
     @patch("jupyter_deploy.cli.app.ShowHandler")

--- a/libs/jupyter-deploy/tests/unit/handlers/test_projects_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_projects_handler.py
@@ -50,6 +50,7 @@ class TestProjectsHandler(unittest.TestCase):
             template_name="base-template",
             template_version="1.0.0",
             engine="terraform",
+            variables={"region": "us-east-1", "instance_type": "t3.medium"},
         )
         mock_store_manager.get_project.return_value = expected
         mock_factory.get_manager.return_value = mock_store_manager
@@ -59,6 +60,7 @@ class TestProjectsHandler(unittest.TestCase):
 
         self.assertEqual(result, expected)
         self.assertEqual(result.template_name, "base-template")
+        self.assertEqual(result.variables, {"region": "us-east-1", "instance_type": "t3.medium"})
         mock_store_manager.get_project.assert_called_once_with("template-abc123", self.mock_display)
 
     @patch("jupyter_deploy.handlers.projects_handler.StoreManagerFactory")

--- a/libs/jupyter-deploy/tests/unit/provider/aws/store/test_s3_store.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/store/test_s3_store.py
@@ -286,7 +286,14 @@ class TestGetProject(unittest.TestCase):
             _obj("my-project/project/f2.txt", 20, now),
         ]
         manifest_yaml = "schema_version: 1\ntemplate:\n  name: base-template\n  version: 1.2.0\n  engine: terraform\n"
-        mock_s3_object.get_object_content.return_value = manifest_yaml
+        variables_yaml = (
+            "schema_version: 1\n"
+            "required:\n  project_name: my-project\n"
+            "required_sensitive:\n  gh_token: secret123\n"
+            "overrides:\n  instance_type: t3.large\n"
+            "defaults:\n  instance_type: t3.medium\n  region: us-east-1\n"
+        )
+        mock_s3_object.get_object_content.side_effect = [manifest_yaml, variables_yaml]
         provider = S3StoreManager(region="us-east-1", bucket_name="bucket")
 
         result = provider.get_project("my-project", NullDisplay())
@@ -297,6 +304,12 @@ class TestGetProject(unittest.TestCase):
         self.assertEqual(result.template_name, "base-template")
         self.assertEqual(result.template_version, "1.2.0")
         self.assertEqual(result.engine, "terraform")
+        self.assertIsNotNone(result.variables)
+        assert result.variables is not None
+        self.assertEqual(result.variables["project_name"], "my-project")
+        self.assertEqual(result.variables["gh_token"], "****")
+        self.assertEqual(result.variables["instance_type"], "t3.large")
+        self.assertEqual(result.variables["region"], "us-east-1")
         mock_s3_object.list_objects.assert_called_once_with(mock_boto3.client.return_value, "bucket", "my-project/")
 
     @patch(f"{_MODULE}.s3_object")
@@ -317,6 +330,7 @@ class TestGetProject(unittest.TestCase):
         self.assertIsNone(result.template_name)
         self.assertIsNone(result.template_version)
         self.assertIsNone(result.engine)
+        self.assertIsNone(result.variables)
 
     @patch(f"{_MODULE}.s3_object")
     @patch(f"{_MODULE}.boto3")

--- a/libs/jupyter-deploy/tests/unit/provider/store/test_store_manager.py
+++ b/libs/jupyter-deploy/tests/unit/provider/store/test_store_manager.py
@@ -1,0 +1,56 @@
+import unittest
+
+from jupyter_deploy.provider.store.store_manager import StoreManager
+
+
+class TestSafeParseVariables(unittest.TestCase):
+    def test_parses_all_sections(self) -> None:
+        content = (
+            "schema_version: 1\n"
+            "required:\n  project_name: my-project\n"
+            "required_sensitive:\n  gh_token: secret123\n"
+            "overrides:\n  instance_type: t3.large\n"
+            "defaults:\n  instance_type: t3.medium\n  region: us-east-1\n"
+        )
+        result = StoreManager._safe_parse_variables(content)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["project_name"], "my-project")
+        self.assertEqual(result["gh_token"], "****")
+        # Override takes precedence over default
+        self.assertEqual(result["instance_type"], "t3.large")
+        self.assertEqual(result["region"], "us-east-1")
+
+    def test_defaults_without_overrides(self) -> None:
+        content = (
+            "schema_version: 1\n"
+            "required:\n  project_name: test\n"
+            "defaults:\n  region: us-west-2\n  instance_type: t3.micro\n"
+        )
+        result = StoreManager._safe_parse_variables(content)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["region"], "us-west-2")
+        self.assertEqual(result["instance_type"], "t3.micro")
+
+    def test_returns_none_for_invalid_yaml(self) -> None:
+        result = StoreManager._safe_parse_variables("{{invalid yaml")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_non_dict(self) -> None:
+        result = StoreManager._safe_parse_variables("just a string")
+        self.assertIsNone(result)
+
+    def test_returns_none_for_invalid_schema(self) -> None:
+        result = StoreManager._safe_parse_variables("schema_version: 99\nrequired: {}\n")
+        self.assertIsNone(result)
+
+    def test_empty_sections(self) -> None:
+        content = "schema_version: 1\nrequired:\nrequired_sensitive:\noverrides:\ndefaults:\n"
+        result = StoreManager._safe_parse_variables(content)
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result, {})

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebook.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebook.py
@@ -4,6 +4,7 @@ import base64
 import json
 import logging
 import time
+import uuid
 from pathlib import Path
 
 from playwright.sync_api import Page
@@ -28,13 +29,24 @@ from pytest_jupyter_deploy.notebooks.notebook_utils import (
 logger = logging.getLogger(__name__)
 
 
-def upload_notebook(deployment: EndToEndDeployment, src_path: str | Path, target_path: str) -> None:
-    """Upload a notebook to the Jupyter server.
+def upload_notebook(deployment: EndToEndDeployment, src_path: str | Path, target_path: str) -> str:
+    """Upload a notebook to the Jupyter server with a unique path.
+
+    A UUID suffix is appended to the target filename to ensure each upload creates a
+    unique server path. This works around a jupyter-server-documents bug where re-using
+    the same notebook path across runs causes a stale Y-doc room and a 'metadata'
+    KeyError on the kernel WebSocket (see issue.md).
 
     Args:
         deployment: The deployment instance
-        src_path: Path to the local notebook file, relative to the jupyterlab home
-        target_path: Target path on the server (relative to /home/jovyan, e.g., "work/test.ipynb")
+        src_path: Path to the local notebook file
+        target_path: Base target path on the server (relative to /home/jovyan,
+            e.g., "e2e-test/application_simple.ipynb"). A UUID is appended before
+            the extension to create the actual unique path.
+
+    Returns:
+        The actual unique path the notebook was uploaded to
+        (e.g., "e2e-test/application_simple-a1b2c3d4.ipynb")
 
     Raises:
         FileNotFoundError: If the source notebook doesn't exist
@@ -43,6 +55,11 @@ def upload_notebook(deployment: EndToEndDeployment, src_path: str | Path, target
     src_path = Path(src_path)
     if not src_path.exists() or not src_path.is_file():
         raise FileNotFoundError(f"Notebook not found: {src_path}")
+
+    # Append a short UUID to the filename so each upload gets a fresh Y-doc room
+    # in jupyter-server-documents (avoids stale room 'metadata' KeyError).
+    stem, ext = target_path.rsplit(".", 1)
+    unique_target = f"{stem}-{uuid.uuid4().hex[:8]}.{ext}"
 
     # Read and parse the notebook JSON
     with open(src_path) as f:
@@ -56,12 +73,13 @@ def upload_notebook(deployment: EndToEndDeployment, src_path: str | Path, target
     # Use python to avoid shell escaping issues with complex JSON content
     python_cmd = (
         f'python3 -c "import base64, os; '
-        f"os.makedirs(os.path.dirname('/home/jovyan/{target_path}'), exist_ok=True); "
+        f"os.makedirs(os.path.dirname('/home/jovyan/{unique_target}'), exist_ok=True); "
         f"data=base64.b64decode('{encoded_notebook}'); "
-        f"open('/home/jovyan/{target_path}', 'wb').write(data)\""
+        f"open('/home/jovyan/{unique_target}', 'wb').write(data)\""
     )
 
     deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", python_cmd])
+    return unique_target
 
 
 def run_notebook_in_jupyterlab(

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
@@ -33,6 +33,12 @@ def prepare_jupyterlab_to_run_notebook(page: Page, notebook_path: str) -> None:
     notebook_toolbar = page.locator(".jp-NotebookPanel-toolbar")
     notebook_toolbar.wait_for(state="visible", timeout=10000)
 
+    # Dismiss "Document session error" dialog if it appeared during notebook load.
+    # This happens when jupyter-server-documents has stale Y-doc room state (e.g., from
+    # a previous test run that uploaded the notebook via filesystem). The dialog blocks
+    # all UI interaction, so we must dismiss it before clicking Run.
+    dismiss_document_session_error_if_present(page)
+
     # Wait for the kernel to be ready before executing cells
     # The kernel status is shown in the status bar (e.g., "Python 3 (ipykernel) | Idle")
     logger.debug("Waiting for kernel to be ready...")

--- a/scripts/ci_helpers.py
+++ b/scripts/ci_helpers.py
@@ -1,0 +1,66 @@
+"""Shared helpers for CI scripts.
+
+Provides boto3-based AWS secret/parameter fetching and jd CLI output reading.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import boto3
+from mypy_boto3_secretsmanager import SecretsManagerClient
+from mypy_boto3_ssm import SSMClient
+
+
+def arn_region(arn: str) -> str:
+    """Extract the AWS region (field 4) from an ARN."""
+    parts = arn.split(":")
+    if len(parts) < 4:
+        print(f"Error: Cannot extract region from ARN: {arn}", file=sys.stderr)
+        sys.exit(1)
+    return parts[3]
+
+
+def jd_output(output_name: str, ci_dir: str) -> str:
+    """Read a jd output value as plain text."""
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-o", output_name, "--text", "-p", ci_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip().replace("\n", "")
+
+
+def fetch_secret_value(arn: str) -> str:
+    """Fetch a secret string from AWS Secrets Manager."""
+    region = arn_region(arn)
+    client: SecretsManagerClient = boto3.client("secretsmanager", region_name=region)
+    response = client.get_secret_value(SecretId=arn)
+    return response["SecretString"]
+
+
+def fetch_ssm_value(arn: str) -> str:
+    """Fetch a parameter value from AWS SSM Parameter Store."""
+    region = arn_region(arn)
+    client: SSMClient = boto3.client("ssm", region_name=region)
+    response = client.get_parameter(Name=arn, WithDecryption=True)
+    return response["Parameter"]["Value"]
+
+
+def fetch_value(arn: str) -> str:
+    """Fetch a value from AWS, auto-detecting Secrets Manager vs SSM from the ARN."""
+    if ":secretsmanager:" in arn:
+        return fetch_secret_value(arn)
+    if ":ssm:" in arn:
+        return fetch_ssm_value(arn)
+    print(f"Error: Unrecognized ARN format: {arn}", file=sys.stderr)
+    sys.exit(1)
+
+
+def put_secret_value(arn: str, value: str) -> None:
+    """Store a secret string in AWS Secrets Manager."""
+    region = arn_region(arn)
+    client: SecretsManagerClient = boto3.client("secretsmanager", region_name=region)
+    client.put_secret_value(SecretId=arn, SecretString=value)

--- a/scripts/ci_restore.py
+++ b/scripts/ci_restore.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Discover and restore the CI project from S3 store, then re-populate
+sensitive variables from AWS Secrets Manager via jd config.
+
+Usage: scripts/ci_restore.py <ci-dir>
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from ci_helpers import fetch_value, jd_output
+
+
+def discover_project_id() -> str:
+    """Discover the CI project ID from S3 store."""
+    result = subprocess.run(
+        ["uv", "run", "jd", "projects", "list", "--store-type", "s3-only", "--text"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    matches = [line for line in result.stdout.strip().splitlines() if line.startswith("tf-aws-iam-ci-")]
+
+    if not matches:
+        print("Error: No CI project found in S3 store (no tf-aws-iam-ci-* project)")
+        sys.exit(1)
+    if len(matches) > 1:
+        print("Error: Multiple CI projects found in S3 store:")
+        for m in matches:
+            print(f"  {m}")
+        print("Expected exactly one tf-aws-iam-ci-* project.")
+        sys.exit(1)
+
+    return matches[0]
+
+
+def restore_project(project_id: str, ci_dir: Path) -> None:
+    """Restore a CI project from S3 store to the given directory."""
+    if ci_dir.exists():
+        shutil.rmtree(ci_dir)
+
+    print(f"Restoring CI project to {ci_dir}...")
+    subprocess.run(
+        ["uv", "run", "jd", "init", str(ci_dir), "--restore-project", project_id, "--store-type", "s3-only"],
+        check=True,
+    )
+
+
+def fetch_secrets_and_configure(ci_dir: Path) -> None:
+    """Fetch sensitive variables from AWS and pass them to jd config."""
+    ci_dir_str = str(ci_dir)
+    config_args: list[str] = []
+
+    # Fetch bot account secrets
+    for var in ("github_bot_account_password", "github_bot_account_recovery_codes"):
+        arn = jd_output(f"{var}_secret_arn", ci_dir_str)
+        val = fetch_value(arn)
+        flag = f"--{var.replace('_', '-')}"
+        config_args.extend([flag, val])
+        print(f"  Fetched {var}")
+
+    # Fetch OAuth app client secrets
+    for i in range(1, 6):
+        arn = jd_output(f"github_oauth_app_client_secret_{i}_arn", ci_dir_str)
+        val = fetch_value(arn)
+        config_args.extend([f"--github-oauth-app-client-secret-{i}", val])
+        print(f"  Fetched github_oauth_app_client_secret_{i}")
+
+    print("Running jd config with fetched secrets...")
+    subprocess.run(
+        ["uv", "run", "jd", "config", *config_args],
+        cwd=ci_dir,
+        check=True,
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: scripts/ci_restore.py <ci-dir>")
+        sys.exit(1)
+
+    ci_dir = Path(sys.argv[1])
+
+    print("Discovering CI project in S3 store...")
+    project_id = discover_project_id()
+    print(f"Found CI project: {project_id}")
+
+    restore_project(project_id, ci_dir)
+
+    print()
+    print("Fetching secrets from AWS to re-populate sensitive variables...")
+    fetch_secrets_and_configure(ci_dir)
+
+    print(f"CI project restored and configured at {ci_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/env_setup_base.py
+++ b/scripts/env_setup_base.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Generate .env for base template E2E tests from a deployed project and CI infrastructure.
+
+Reads deployment variables from the base project via `jd show -v`,
+fetches OAuth credentials from CI infrastructure (SSM/Secrets Manager),
+and merges user-supplied options. Options override project-derived values.
+
+Usage: scripts/env_setup_base.py <project-dir> <ci-dir> <oauth-app-num> [options]
+
+Options are comma-separated key=value pairs (same format as `just test-e2e`).
+
+Examples:
+  scripts/env_setup_base.py sandbox-e2e sandbox-ci 4
+  scripts/env_setup_base.py sandbox-e2e sandbox-ci 4 user=botuser,safe-user=realuser
+  scripts/env_setup_base.py sandbox-e2e sandbox-ci 4 allowed-usernames=[],allowed-org=my-org
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from ci_helpers import fetch_value, jd_output
+
+ENV_FILE = Path(".env")
+ENV_EXAMPLE = Path("libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/configurations/env.example")
+
+# Mapping from jd variable names to env var names
+# These are read from the deployed base project via `jd show -v <var> --text`
+PROJECT_VAR_MAP = {
+    "domain": "JD_E2E_VAR_DOMAIN",
+    "subdomain": "JD_E2E_VAR_SUBDOMAIN",
+    "letsencrypt_email": "JD_E2E_VAR_EMAIL",
+    "oauth_allowed_org": "JD_E2E_VAR_OAUTH_ALLOWED_ORG",
+    "oauth_allowed_teams": "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+    "oauth_allowed_usernames": "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES",
+}
+
+# Mapping from option keys to env var names
+# These are user-supplied values passed as key=value arguments
+# Options can override both project-derived and test-only variables
+OPTION_MAP = {
+    # Override project-derived access control variables
+    "allowed-usernames": "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES",
+    "allowed-org": "JD_E2E_VAR_OAUTH_ALLOWED_ORG",
+    "allowed-teams": "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+    # Test-only variables
+    "user": "JD_E2E_USER",
+    "safe-user": "JD_E2E_SAFE_USER",
+    "org": "JD_E2E_ORG",
+    "safe-org": "JD_E2E_SAFE_ORG",
+    "team": "JD_E2E_TEAM",
+    "safe-team": "JD_E2E_SAFE_TEAM",
+    "larger-instance": "JD_E2E_LARGER_INSTANCE",
+    "larger-log-retention-days": "JD_E2E_LARGER_LOG_RETENTION_DAYS",
+    "cpu-instance": "JD_E2E_CPU_INSTANCE",
+    "gpu-instance": "JD_E2E_GPU_INSTANCE",
+}
+
+
+def _parse_options(options_str: str) -> list[str]:
+    """Parse comma-separated key=value pairs.
+
+    Splits on commas only when followed by a recognized option key and '='.
+    This avoids breaking values that contain commas (e.g. JSON arrays).
+    """
+    if not options_str:
+        return []
+    # Build regex: split on comma followed by a known key and '='
+    keys_pattern = "|".join(re.escape(k) for k in OPTION_MAP)
+    parts = re.split(rf",(?=(?:{keys_pattern})=)", options_str)
+    return [p for p in parts if p]
+
+
+def normalize_list_value(value: str) -> str:
+    """Normalize list values to JSON syntax.
+
+    Handles:
+    - Python repr from `jd show -v` (e.g. ['a', 'b'] -> ["a", "b"])
+    - Unquoted brackets from shell (e.g. [a, b] -> ["a", "b"])
+    - Already valid JSON is returned as-is
+    """
+    # Try Python literal first (handles quoted strings)
+    try:
+        parsed = ast.literal_eval(value)
+        if isinstance(parsed, list):
+            return json.dumps(parsed)
+    except (ValueError, SyntaxError):
+        pass
+    # Handle unquoted bracket lists (shell strips quotes)
+    # e.g. [team1, team2] or [team1]
+    m = re.fullmatch(r"\[([^\]]*)\]", value.strip())
+    if m:
+        inner = m.group(1).strip()
+        if not inner:
+            return "[]"
+        items = [item.strip().strip('"').strip("'") for item in inner.split(",")]
+        return json.dumps(items)
+    return value
+
+
+def jd_variable(var_name: str, project_dir: str) -> str:
+    """Read a jd variable value as plain text."""
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-v", var_name, "--text", "-p", project_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return normalize_list_value(result.stdout.strip())
+
+
+def set_env_var(key: str, value: str) -> None:
+    """Update or append a key=value pair in the .env file."""
+    if ENV_FILE.exists():
+        lines = ENV_FILE.read_text().splitlines(keepends=True)
+        for i, line in enumerate(lines):
+            if line.startswith(f"{key}="):
+                lines[i] = f"{key}={value}\n"
+                ENV_FILE.write_text("".join(lines))
+                return
+    # Key not found or file doesn't exist — append
+    with ENV_FILE.open("a") as f:
+        f.write(f"{key}={value}\n")
+
+
+def main() -> None:
+    if len(sys.argv) < 4:
+        print("Usage: scripts/env_setup_base.py <project-dir> <ci-dir> <oauth-app-num> [options]")
+        print()
+        print("Options (comma-separated key=value pairs):")
+        for key, env_var in sorted(OPTION_MAP.items()):
+            print(f"  {key}=<value>  -> {env_var}")
+        sys.exit(1)
+
+    project_dir = sys.argv[1]
+    ci_dir = sys.argv[2]
+    oauth_app_num = sys.argv[3]
+    options_str = sys.argv[4] if len(sys.argv) > 4 else ""
+    options = _parse_options(options_str)
+
+    if oauth_app_num not in ("1", "2", "3", "4", "5"):
+        print(f"Error: OAuth app number must be 1-5, got: {oauth_app_num}")
+        sys.exit(1)
+
+    # Validate options
+    parsed_options: dict[str, str] = {}
+    for opt in options:
+        if "=" not in opt:
+            print(f"Error: Invalid option '{opt}', expected key=value")
+            sys.exit(1)
+        key, value = opt.split("=", 1)
+        if key not in OPTION_MAP:
+            print(f"Error: Unknown option '{key}'")
+            print(f"Valid options: {', '.join(sorted(OPTION_MAP.keys()))}")
+            sys.exit(1)
+        parsed_options[key] = value
+
+    # Seed .env from template if it doesn't exist yet
+    if not ENV_FILE.exists():
+        if ENV_EXAMPLE.exists():
+            ENV_FILE.write_text(ENV_EXAMPLE.read_text())
+            print(f"Created {ENV_FILE} from {ENV_EXAMPLE}")
+        else:
+            print(f"Warning: {ENV_EXAMPLE} not found, creating empty .env")
+
+    # Collect env vars that will be overridden by options (to skip project reads)
+    option_env_vars = {OPTION_MAP[k] for k in parsed_options}
+
+    # 1. Read deployment variables from the base project
+    print(f"Reading deployment variables from {project_dir}...")
+    for jd_var, env_var in PROJECT_VAR_MAP.items():
+        if env_var in option_env_vars:
+            print(f"  {env_var} — skipped (overridden by option)")
+            continue
+        value = jd_variable(jd_var, project_dir)
+        set_env_var(env_var, value)
+        print(f"  {env_var}={value}")
+
+    # 2. Fetch OAuth credentials from CI infrastructure
+    print(f"\nFetching OAuth app #{oauth_app_num} credentials from CI ({ci_dir})...")
+
+    client_id_arn = jd_output(f"github_oauth_app_client_id_{oauth_app_num}_arn", ci_dir)
+    client_secret_arn = jd_output(f"github_oauth_app_client_secret_{oauth_app_num}_arn", ci_dir)
+
+    print("  Fetching client ID from SSM...")
+    client_id = fetch_value(client_id_arn)
+    set_env_var("JD_E2E_VAR_OAUTH_APP_CLIENT_ID", client_id)
+    print(f"  JD_E2E_VAR_OAUTH_APP_CLIENT_ID={client_id[:8]}...")
+
+    print("  Fetching client secret from Secrets Manager...")
+    client_secret = fetch_value(client_secret_arn)
+    set_env_var("JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET", client_secret)
+    print("  JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET=****")
+
+    # 3. Write user-supplied options (overrides project values if overlapping)
+    if parsed_options:
+        print("\nSetting user-supplied options...")
+        for key, value in sorted(parsed_options.items()):
+            env_var = OPTION_MAP[key]
+            value = normalize_list_value(value)
+            set_env_var(env_var, value)
+            print(f"  {env_var}={value}")
+
+    print(f"\n.env updated successfully ({ENV_FILE.absolute()})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sync_auth_state.py
+++ b/scripts/sync_auth_state.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Export/import/check Playwright auth state to/from AWS Secrets Manager.
+
+Usage:
+    scripts/sync_auth_state.py export <ci-project-dir>
+    scripts/sync_auth_state.py import <ci-project-dir>
+    scripts/sync_auth_state.py check
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ci_helpers import fetch_secret_value, jd_output, put_secret_value
+from pytest_jupyter_deploy.constants import AUTH_DIR as AUTH_DIR_NAME
+from pytest_jupyter_deploy.constants import GITHUB_OAUTH_STATE_FILE
+
+AUTH_DIR = Path(AUTH_DIR_NAME)
+AUTH_FILE = AUTH_DIR / GITHUB_OAUTH_STATE_FILE
+
+WARN_THRESHOLD_DAYS = 7
+WARN_THRESHOLD_SECS = WARN_THRESHOLD_DAYS * 24 * 3600
+
+
+def print_cookie_summary() -> int:
+    """Print cookie expiry summary. Returns: 0=OK, 1=warning, 2=expired."""
+    if not AUTH_FILE.exists():
+        print(f"Error: {AUTH_FILE} does not exist")
+        return 1
+
+    data = json.loads(AUTH_FILE.read_text())
+    cookies = data.get("cookies", [])
+    github_cookies = [c for c in cookies if ".github.com" in c.get("domain", "")]
+    now = time.time()
+
+    print(f"GitHub cookies: {len(github_cookies)} (total: {len(cookies)})")
+    print()
+
+    has_warning = False
+    has_expired = False
+
+    for c in github_cookies:
+        expires = c.get("expires", -1)
+        if expires == -1:
+            continue
+        name = c.get("name", "?")
+        exp_dt = datetime.fromtimestamp(expires, tz=UTC)
+        remaining = expires - now
+
+        if remaining < 0:
+            print(f"  EXPIRED: {name} (expired {exp_dt:%Y-%m-%d %H:%M} UTC)")
+            has_expired = True
+        elif remaining < WARN_THRESHOLD_SECS:
+            days_left = remaining / 86400
+            print(f"  WARNING: {name} expires in {days_left:.1f} days ({exp_dt:%Y-%m-%d %H:%M} UTC)")
+            has_warning = True
+        else:
+            days_left = remaining / 86400
+            print(f"  OK: {name} expires in {days_left:.0f} days ({exp_dt:%Y-%m-%d %H:%M} UTC)")
+
+    if has_expired:
+        return 2
+    if has_warning:
+        return 1
+    return 0
+
+
+def cmd_export(ci_dir: str) -> None:
+    if not AUTH_FILE.exists():
+        print(f"Error: {AUTH_FILE} does not exist")
+        print("Run 'just auth-setup-base <project-dir>' first to create it.")
+        sys.exit(1)
+
+    auth_content = AUTH_FILE.read_text()
+    try:
+        json.loads(auth_content)
+    except (json.JSONDecodeError, OSError):
+        print(f"Error: {AUTH_FILE} is not valid JSON")
+        sys.exit(1)
+
+    secret_arn = jd_output("auth_state_secret_arn", ci_dir)
+    print("Uploading auth state to Secrets Manager...")
+    put_secret_value(secret_arn, auth_content)
+    print("Auth state exported successfully.")
+    print()
+    print_cookie_summary()
+
+
+def cmd_import(ci_dir: str) -> None:
+    secret_arn = jd_output("auth_state_secret_arn", ci_dir)
+    print("Downloading auth state from Secrets Manager...")
+    AUTH_DIR.mkdir(parents=True, exist_ok=True)
+    value = fetch_secret_value(secret_arn)
+    AUTH_FILE.write_text(value)
+    print(f"Auth state imported to {AUTH_FILE}")
+    print()
+    print_cookie_summary()
+
+
+def cmd_check() -> None:
+    if not AUTH_FILE.exists():
+        print(f"Error: {AUTH_FILE} does not exist")
+        print("Run 'just auth-import' to pull auth state from Secrets Manager.")
+        sys.exit(1)
+
+    print("Checking auth state cookie expiry...")
+    rc = print_cookie_summary()
+    sys.exit(rc)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: scripts/sync_auth_state.py <export|import|check> [ci-project-dir]")
+        sys.exit(1)
+
+    subcommand = sys.argv[1]
+
+    if subcommand == "export":
+        if len(sys.argv) < 3:
+            print("Usage: scripts/sync_auth_state.py export <ci-project-dir>")
+            sys.exit(1)
+        cmd_export(sys.argv[2])
+    elif subcommand == "import":
+        if len(sys.argv) < 3:
+            print("Usage: scripts/sync_auth_state.py import <ci-project-dir>")
+            sys.exit(1)
+        cmd_import(sys.argv[2])
+    elif subcommand == "check":
+        cmd_check()
+    else:
+        print(f"Error: Unknown subcommand '{subcommand}'")
+        print("Usage: scripts/sync_auth_state.py <export|import|check> [ci-project-dir]")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -317,6 +317,7 @@ aws = [
     { name = "mypy-boto3-dynamodb" },
     { name = "mypy-boto3-ec2" },
     { name = "mypy-boto3-s3" },
+    { name = "mypy-boto3-secretsmanager" },
     { name = "mypy-boto3-ssm" },
     { name = "mypy-boto3-sts" },
 ]
@@ -343,6 +344,7 @@ requires-dist = [
     { name = "mypy-boto3-dynamodb", marker = "extra == 'aws'", specifier = ">=1.38.0" },
     { name = "mypy-boto3-ec2", marker = "extra == 'aws'", specifier = ">=1.40.4" },
     { name = "mypy-boto3-s3", marker = "extra == 'aws'", specifier = ">=1.38.0" },
+    { name = "mypy-boto3-secretsmanager", marker = "extra == 'aws'", specifier = ">=1.38.0" },
     { name = "mypy-boto3-ssm", marker = "extra == 'aws'", specifier = ">=1.38.5" },
     { name = "mypy-boto3-sts", marker = "extra == 'aws'", specifier = ">=1.38.0" },
     { name = "packaging", specifier = ">=25.0" },
@@ -422,6 +424,7 @@ dependencies = [
     { name = "mypy-boto3-dynamodb" },
     { name = "mypy-boto3-ec2" },
     { name = "mypy-boto3-s3" },
+    { name = "mypy-boto3-secretsmanager" },
     { name = "mypy-boto3-ssm" },
     { name = "mypy-boto3-sts" },
 ]
@@ -447,6 +450,7 @@ requires-dist = [
     { name = "mypy-boto3-dynamodb" },
     { name = "mypy-boto3-ec2" },
     { name = "mypy-boto3-s3" },
+    { name = "mypy-boto3-secretsmanager" },
     { name = "mypy-boto3-ssm" },
     { name = "mypy-boto3-sts" },
 ]
@@ -550,6 +554,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/41/44066f4cd3421bacb6aad4ec7b1da8d0f8858560e526166db64d95fa7ad7/mypy_boto3_s3-1.42.37.tar.gz", hash = "sha256:628a4652f727870a07e1c3854d6f30dc545a7dd5a4b719a2c59c32a95d92e4c1", size = 76317, upload-time = "2026-01-28T20:51:52.971Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/06/cb6050ecd72f5fa449bac80ad1a4711719367c4f545201317f36e3999784/mypy_boto3_s3-1.42.37-py3-none-any.whl", hash = "sha256:7c118665f3f583dbfde1013ce47908749f9d2a760f28f59ec65732306ee9cec9", size = 83439, upload-time = "2026-01-28T20:51:49.99Z" },
+]
+
+[[package]]
+name = "mypy-boto3-secretsmanager"
+version = "1.42.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/58/ccae71b7b7f550eab01d600e956d57e6e6bb9148dbf5d116696d0dc43369/mypy_boto3_secretsmanager-1.42.8.tar.gz", hash = "sha256:5ab42f35ce932765ebb1684146f478a87cc4b83bef950fd1aa0e268b88d59c81", size = 19863, upload-time = "2025-12-11T22:12:51.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/42/90cef7241c98f6e504cabc9a99d89dd38b84e4d40ff0774c89bc871ffb18/mypy_boto3_secretsmanager-1.42.8-py3-none-any.whl", hash = "sha256:50c891a88e725a8dba7444018e47590ea63d8e938abe2b1c0b25e5413f39d51d", size = 27243, upload-time = "2025-12-11T22:12:44.389Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds utilities to restore the account's ci project, retrieve the secret values (e.g. oauth client secrets), and store the webbrowser context w/ the 2FA auth cookies.

Many of these utilities assume that an `aws-iam-ci` template is present in the AWS account and can be restored locally - see #175 

Also in this PR:
- show a project variables w/ `jd projects show <PROJECT-ID>` (enable to identify which projects to restore)
- fix regression in E2E `test_project` of the base template introduced by #171 
- use different notebook name for E2E notebook tests (regression introduced by change in `jupyter-server-documents`

### Developer experience
- `just ci-restore <TARGET-DIR>`: looks up an `aws-iam-ci` project in the store, restore to target dir; errors out if 0 or more than 1 projects are found)
- `just auth-export <CI-DIR>`: upload the local webbrowser context to the secrets defined by ci project
- `just auth-import <CI-DIR>`: downloads the webbrowser context from the secret defined by ci project
- `just auth-check`: verify that the webbrowser context is still valid and not about to expire
- `just env-setup-base <PROJECT-DIR> <CI-DIR> <OAUTH-APP-NUM> [options]`: Generates a complete `.env` for base template E2E tests from a deployed project + CI infrastructure. Example: `just env-setup-base sandbox-e2e sandbox-ci 4 'allowed-teams=[team1],user=botuser,safe-user=realuser,...'

### Implementation
- add python scripts for each command
- update `ProjectsHandler:show()` method to parse `variables.yaml` (if present)

**just env-setup-base**
1. Seeds `.env` from `env.example` template if it doesn't exist
2. Reads deployment variables from the project via `jd show -v <var> --text`
3. Fetches OAuth app credentials from CI project secrets
4. Applies user-supplied options (comma-separated key=value pairs)

### Testing
- run E2E tests

### Screenshots
<img width="1069" height="618" alt="Screenshot 2026-03-19 at 11 07 25 PM" src="https://github.com/user-attachments/assets/a5633276-762b-45a2-b662-da3c31ac2928" />
