### PR TITLE
feat: host connect status

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -74,6 +74,17 @@ commands:
     - api-attribute: instance_id
       source: output
       source-key: instance_id
+- cmd: host.status-for-connection
+  sequence:
+  - api-name: aws.ssm.get-connection-status
+    arguments:
+    - api-attribute: instance_id
+      source: output
+      source-key: instance_id
+  results:
+  - result-name: host.status-for-connection
+    source: result
+    source-key: '[0].Status'
 - cmd: host.connect
   sequence:
   - api-name: aws.ssm.start-session

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_host.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_host.py
@@ -28,6 +28,10 @@ def test_host_stop(e2e_deployment: EndToEndDeployment) -> None:
     host_status = e2e_deployment.cli.get_host_status()
     assert host_status == "stopped", f"Expected host status 'stopped', got '{host_status}'"
 
+    # Verify connection agent reports not connected
+    connection_status = e2e_deployment.cli.get_connection_status()
+    assert connection_status == "notconnected", f"Expected 'notconnected', got '{connection_status}'"
+
 
 def test_host_start(e2e_deployment: EndToEndDeployment) -> None:
     """Test that the host can be started from command line."""
@@ -41,12 +45,17 @@ def test_host_start(e2e_deployment: EndToEndDeployment) -> None:
     host_status = e2e_deployment.cli.get_host_status()
     assert host_status == "running", f"Expected host status 'running', got '{host_status}'"
 
+    # Check connection status
+    e2e_deployment.wait_for_connection_agent()
+    status = e2e_deployment.cli.get_connection_status()
+    assert status == "connected", f"Expected 'connected', got '{status}'"
+
 
 def test_host_connect_whoami(e2e_deployment: EndToEndDeployment) -> None:
     """Test that we can connect to the host via SSM and run a simple command."""
     # Prerequisites
     e2e_deployment.ensure_host_running()
-    e2e_deployment.wait_for_ssm_ready()
+    e2e_deployment.wait_for_connection_agent()
 
     # Start an interactive jd host connect session
     with e2e_deployment.cli.spawn_interactive_session("jupyter-deploy host connect") as session:
@@ -70,7 +79,7 @@ def test_host_exec_simple_command(e2e_deployment: EndToEndDeployment) -> None:
     """Test that we can execute a simple command on the host."""
     # Prerequisites
     e2e_deployment.ensure_host_running()
-    e2e_deployment.wait_for_ssm_ready()
+    e2e_deployment.wait_for_host_agent()
 
     # Execute whoami command
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "exec", "--", "whoami"])
@@ -84,7 +93,7 @@ def test_host_exec_disk_usage(e2e_deployment: EndToEndDeployment) -> None:
     """Test host exec with disk usage command."""
     # Prerequisites
     e2e_deployment.ensure_host_running()
-    e2e_deployment.wait_for_ssm_ready()
+    e2e_deployment.wait_for_host_agent()
 
     # Execute df command
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "exec", "--", "df", "-h"])
@@ -98,7 +107,7 @@ def test_host_exec_failed_command(e2e_deployment: EndToEndDeployment) -> None:
     """Test host exec with a command that fails."""
     # Prerequisites
     e2e_deployment.ensure_host_running()
-    e2e_deployment.wait_for_ssm_ready()
+    e2e_deployment.wait_for_host_agent()
 
     # Execute non-existent command - should raise JDCliError with non-zero exit code
     with pytest.raises(JDCliError) as exc_info:

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_server.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_server.py
@@ -181,7 +181,7 @@ def test_server_connect_default_service(e2e_deployment: EndToEndDeployment) -> N
     """Test that we can connect to the default service (jupyter) via SSM and run a simple command."""
     # Prerequisites
     e2e_deployment.ensure_server_running()
-    e2e_deployment.wait_for_ssm_ready()
+    e2e_deployment.wait_for_connection_agent()
 
     # Start an interactive jd server connect session (no -s flag, should default to jupyter)
     with e2e_deployment.cli.spawn_interactive_session("jupyter-deploy server connect") as session:
@@ -205,7 +205,7 @@ def test_server_connect_jupyter(e2e_deployment: EndToEndDeployment) -> None:
     """Test that we can connect to the jupyter service via SSM and run a simple command."""
     # Prerequisites
     e2e_deployment.ensure_server_running()
-    e2e_deployment.wait_for_ssm_ready()
+    e2e_deployment.wait_for_connection_agent()
 
     # Start an interactive jd server connect session with explicit -s jupyter
     with e2e_deployment.cli.spawn_interactive_session("jupyter-deploy server connect -s jupyter") as session:
@@ -229,7 +229,7 @@ def test_server_connect_traefik(e2e_deployment: EndToEndDeployment) -> None:
     """Test that we can connect to the traefik service via SSM and run a simple command."""
     # Prerequisites
     e2e_deployment.ensure_server_running()
-    e2e_deployment.wait_for_ssm_ready()
+    e2e_deployment.wait_for_connection_agent()
 
     # Start an interactive jd server connect session with explicit -s traefik
     with e2e_deployment.cli.spawn_interactive_session("jupyter-deploy server connect -s traefik") as session:

--- a/libs/jupyter-deploy/jupyter_deploy/api/aws/ssm/ssm_connection.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/aws/ssm/ssm_connection.py
@@ -1,0 +1,15 @@
+from mypy_boto3_ssm.client import SSMClient
+from mypy_boto3_ssm.literals import ConnectionStatusType
+
+CONNECTION_STATUS_CONNECTED: ConnectionStatusType = "connected"
+CONNECTION_STATUS_NOT_CONNECTED: ConnectionStatusType = "notconnected"
+
+
+def get_connection_status(client: SSMClient, instance_id: str) -> ConnectionStatusType:
+    """Call SSM:GetConnectionStatus, return the Session Manager connection status.
+
+    Returns:
+        "connected" or "notconnected"
+    """
+    response = client.get_connection_status(Target=instance_id)
+    return response["Status"]

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -23,7 +23,7 @@ def status(
     ] = None,
     status_for: Annotated[
         HostStatusType | None,
-        typer.Option("--for", help="Check a specific status. Supported: 'connection' (session agent readiness)."),
+        typer.Option("--for", help="Check the status of specific agent or access point within the host."),
     ] = None,
 ) -> None:
     """Check the status of the host machine.
@@ -41,7 +41,7 @@ def status(
                 result = handler.get_connection_status()
             console.print(f"Host agent connection status: [bold cyan]{result}[/]")
             return
-        
+
         with simple_display_manager.spinner("Checking host status..."):
             result = handler.get_host_status()
             console.print(f"Host status: [bold cyan]{result}[/]")

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -6,6 +6,7 @@ from rich.console import Console
 from jupyter_deploy import cmd_utils
 from jupyter_deploy.cli.error_decorator import handle_cli_errors
 from jupyter_deploy.cli.simple_display import SimpleDisplayManager
+from jupyter_deploy.enum import HostStatusType
 from jupyter_deploy.handlers.resource import host_handler
 
 host_app = typer.Typer(
@@ -20,6 +21,10 @@ def status(
         str | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to check status."),
     ] = None,
+    status_for: Annotated[
+        HostStatusType | None,
+        typer.Option("--for", help="Check a specific status. Supported: 'connection' (session agent readiness)."),
+    ] = None,
 ) -> None:
     """Check the status of the host machine.
 
@@ -31,10 +36,15 @@ def status(
         simple_display_manager = SimpleDisplayManager(console=console)
         handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
+        if status_for == HostStatusType.CONNECTION:
+            with simple_display_manager.spinner("Checking status of agent on host..."):
+                result = handler.get_connection_status()
+            console.print(f"Host agent connection status: [bold cyan]{result}[/]")
+            return
+        
         with simple_display_manager.spinner("Checking host status..."):
-            status = handler.get_host_status()
-
-        console.print(f"Jupyter host status: [bold cyan]{status}[/]")
+            result = handler.get_host_status()
+            console.print(f"Host status: [bold cyan]{result}[/]")
 
 
 @host_app.command()

--- a/libs/jupyter-deploy/jupyter_deploy/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/enum.py
@@ -1,6 +1,12 @@
 from enum import Enum
 
 
+class HostStatusType(str, Enum):
+    """Types of host status checks available via `jd host status --for`."""
+
+    CONNECTION = "connection"
+
+
 class HistoryEnabledCommandType(str, Enum):
     """Command types for history tracking."""
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
@@ -4,7 +4,9 @@ from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
-from jupyter_deploy.provider.resolved_clidefs import ListStrResolvedCliParameter
+from jupyter_deploy.provider.resolved_clidefs import (
+    ListStrResolvedCliParameter,
+)
 
 
 class HostHandler(BaseProjectHandler):
@@ -74,6 +76,17 @@ class HostHandler(BaseProjectHandler):
             command,
             cli_paramdefs={},
         )
+
+    def get_connection_status(self) -> str:
+        """Returns the Session Manager connection status of the host."""
+        command = self.project_manifest.get_command("host.status-for-connection")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        runner.run_command_sequence(command, cli_paramdefs={})
+        return runner.get_result_value(command, "host.status-for-connection", str)
 
     def connect(self) -> None:
         """Start an SSH-style connection to the host."""

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ssm_runner.py
@@ -4,7 +4,7 @@ import boto3
 from mypy_boto3_ssm.client import SSMClient
 
 from jupyter_deploy import cmd_utils, verify_utils
-from jupyter_deploy.api.aws.ssm import ssm_command, ssm_session
+from jupyter_deploy.api.aws.ssm import ssm_command, ssm_connection, ssm_session
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import JupyterDeployTool
 from jupyter_deploy.exceptions import (
@@ -39,6 +39,7 @@ class AwsSsmInstruction(str, Enum):
     SEND_CMD_AND_WAIT_SYNC = "wait-command-sync"
     SEND_DFT_SHELL_DOC_CMD_AND_WAIT_SYNC = "wait-default-shell-command-sync"
     START_SESSION = "start-session"
+    GET_CONNECTION_STATUS = "get-connection-status"
 
 
 class AwsSsmRunner(InstructionRunner):
@@ -49,6 +50,7 @@ class AwsSsmRunner(InstructionRunner):
     def __init__(self, display_manager: DisplayManager, region_name: str | None) -> None:
         """Instantiates the SSM boto3 client."""
         super().__init__(display_manager)
+        self.region_name = region_name
         self.client: SSMClient = boto3.client("ssm", region_name=region_name)
 
     def _verify_ec2_instance_accessible(
@@ -240,6 +242,8 @@ class AwsSsmRunner(InstructionRunner):
 
         # start the session
         start_session_cmds = START_SESSION_CMD.copy()
+        if self.region_name:
+            start_session_cmds.extend(["--region", self.region_name])
         start_session_cmds.extend(["--target", target_id_arg.value])
 
         # Add optional document name if provided
@@ -268,6 +272,16 @@ class AwsSsmRunner(InstructionRunner):
 
         return {}
 
+    def _get_connection_status(
+        self,
+        resolved_arguments: dict[str, ResolvedInstructionArgument],
+    ) -> dict[str, ResolvedInstructionResult]:
+        instance_id_arg = require_arg(resolved_arguments, "instance_id", StrResolvedInstructionArgument)
+        status = ssm_connection.get_connection_status(self.client, instance_id=instance_id_arg.value)
+        return {
+            "Status": StrResolvedInstructionResult(result_name="Status", value=status),
+        }
+
     def execute_instruction(
         self,
         instruction_name: str,
@@ -283,6 +297,10 @@ class AwsSsmRunner(InstructionRunner):
             )
         elif instruction_name == AwsSsmInstruction.START_SESSION:
             return self._start_session(
+                resolved_arguments=resolved_arguments,
+            )
+        elif instruction_name == AwsSsmInstruction.GET_CONNECTION_STATUS:
+            return self._get_connection_status(
                 resolved_arguments=resolved_arguments,
             )
 

--- a/libs/jupyter-deploy/tests/unit/api/aws/ssm/test_ssm_connection.py
+++ b/libs/jupyter-deploy/tests/unit/api/aws/ssm/test_ssm_connection.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import Mock
+
+from jupyter_deploy.api.aws.ssm.ssm_connection import (
+    CONNECTION_STATUS_CONNECTED,
+    CONNECTION_STATUS_NOT_CONNECTED,
+    get_connection_status,
+)
+
+
+class TestGetConnectionStatus(unittest.TestCase):
+    def test_returns_connected(self) -> None:
+        mock_client: Mock = Mock()
+        mock_client.get_connection_status.return_value = {
+            "Target": "i-123",
+            "Status": "connected",
+        }
+
+        result = get_connection_status(mock_client, "i-123")
+
+        self.assertEqual(result, CONNECTION_STATUS_CONNECTED)
+        mock_client.get_connection_status.assert_called_once_with(Target="i-123")
+
+    def test_returns_notconnected(self) -> None:
+        mock_client: Mock = Mock()
+        mock_client.get_connection_status.return_value = {
+            "Target": "i-123",
+            "Status": "notconnected",
+        }
+
+        result = get_connection_status(mock_client, "i-123")
+
+        self.assertEqual(result, CONNECTION_STATUS_NOT_CONNECTED)

--- a/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
@@ -327,6 +327,93 @@ class TestHostRestartCommand(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
 
 
+class TestHostStatusForFlag(unittest.TestCase):
+    def get_mock_host_handler(self) -> tuple[Mock, dict[str, Mock]]:
+        mock_host_handler = Mock()
+        mock_host_handler.get_connection_status.return_value = "connected"
+        mock_host_handler.get_host_status.return_value = "running"
+        return mock_host_handler, {
+            "get_connection_status": mock_host_handler.get_connection_status,
+            "get_host_status": mock_host_handler.get_host_status,
+        }
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_status_without_for_calls_get_host_status(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["status"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["get_host_status"].assert_called_once()
+        mock_handler_fns["get_connection_status"].assert_not_called()
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_status_for_connection_calls_get_connection_status(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["status", "--for", "connection"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["get_connection_status"].assert_called_once()
+        mock_handler_fns["get_host_status"].assert_not_called()
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_status_for_unknown_value_exits_with_error(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        mock_host_handler, _ = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["status", "--for", "bogus"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_status_for_connection_switches_dir_when_passed_a_project(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        mock_host_handler, _ = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["status", "--for", "connection", "--path", "/test/project/path"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with("/test/project/path")
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_status_for_connection_raises_when_handler_raises(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_handler_fns["get_connection_status"].side_effect = Exception("Test error")
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["status", "--for", "connection"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+
 class TestHostConnectCommand(unittest.TestCase):
     def get_mock_host_handler(self) -> tuple[Mock, dict[str, Mock]]:
         mock_connect = Mock()

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
@@ -133,6 +133,9 @@ class TestHostHandler(unittest.TestCase):
             handler.connect()
 
         with self.assertRaises(NotImplementedError):
+            handler.get_connection_status()
+
+        with self.assertRaises(NotImplementedError):
             handler.exec_command(["echo", "hello"])
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
@@ -222,6 +225,9 @@ class TestHostHandler(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             handler.connect()
+
+        with self.assertRaises(RuntimeError):
+            handler.get_connection_status()
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
@@ -543,3 +549,32 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value_with_fallback"].assert_called_once_with(
             mock_cmd, "host.exec.returncode", int, 0
         )
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_get_connection_status_returns_status(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].return_value = "connected"
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = HostHandler(display_manager=NullDisplay())
+        result = handler.get_connection_status()
+
+        self.assertEqual(result, "connected")
+        mock_manifest_fns["get_command"].assert_called_once_with("host.status-for-connection")
+        mock_cmd_runner_fns["get_result_value"].assert_called_once_with(mock_cmd, "host.status-for-connection", str)

--- a/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
+++ b/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
@@ -65,6 +65,24 @@ commands:
           - api-attribute: "instance_id"
             source: "output"
             source-key: "instance_id"
+  - cmd: "host.status-for-connection"
+    sequence:
+      - api-name: "aws.ssm.get-connection-status"
+        arguments:
+          - api-attribute: "instance_id"
+            source: "output"
+            source-key: "instance_id"
+    results:
+      - result-name: "host.status-for-connection"
+        source: "result"
+        source-key: "[0].Status"
+  - cmd: "host.connect"
+    sequence:
+      - api-name: "aws.ssm.start-session"
+        arguments:
+          - api-attribute: "target_id"
+            source: "output"
+            source-key: "instance_id"
   - cmd: "host.exec"
     sequence:
       - api-name: "aws.ssm.wait-default-shell-command-sync"

--- a/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ssm_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ssm_runner.py
@@ -729,8 +729,10 @@ class TestExecuteInstructions(unittest.TestCase):
     @patch("jupyter_deploy.provider.aws.aws_ssm_runner.cmd_utils.run_cmd_and_pipe_to_terminal")
     @patch("jupyter_deploy.api.aws.ssm.ssm_command.send_cmd_to_one_instance_and_wait_sync")
     @patch("jupyter_deploy.api.aws.ssm.ssm_session.describe_instance_information")
+    @patch("jupyter_deploy.api.aws.ssm.ssm_connection.get_connection_status")
     def test_all_ssm_instructions_implemented(
         self,
+        mock_get_conn_status: Mock,
         mock_describe_info: Mock,
         mock_send_cmd: Mock,
         mock_run_cmd: Mock,
@@ -755,6 +757,8 @@ class TestExecuteInstructions(unittest.TestCase):
             "StandardOutputContent": "Command output",
         }
 
+        mock_get_conn_status.return_value = "connected"
+
         # Verify each instruction in AwsSsmInstruction can be executed
         for instruction in AwsSsmInstruction:
             # Reset mocks between iterations
@@ -763,6 +767,7 @@ class TestExecuteInstructions(unittest.TestCase):
             mock_run_cmd.reset_mock()
             mock_send_cmd.reset_mock()
             mock_describe_info.reset_mock()
+            mock_get_conn_status.reset_mock()
 
             # Basic arguments that work for any instruction
             base_resolved_arguments: dict[str, ResolvedInstructionArgument] = {}
@@ -780,6 +785,10 @@ class TestExecuteInstructions(unittest.TestCase):
             elif instruction == AwsSsmInstruction.START_SESSION:
                 base_resolved_arguments = {
                     "target_id": StrResolvedInstructionArgument(argument_name="target_id", value="i-12345"),
+                }
+            elif instruction == AwsSsmInstruction.GET_CONNECTION_STATUS:
+                base_resolved_arguments = {
+                    "instance_id": StrResolvedInstructionArgument(argument_name="instance_id", value="i-12345"),
                 }
             else:
                 raise NotImplementedError(f"Instruction {instruction} not implemented")
@@ -801,6 +810,9 @@ class TestExecuteInstructions(unittest.TestCase):
                 mock_verify_tools.assert_called_once()
                 mock_verify_ec2.assert_called_once()
                 mock_run_cmd.assert_called_once()
+            elif instruction == AwsSsmInstruction.GET_CONNECTION_STATUS:
+                mock_get_conn_status.assert_called_once()
+                self.assertEqual(result["Status"].value, "connected")
 
     def test_raise_not_implemented_error_on_unrecognized_instruction(self) -> None:
         # Arrange
@@ -1057,3 +1069,47 @@ class TestSendCmdToOneInstanceUsingDefaultShellDoc(unittest.TestCase):
         # Assert - Should default to 0 when ResponseCode is missing
         self.assertIn("ResponseCode", result)
         self.assertEqual(result["ResponseCode"].value, 0)
+
+
+class TestGetConnectionStatus(unittest.TestCase):
+    @patch("jupyter_deploy.api.aws.ssm.ssm_connection.get_connection_status")
+    def test_returns_connected_status(self, mock_get_conn: Mock) -> None:
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
+        mock_get_conn.return_value = "connected"
+
+        resolved_arguments: dict[str, ResolvedInstructionArgument] = {
+            "instance_id": StrResolvedInstructionArgument(argument_name="instance_id", value="i-123"),
+        }
+
+        result = runner.execute_instruction(
+            instruction_name=AwsSsmInstruction.GET_CONNECTION_STATUS,
+            resolved_arguments=resolved_arguments,
+        )
+
+        self.assertEqual(result["Status"].value, "connected")
+        mock_get_conn.assert_called_once_with(runner.client, instance_id="i-123")
+
+    @patch("jupyter_deploy.api.aws.ssm.ssm_connection.get_connection_status")
+    def test_returns_notconnected_status(self, mock_get_conn: Mock) -> None:
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
+        mock_get_conn.return_value = "notconnected"
+
+        resolved_arguments: dict[str, ResolvedInstructionArgument] = {
+            "instance_id": StrResolvedInstructionArgument(argument_name="instance_id", value="i-123"),
+        }
+
+        result = runner.execute_instruction(
+            instruction_name=AwsSsmInstruction.GET_CONNECTION_STATUS,
+            resolved_arguments=resolved_arguments,
+        )
+
+        self.assertEqual(result["Status"].value, "notconnected")
+
+    def test_raises_on_missing_instance_id(self) -> None:
+        runner = AwsSsmRunner(NullDisplay(), region_name="us-west-2")
+
+        with self.assertRaises(KeyError):
+            runner.execute_instruction(
+                instruction_name=AwsSsmInstruction.GET_CONNECTION_STATUS,
+                resolved_arguments={},
+            )

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
@@ -80,9 +80,9 @@ class JDCli:
         """
         result = self.run_command(["jupyter-deploy", "host", "status"])
 
-        # Parse output for line "Jupyter host status: <status>"
+        # Parse output for line "Host status: <status>"
         for line in result.stdout.splitlines():
-            if line.startswith("Jupyter host status:"):
+            if line.startswith("Host status:"):
                 # Extract status after the colon and color codes
                 status = line.split(":", 1)[1].strip()
                 # Remove ANSI color codes if present
@@ -90,6 +90,27 @@ class JDCli:
                 return status.lower()
 
         raise ValueError("Could not parse host status from command output")
+
+    def get_connection_status(self) -> str:
+        """Get the Session Manager connection status.
+
+        Returns:
+            Connection status string (e.g., "connected", "notconnected")
+
+        Raises:
+            JDCliError: If command fails
+            ValueError: If status cannot be parsed
+        """
+        result = self.run_command(["jupyter-deploy", "host", "status", "--for", "connection"])
+
+        # Parse output for line "Host agent connection status: <status>"
+        for line in result.stdout.splitlines():
+            if line.startswith("Host agent connection status:"):
+                status = line.split(":", 1)[1].strip()
+                status = re.sub(r"\x1b\[[0-9;]*m", "", status)
+                return status
+
+        raise ValueError("Could not parse connection status from command output")
 
     def get_server_status(self) -> str:
         """Get the server status string.

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/constants.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/constants.py
@@ -18,3 +18,7 @@ CONFIGURATION_DEFAULT_NAME = "base"
 # Timeouts (in seconds)
 DEPLOY_TIMEOUT_SECONDS = 1800  # 30 minutes
 DESTROY_TIMEOUT_SECONDS = 600  # 10 minutes
+
+# Error message sentinels (cross-referenced with provider error messages)
+# See: jupyter_deploy/api/aws/ssm/ssm_session.py
+SSM_NOT_REPORTING_SENTINEL = "is not reporting to SSM"

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/deployment.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/deployment.py
@@ -21,6 +21,7 @@ from pytest_jupyter_deploy.constants import (
     CONFIGURATION_DEFAULT_NAME,
     DEPLOY_TIMEOUT_SECONDS,
     DESTROY_TIMEOUT_SECONDS,
+    SSM_NOT_REPORTING_SENTINEL,
 )
 from pytest_jupyter_deploy.suite_config import SuiteConfig
 
@@ -166,9 +167,8 @@ class EndToEndDeployment:
                 if not self._is_host_running():
                     raise RuntimeError("Host failed to start") from None
 
-            # Wait for SSM agent to register after host start
-            # TODO: this is too aws-specific, we should gate by a flag
-            self.wait_for_ssm_ready()
+            # Wait for host to be reachable after the start
+            self.wait_for_host_agent()
 
         # Step 3: Attempt to restart the server
         self.cli.run_command(["jupyter-deploy", "server", "restart"])
@@ -304,15 +304,12 @@ class EndToEndDeployment:
         status = self.cli.get_server_status()
         return status == "STOPPED"
 
-    def wait_for_ssm_ready(self, max_retries: int = 6) -> None:
-        """Wait for SSM agent to be ready after host state change.
+    def wait_for_host_agent(self, max_retries: int = 6) -> None:
+        """Wait for agent responsible for communication to be ready on the host.
 
         SSM agent needs time to register with AWS Systems Manager after
         the EC2 instance starts or restarts. This method polls until SSM
         is ready or max retries is reached.
-
-        After instance replacements or restarts, SSM agent registration can take
-        30-90 seconds, especially when cloud-init volume mounting is in progress.
 
         Args:
             max_retries: Maximum number of retry attempts (default: 6)
@@ -324,10 +321,9 @@ class EndToEndDeployment:
             try:
                 # Try a simple server status check to verify SSM is ready
                 self.cli.get_server_status()
-                return  # Success - SSM is ready
+                return
             except JDCliError as e:
-                error_str = str(e)
-                if "is not reporting to SSM" in error_str:
+                if SSM_NOT_REPORTING_SENTINEL in str(e):
                     if attempt < max_retries - 1:
                         # Exponential backoff with cap: 2, 4, 8, 16, 30, 30... (max ~90s total)
                         delay = min(2 ** (attempt + 1), 30)
@@ -338,6 +334,29 @@ class EndToEndDeployment:
                 else:
                     # Different error - don't retry
                     raise
+
+    def wait_for_connection_agent(self, max_retries: int = 10) -> None:
+        """Wait for Session Manager connection to be ready on the host.
+
+        The ssmmessages WebSocket channel (used by StartSession) can lag behind
+        the ec2messages channel (used by SendCommand). This method polls
+        SSM:GetConnectionStatus until the session channel is ready.
+
+        Args:
+            max_retries: Maximum number of retry attempts (default: 10)
+
+        Raises:
+            JDCliError: If connection doesn't become ready within max_retries
+        """
+        for attempt in range(max_retries):
+            status = self.cli.get_connection_status()
+            if status == "connected":
+                return
+            if attempt < max_retries - 1:
+                delay = min(2 ** (attempt + 1), 30)
+                time.sleep(delay)
+
+        raise JDCliError(f"Session Manager connection not ready after {max_retries} attempts (last status: {status})")
 
     def ensure_no_org_nor_teams_allowlisted(self) -> None:
         """Unset the organization, list then remove any allowlisted team."""


### PR DESCRIPTION
This PR fixes a regression in the e2e test container (due to `AWS_REGION`) by explicitly passing the `--region` flag to the AWS CLI to start the session. Also it adds a new flag to `jd host status`. to verify the status of the SSM agent (or any host agent): `jd host status --for connection`.

### User experience
- `jd host status --for connection` >> return `connected` or `notconnected` (pass-through from `aws` CLI)

### Implementation
- maps to `host.status-for-connection` instruction
- in the base template, maps to `SSM:GetConnectionStatus`

### Testing
- updated E2E tests (server & host)
- ran E2E tests, verify behavior

### Screenshot
**host status --help**
<img width="1293" height="191" alt="Screenshot 2026-03-20 at 3 18 39 PM" src="https://github.com/user-attachments/assets/45637998-dfbb-44dc-bed6-b068b4c6bac8" />

**host status --for connection**
<img width="458" height="47" alt="Screenshot 2026-03-20 at 3 16 31 PM" src="https://github.com/user-attachments/assets/a7087942-c757-42a3-9cb6-316d8d14ebb8" />
