### PR TITLE
feat: plugin 2fa

### DIFF
--- a/justfile
+++ b/justfile
@@ -585,12 +585,14 @@ auth-bot-email ci_dir="sandbox-ci":
 auth-bot-username ci_dir="sandbox-ci":
     @just auth-bot-email {{ci_dir}} | cut -d'@' -f1
 
-# Generate .env for base template E2E tests from deployed project + CI infrastructure
-# Reads variables from the project, OAuth creds from CI, and accepts user options
+# Generate .env for base template E2E tests
+# Two modes:
+#   Existing project: reads deployment variables from the project via `jd show -v`
+#   Fresh deploy:     pass "" as project-dir, provide deployment vars as options
 # Usage: just env-setup-base <project-dir> [ci-dir] [oauth-app-num] [options]
 # Options: comma-separated key=value pairs (same format as test-e2e options)
 # Quote options containing [] values (zsh treats brackets as glob patterns)
 # Example: just env-setup-base sandbox-e2e sandbox-ci 4 user=botuser,safe-user=realuser
-# Example: just env-setup-base sandbox-e2e sandbox-ci 4 'allowed-teams=[team1],user=botuser'
+# Example: just env-setup-base "" sandbox-ci 4 'user=botuser,safe-user=realuser'
 env-setup-base project_dir ci_dir="sandbox-ci" oauth_app_num="1" options="":
-    uv run python scripts/env_setup_base.py {{project_dir}} {{ci_dir}} {{oauth_app_num}} "{{options}}"
+    uv run python scripts/env_setup_base.py "{{project_dir}}" {{ci_dir}} {{oauth_app_num}} "{{options}}"

--- a/justfile
+++ b/justfile
@@ -133,6 +133,7 @@ e2e-sync:
 # Example: just test-e2e sandbox2 test_config_changes mutate=true   # test existing project with mutating tests
 # Example: just test-e2e sandbox-e2e "" mutate=true,destroy=true    # deploy from scratch and destroy after tests
 # Example: just test-e2e sandbox2 "" log-level=debug          # test with debug logging
+# Example: just test-e2e sandbox2 test_application ci-dir=sandbox-ci  # CI mode with automated 2FA
 test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-template:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -200,15 +201,30 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         fi
     fi
 
-    # Create temporary override file to mount the project directory and test-results
+    # Parse ci-dir from options early (needed for override file)
+    CI_DIR=""
+    OPTIONS_STR_EARLY="{{options}}"
+    if echo "$OPTIONS_STR_EARLY" | grep -qE "ci-dir="; then
+        CI_DIR=$(echo "$OPTIONS_STR_EARLY" | grep -oE "ci-dir=[^,]+" | cut -d'=' -f2)
+        if [ ! -d "$CI_DIR" ]; then
+            echo "Error: CI directory '$CI_DIR' does not exist"
+            exit 1
+        fi
+        echo "CI directory: $CI_DIR"
+    fi
+
+    # Create temporary override file to mount the project directory, test-results, and optionally CI dir
     OVERRIDE_FILE="{{justfile_directory()}}/docker-compose.e2e-override.yml"
-    cat > "$OVERRIDE_FILE" <<EOF
-    services:
-      e2e:
-        volumes:
-          - ./{{project_dir}}:/workspace/{{project_dir}}
-          - ./test-results:/workspace/test-results
-    EOF
+    {
+        echo "services:"
+        echo "  e2e:"
+        echo "    volumes:"
+        echo "      - ./{{project_dir}}:/workspace/{{project_dir}}"
+        echo "      - ./test-results:/workspace/test-results"
+        if [ -n "$CI_DIR" ]; then
+            echo "      - ./${CI_DIR}:/workspace/${CI_DIR}"
+        fi
+    } > "$OVERRIDE_FILE"
 
     # Stop and restart container with new mounts (ensures clean mount state)
     echo "Restarting E2E container with project mount..."
@@ -272,7 +288,7 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         echo "Options: $OPTIONS_STR"
 
         # List of recognized options (for validation)
-        RECOGNIZED_OPTIONS="mutate destroy log-level"
+        RECOGNIZED_OPTIONS="mutate destroy log-level ci-dir"
 
         # Validate all options are recognized
         IFS=',' read -ra OPTS <<< "$OPTIONS_STR"
@@ -316,11 +332,11 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
             echo "  - log level: $LOG_LEVEL"
         fi
 
-        # Future options can be added here:
-        # if echo "$OPTIONS_STR" | grep -q "stream-logs=true"; then
-        #     RECOGNIZED_OPTIONS="$RECOGNIZED_OPTIONS stream-logs"
-        #     # handle stream-logs option
-        # fi
+        # Parse ci-dir option (enables CI mode with automated 2FA)
+        if [ -n "$CI_DIR" ]; then
+            PYTEST_ARGS="$PYTEST_ARGS --ci --ci-dir $CI_DIR"
+            echo "  - CI mode: enabled (ci-dir=$CI_DIR)"
+        fi
     fi
 
     # Add common pytest options
@@ -564,6 +580,10 @@ auth-bot-2fa ci_dir="sandbox-ci":
 # Print the GitHub bot account email from CI project variables
 auth-bot-email ci_dir="sandbox-ci":
     @uv run jd show -v github_bot_account_email --text --path {{ci_dir}}
+
+# Print the GitHub bot account username (email prefix before @)
+auth-bot-username ci_dir="sandbox-ci":
+    @just auth-bot-email {{ci_dir}} | cut -d'@' -f1
 
 # Generate .env for base template E2E tests from deployed project + CI infrastructure
 # Reads variables from the project, OAuth creds from CI, and accepts user options

--- a/justfile
+++ b/justfile
@@ -524,6 +524,17 @@ test-e2e-ci project_dir="sandbox-e2e-ci" test_filter="" options="":
 auth-setup-base project_dir display="${DISPLAY:-}":
     @just auth-setup {{project_dir}} "{{display}}"
 
+# Initialize a new base template project directory
+init-base project_dir:
+    uv run jd init {{project_dir}}
+
+# Configure a base template project using CI OAuth app settings
+# Usage: just config-base-from-ci <project-dir> [ci-dir] [oauth-app-num] [allowed-usernames]
+# Example: just config-base-from-ci sandbox-base sandbox-ci 1
+# Example: just config-base-from-ci sandbox-base sandbox-ci 1 '["bot-user","admin"]'
+config-base-from-ci project_dir ci_dir="sandbox-ci" oauth_app_num="1" allowed_usernames="":
+    uv run python scripts/config_base_from_ci.py {{project_dir}} {{ci_dir}} {{oauth_app_num}} "{{allowed_usernames}}"
+
 # --- CI infrastructure commands ---
 
 # Discover and restore CI project from S3 store

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     curl \
     jq \
     git \
+    oathtool \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Terraform

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/docker-compose.yml
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/docker-compose.yml
@@ -36,9 +36,6 @@ services:
       - AWS_PROFILE=${AWS_PROFILE:-default}
       - AWS_CONFIG_FILE=/home/testuser/.aws/config
       - AWS_SHARED_CREDENTIALS_FILE=/home/testuser/.aws/credentials
-      # GitHub credentials (for CI OAuth login without 2FA)
-      - GITHUB_USERNAME=${GITHUB_USERNAME:-}
-      - GITHUB_PASSWORD=${GITHUB_PASSWORD:-}
     network_mode: host
     # Keep container running in background
     command: sleep infinity

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/ci_credentials.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/ci_credentials.py
@@ -1,0 +1,38 @@
+"""CI credential fetching from mounted CI project directory."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+
+
+def _run(args: list[str]) -> str:
+    """Run a command and return stripped stdout."""
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def fetch_ci_credentials(ci_dir: str) -> tuple[str, str, Callable[[], str]]:
+    """Fetch bot credentials from the CI project directory.
+
+    Calls the underlying CLI commands directly (no `just` dependency).
+    The TOTP function is a closure called just-in-time (30s TOTP window).
+
+    Args:
+        ci_dir: Path to the CI infrastructure project directory
+
+    Returns:
+        Tuple of (email, password, totp_fn) where totp_fn generates fresh TOTP codes
+    """
+    email = _run(["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "--path", ci_dir])
+    password = _run(["uv", "run", "python", "scripts/auth_bot_secret.py", ci_dir, "password"])
+
+    def totp_fn() -> str:
+        return _run(["uv", "run", "python", "scripts/auth_bot_secret.py", ci_dir, "totp"])
+
+    return email, password, totp_fn

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
@@ -2,8 +2,8 @@
 
 import contextlib
 import logging
-import os
 import time
+from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -16,7 +16,14 @@ class GitHubOAuth2ProxyApplication:
     """Helper class for authenticating through GitHub OAuth2 Proxy."""
 
     def __init__(
-        self, page: Page, jupyterlab_url: str, storage_state_path: Path | None = None, is_ci: bool = False
+        self,
+        page: Page,
+        jupyterlab_url: str,
+        storage_state_path: Path | None = None,
+        is_ci: bool = False,
+        ci_email: str | None = None,
+        ci_password: str | None = None,
+        ci_totp_fn: Callable[[], str] | None = None,
     ) -> None:
         """Initialize the GitHub OAuth2 Proxy application helper.
 
@@ -24,12 +31,18 @@ class GitHubOAuth2ProxyApplication:
             page: Playwright Page instance
             jupyterlab_url: The JupyterLab URL behind OAuth2 Proxy
             storage_state_path: Optional path to save/load browser storage state for auth persistence
-            is_ci: Whether running in CI environment (uses GITHUB_USERNAME/GITHUB_PASSWORD)
+            is_ci: Whether running in CI environment (automated 2FA via CI infrastructure)
+            ci_email: GitHub bot account email (CI mode only)
+            ci_password: GitHub bot account password (CI mode only)
+            ci_totp_fn: Callable that returns a fresh TOTP code (CI mode only, called just-in-time)
         """
         self.page = page
         self.jupyterlab_url = jupyterlab_url
         self.storage_state_path = storage_state_path
         self.is_ci = is_ci
+        self._ci_email = ci_email
+        self._ci_password = ci_password
+        self._ci_totp_fn = ci_totp_fn
 
     def _navigate_with_retry(
         self, url: str, timeout: int = 60000, wait_until: str = "load", max_retries: int = 3
@@ -156,8 +169,7 @@ class GitHubOAuth2ProxyApplication:
                     "  1. Run: just auth-setup <project-dir>\n"
                     "  2. Complete authentication in the browser\n"
                     "  3. Re-run tests\n\n"
-                    "For CI without 2FA:\n"
-                    "  Use --ci flag and set GITHUB_USERNAME and GITHUB_PASSWORD environment variables"
+                    "For CI: use --ci --ci-dir <path> for automated 2FA authentication"
                 )
                 raise RuntimeError(error_msg) from None
         except Exception as e:
@@ -171,8 +183,7 @@ class GitHubOAuth2ProxyApplication:
                 "  1. Run: just auth-setup <project-dir>\n"
                 "  2. Complete authentication in the browser\n"
                 "  3. Re-run tests\n\n"
-                "For CI without 2FA:\n"
-                "  Use --ci flag and set GITHUB_USERNAME and GITHUB_PASSWORD environment variables"
+                "For CI: use --ci --ci-dir <path> for automated 2FA authentication"
             )
             raise RuntimeError(error_msg) from e
 
@@ -202,19 +213,16 @@ class GitHubOAuth2ProxyApplication:
         else:
             self._handle_oauth_standard_authorize_page()
 
-    def login_with_auth_session(self) -> None:
-        """Login using saved authentication session from storage state.
+    def _try_auth_session(self) -> bool:
+        """Try authenticating with existing cookies (storage state).
 
-        This method handles two scenarios:
-        1. OAuth2 Proxy session is valid → goes straight to JupyterLab
-        2. OAuth2 Proxy session expired but GitHub cookies valid →
-           clicks "Sign in with GitHub" and GitHub auto-authenticates
+        Navigates to JupyterLab URL and attempts to authenticate using saved cookies.
+        If OAuth2 Proxy or GitHub cookies are valid, completes authentication and returns True.
+        If all cookies are expired and the GitHub login page is reached, returns False
+        with the page left on the GitHub login page for the caller to handle.
 
-        Raises:
-            RuntimeError: If GitHub cookies are also expired (requires manual 2FA)
-            FileNotFoundError: If storage state wasn't loaded
-
-        Note: Run scripts/github_auth_setup.py first to create the storage state file.
+        Returns:
+            True if authentication succeeded via cookies, False if login page reached.
         """
         # Navigate to the JupyterLab URL
         # Storage state should be loaded by browser context at this point
@@ -227,166 +235,139 @@ class GitHubOAuth2ProxyApplication:
         except Exception:
             sign_in_visible = False
 
-        if sign_in_visible:
-            # OAuth2 Proxy session expired, but GitHub cookies might still be valid
-            # Click "Sign in with GitHub" to attempt auto-authentication
-            sign_in_button.click()
-
-            # Wait for redirect - either:
-            # 1. OAuth authorize page → callback → JupyterLab (GitHub cookies valid)
-            # 2. GitHub login page (GitHub cookies expired)
-
-            # Wait for navigation to complete (GitHub OAuth flow)
-            # Network might not go idle if there are ongoing requests
-            with contextlib.suppress(Exception):
-                # Wait for redirect away from OAuth2 Proxy or to complete OAuth flow
-                # This handles: OAuth2 Proxy → GitHub OAuth authorize → callback → JupyterLab
-                self.page.wait_for_load_state("networkidle", timeout=10000)
-
-            # Check current URL
-            current_url = self.page.url
-
-            # Check if we're on GitHub OAuth authorize page
-            if "github.com/login/oauth/authorize" in current_url:
-                # With valid cookies, GitHub should either:
-                # 1. Auto-submit the authorization (approval_prompt=force)
-                # 2. Show an "Authorize" button that we need to click
-                # 3. Show a reauthorization page with a disabled button that becomes enabled
-
-                # Wait a moment for page to load and auto-submit
-                try:
-                    # Check if we're redirected automatically (back to app domain, not GitHub)
-                    self.page.wait_for_url(lambda url: "github.com" not in url, timeout=5000)
-                except Exception:
-                    # Still on authorize page - handle both normal and reauthorization flows
-                    self._handle_oauth_authorize_page()
-            elif "github.com" in current_url and self.jupyterlab_url not in current_url:
-                # We're on some GitHub page but not authorize or JupyterLab
-                # This could be the login page if cookies expired
-                error_msg = (
-                    "GitHub authentication required!\n\n"
-                    "Redirected to GitHub but not on JupyterLab. GitHub cookies may have expired.\n"
-                    f"Current URL: {current_url}\n\n"
-                    "For local development:\n"
-                    "  1. Run: just auth-setup <project-dir>\n"
-                    "  2. Complete authentication in the browser\n"
-                    "  3. Re-run tests\n\n"
-                    "For CI without 2FA:\n"
-                    "  Use --ci flag and set GITHUB_USERNAME and GITHUB_PASSWORD environment variables"
-                )
-                raise RuntimeError(error_msg) from None
-
-            # Save the new OAuth2 Proxy session for future test runs
+        if not sign_in_visible:
+            # OAuth2 Proxy session is valid — already authenticated
             self.save_storage_state()
+            return True
+
+        # OAuth2 Proxy session expired, but GitHub cookies might still be valid
+        # Click "Sign in with GitHub" to attempt auto-authentication
+        sign_in_button.click()
+
+        # Wait for navigation to complete (GitHub OAuth flow)
+        # Network might not go idle if there are ongoing requests
+        with contextlib.suppress(Exception):
+            self.page.wait_for_load_state("networkidle", timeout=10000)
+
+        # Check current URL
+        current_url = self.page.url
+
+        # Check if we're on GitHub OAuth authorize page
+        if "github.com/login/oauth/authorize" in current_url:
+            # With valid cookies, GitHub should either:
+            # 1. Auto-submit the authorization (approval_prompt=force)
+            # 2. Show an "Authorize" button that we need to click
+            # 3. Show a reauthorization page with a disabled button that becomes enabled
+            try:
+                # Check if we're redirected automatically (back to app domain, not GitHub)
+                self.page.wait_for_url(lambda url: "github.com" not in url, timeout=5000)
+            except Exception:
+                # Still on authorize page - handle both normal and reauthorization flows
+                self._handle_oauth_authorize_page()
+
+            # Successfully authenticated via cookies
+            self.save_storage_state()
+            return True
+
+        # Check if we ended up on the GitHub login page (cookies expired)
+        if "github.com" in current_url:
+            # Page is on GitHub login — caller must handle credentials
+            return False
+
+        # We're back on the app domain — authentication succeeded
+        self.save_storage_state()
+        return True
+
+    def login_with_auth_session(self) -> None:
+        """Login using saved authentication session from storage state.
+
+        Tries cookies first. If GitHub cookies are expired, raises RuntimeError
+        with instructions for local development or CI setup.
+
+        Raises:
+            RuntimeError: If GitHub cookies are expired (requires manual setup or CI mode)
+        """
+        if not self._try_auth_session():
+            current_url = self.page.url
+            error_msg = (
+                "GitHub authentication required!\n\n"
+                "Redirected to GitHub but cookies are expired.\n"
+                f"Current URL: {current_url}\n\n"
+                "For local development:\n"
+                "  1. Run: just auth-setup <project-dir>\n"
+                "  2. Complete authentication in the browser\n"
+                "  3. Re-run tests\n\n"
+                "For CI: use --ci --ci-dir <path> for automated 2FA authentication"
+            )
+            raise RuntimeError(error_msg) from None
 
         # Verify we're back on the application domain (not GitHub)
-        # We don't verify JupyterLab is accessible here because the user might be
-        # authenticated but not authorized (403 Forbidden)
         current_url = self.page.url
         if "github.com" in current_url:
             raise RuntimeError(f"Authentication did not complete successfully. Still on GitHub: {current_url}")
 
-    def login_without_2fa(self) -> None:
-        """Login using username/password without 2FA (for CI environments).
+    def login_with_2fa(self, email: str, password: str, totp_fn: Callable[[], str]) -> None:
+        """Login using email, password, and TOTP code (for CI environments with 2FA).
 
-        This method handles three scenarios:
-        1. OAuth2 Proxy session is valid (saved cookies) → goes straight to JupyterLab
-        2. OAuth2 Proxy session expired but GitHub cookies valid → clicks "Sign in with GitHub",
-           GitHub auto-authenticates via OAuth authorize page
-        3. Both sessions expired → performs full username/password login
+        Tries cookies first via _try_auth_session(). If cookies are expired,
+        performs full login: email + password + TOTP code.
 
-        The method:
-        1. Navigates to JupyterLab URL (with any existing cookies from storage state)
-        2. Checks if OAuth2 Proxy sign-in page is shown
-        3. If sign-in required:
-           - Clicks "Sign in with GitHub"
-           - If GitHub cookies valid: GitHub auto-authenticates (or clicks Authorize button)
-           - If GitHub cookies expired: enters username/password
-        4. If already authenticated: skips login (reuses valid OAuth2 Proxy session cookies)
-        5. Saves storage state with fresh cookies for future test runs
-
-        After first successful authentication, subsequent test runs will reuse the saved
-        session cookies (both OAuth2 Proxy and GitHub), avoiding unnecessary authentication.
-
-        Requires environment variables:
-        - GITHUB_USERNAME: GitHub username
-        - GITHUB_PASSWORD: GitHub password
-
-        Raises:
-            ValueError: If environment variables are not set
-
-        Note: Only use this for CI environments with GitHub accounts that have 2FA disabled.
+        Args:
+            email: GitHub account email
+            password: GitHub account password
+            totp_fn: Callable that returns a fresh 6-digit TOTP code (called just-in-time)
         """
-        # Check for required environment variables
-        github_username = os.getenv("GITHUB_USERNAME")
-        github_password = os.getenv("GITHUB_PASSWORD")
+        if self._try_auth_session():
+            logger.info("Authenticated via saved cookies (no 2FA needed)")
+            return
 
-        if not github_username or not github_password:
-            raise ValueError(
-                "GITHUB_USERNAME and GITHUB_PASSWORD environment variables must be set for CI authentication"
-            )
+        # Page is on GitHub login page — fill credentials
+        logger.info("Cookies expired, performing full 2FA login")
+        current_url = self.page.url
+        logger.debug(f"Current URL before login: {current_url}")
 
-        # Navigate to the JupyterLab URL
-        # Storage state should be loaded by browser context at this point
-        self._navigate_with_retry(self.jupyterlab_url, timeout=60000)
+        # Fill in GitHub credentials
+        self.page.fill('input[name="login"]', email)
+        self.page.fill('input[name="password"]', password)
+        self.page.click('input[type="submit"]')
 
-        # Check if we see the OAuth2 Proxy sign-in page
-        sign_in_button = self.page.get_by_role("button", name="Sign in with GitHub")
+        # Wait for TOTP page
+        logger.debug("Waiting for GitHub TOTP page...")
+        self.page.wait_for_url("**/sessions/two-factor/app**", timeout=30000)
+
+        # Generate fresh TOTP code and fill it
+        totp_code = totp_fn()
+        logger.debug("Generated TOTP code, filling...")
+        self.page.fill("#app_totp", totp_code)
+
+        # GitHub may auto-submit on input, or we may need to click
+        # Wait for navigation away from the 2FA page
         try:
-            sign_in_visible = sign_in_button.is_visible(timeout=2000)
+            self.page.wait_for_url(lambda url: "two-factor" not in url, timeout=10000)
         except Exception:
-            sign_in_visible = False
-
-        if sign_in_visible:
-            # OAuth2 Proxy session expired, but GitHub cookies might still be valid
-            # Click "Sign in with GitHub" to attempt auto-authentication
-            sign_in_button.click()
-
-            # Wait for redirect - either:
-            # 1. OAuth authorize page → callback → JupyterLab (GitHub cookies valid)
-            # 2. GitHub login page (GitHub cookies expired)
-
-            # Wait for navigation to complete (GitHub OAuth flow)
+            # Try clicking submit if auto-submit didn't happen
             with contextlib.suppress(Exception):
-                self.page.wait_for_load_state("networkidle", timeout=10000)
+                self.page.click('button[type="submit"]')
+            self.page.wait_for_url(lambda url: "two-factor" not in url, timeout=10000)
 
-            # Check current URL
-            current_url = self.page.url
+        logger.debug(f"Post-2FA URL: {self.page.url}")
 
-            # Check if we're on GitHub OAuth authorize page
-            if "github.com/login/oauth/authorize" in current_url:
-                # With valid cookies, GitHub should either:
-                # 1. Auto-submit the authorization
-                # 2. Show an "Authorize" button that we need to click
-                # 3. Show a reauthorization page with a disabled button that becomes enabled
+        # After 2FA, we may land on:
+        # 1. OAuth authorize page (need to click Authorize)
+        # 2. Directly back to the app (auto-authorized)
+        current_url = self.page.url
+        if "github.com/login/oauth/authorize" in current_url:
+            try:
+                self.page.wait_for_url(lambda url: "github.com" not in url, timeout=5000)
+            except Exception:
+                self._handle_oauth_authorize_page()
+        elif "github.com" in current_url:
+            # Wait a bit for any redirects to complete
+            with contextlib.suppress(Exception):
+                self.page.wait_for_url(lambda url: "github.com" not in url, timeout=10000)
 
-                # Wait a moment for page to load and auto-submit
-                try:
-                    # Check if we're redirected automatically (back to app domain, not GitHub)
-                    self.page.wait_for_url(lambda url: "github.com" not in url, timeout=5000)
-                except Exception:
-                    # Still on authorize page - handle both normal and reauthorization flows
-                    with contextlib.suppress(Exception):
-                        # No authorize button - might need username/password
-                        # Fall through to check if we're on login page below
-                        self._handle_oauth_authorize_page()
-
-            # Check if we're on GitHub login page (GitHub cookies expired)
-            current_url = self.page.url
-            if "github.com/login" in current_url and "oauth" not in current_url:
-                # GitHub cookies expired, need to enter username/password
-                # Fill in GitHub credentials
-                self.page.fill('input[name="login"]', github_username)
-                self.page.fill('input[name="password"]', github_password)
-
-                # Submit the form
-                self.page.click('input[type="submit"]')
-
-                # Wait for authentication to complete and redirect back to application
-                self.page.wait_for_url(f"{self.jupyterlab_url}**", timeout=60000)
-
-        # Save storage state for future test runs (whether we authenticated or used existing session)
         self.save_storage_state()
+        logger.info("2FA login complete, storage state saved")
 
     def verify_jupyterlab_accessible(self) -> None:
         """Verify that JupyterLab is accessible and loaded.
@@ -489,11 +470,13 @@ class GitHubOAuth2ProxyApplication:
         """Ensure the user is authenticated, performing login if necessary.
 
         Uses the appropriate login method based on environment:
-        - CI mode (--is-ci): Uses login_without_2fa() with GITHUB_USERNAME/GITHUB_PASSWORD
+        - CI mode (--ci --ci-dir): Uses login_with_2fa() with automated 2FA credentials
         - Local mode: Uses login_with_auth_session() with saved storage state
         """
         if self.is_ci:
-            self.login_without_2fa()
+            if not self._ci_email or not self._ci_password or not self._ci_totp_fn:
+                raise RuntimeError("CI mode requires credentials. Use --ci --ci-dir <path> to provide them.")
+            self.login_with_2fa(self._ci_email, self._ci_password, self._ci_totp_fn)
         else:
             self.login_with_auth_session()
 

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/plugin.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/plugin.py
@@ -12,6 +12,7 @@ from playwright.sync_api import Page
 from pytest_jupyter_deploy import constants
 from pytest_jupyter_deploy.constants import DEPLOY_TIMEOUT_SECONDS, DESTROY_TIMEOUT_SECONDS
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.oauth2_proxy.ci_credentials import fetch_ci_credentials
 from pytest_jupyter_deploy.oauth2_proxy.github import GitHubOAuth2ProxyApplication
 from pytest_jupyter_deploy.suite_config import SuiteConfig
 
@@ -100,7 +101,13 @@ def pytest_addoption(parser: Any) -> None:
         "--ci",
         action="store_true",
         default=False,
-        help="CI mode: use GITHUB_USERNAME/GITHUB_PASSWORD for authentication without 2FA",
+        help="CI mode: automated authentication via 2FA using CI infrastructure project (requires --ci-dir)",
+    )
+    add_option_if_not_exists(
+        "--ci-dir",
+        action="store",
+        default=None,
+        help="Path to CI infrastructure project (required with --ci for credential fetching)",
     )
     add_option_if_not_exists(
         "--with-mutating-cases",
@@ -249,14 +256,7 @@ def handle_browser_context_args(browser_context_args: dict[str, Any], request: p
     Returns:
         Updated browser context args with storage_state if available
     """
-    # Check if running in CI mode
-    is_ci = request.config.getoption("--ci", default=False)
-
-    # Skip loading storage state in CI mode (will use username/password login)
-    if is_ci:
-        return {**browser_context_args}
-
-    # Load storage state if file exists
+    # Always load storage state if available (both CI and local try cookies first)
     storage_state_path = Path.cwd() / constants.AUTH_DIR / constants.GITHUB_OAUTH_STATE_FILE
 
     if storage_state_path.exists():
@@ -299,6 +299,21 @@ def github_oauth_app(
     # Get CI mode from pytest option
     is_ci = request.config.getoption("--ci", default=False)
 
+    ci_email: str | None = None
+    ci_password: str | None = None
+    ci_totp_fn: Callable[[], str] | None = None
+    if is_ci:
+        ci_dir = request.config.getoption("--ci-dir")
+        if not ci_dir:
+            raise pytest.UsageError("--ci requires --ci-dir <path> for credential fetching")
+        ci_email, ci_password, ci_totp_fn = fetch_ci_credentials(ci_dir)
+
     return GitHubOAuth2ProxyApplication(
-        page=page, jupyterlab_url=jupyterlab_url, storage_state_path=storage_state_path, is_ci=is_ci
+        page=page,
+        jupyterlab_url=jupyterlab_url,
+        storage_state_path=storage_state_path,
+        is_ci=is_ci,
+        ci_email=ci_email,
+        ci_password=ci_password,
+        ci_totp_fn=ci_totp_fn,
     )

--- a/libs/pytest-jupyter-deploy/tests/test_ci_credentials.py
+++ b/libs/pytest-jupyter-deploy/tests/test_ci_credentials.py
@@ -1,0 +1,72 @@
+"""Unit tests for CI credential fetching."""
+
+import subprocess
+import unittest
+from unittest.mock import Mock, call, patch
+
+from pytest_jupyter_deploy.oauth2_proxy.ci_credentials import fetch_ci_credentials
+
+
+class TestFetchCiCredentials(unittest.TestCase):
+    @patch("pytest_jupyter_deploy.oauth2_proxy.ci_credentials.subprocess.run")
+    def test_returns_email_password_and_totp_fn(self, mock_run: Mock) -> None:
+        mock_run.side_effect = [
+            Mock(stdout="bot@example.com\n"),
+            Mock(stdout="s3cret\n"),
+        ]
+
+        email, password, totp_fn = fetch_ci_credentials("/ci/dir")
+
+        assert email == "bot@example.com"
+        assert password == "s3cret"
+        assert callable(totp_fn)
+        mock_run.assert_has_calls(
+            [
+                call(
+                    ["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "--path", "/ci/dir"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ),
+                call(
+                    ["uv", "run", "python", "scripts/auth_bot_secret.py", "/ci/dir", "password"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ),
+            ]
+        )
+
+    @patch("pytest_jupyter_deploy.oauth2_proxy.ci_credentials.subprocess.run")
+    def test_totp_fn_spawns_new_subprocess_each_call(self, mock_run: Mock) -> None:
+        mock_run.side_effect = [
+            Mock(stdout="bot@example.com\n"),
+            Mock(stdout="s3cret\n"),
+            Mock(stdout="123456\n"),
+            Mock(stdout="654321\n"),
+        ]
+
+        _, _, totp_fn = fetch_ci_credentials("/ci/dir")
+
+        first_code = totp_fn()
+        second_code = totp_fn()
+
+        assert first_code == "123456"
+        assert second_code == "654321"
+        # 2 initial calls (email, password) + 2 totp calls = 4 total
+        assert mock_run.call_count == 4
+        totp_call = call(
+            ["uv", "run", "python", "scripts/auth_bot_secret.py", "/ci/dir", "totp"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert mock_run.call_args_list[2] == totp_call
+        assert mock_run.call_args_list[3] == totp_call
+
+    @patch("pytest_jupyter_deploy.oauth2_proxy.ci_credentials.subprocess.run")
+    def test_subprocess_failure_raises(self, mock_run: Mock) -> None:
+        mock_run.side_effect = subprocess.CalledProcessError(1, "uv", stderr="not found")
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            fetch_ci_credentials("/ci/dir")

--- a/libs/pytest-jupyter-deploy/tests/test_github_oauth.py
+++ b/libs/pytest-jupyter-deploy/tests/test_github_oauth.py
@@ -1,0 +1,214 @@
+"""Unit tests for GitHubOAuth2ProxyApplication auth methods."""
+
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, PropertyMock, patch
+
+from pytest_jupyter_deploy.oauth2_proxy.github import GitHubOAuth2ProxyApplication
+
+
+def _make_app(
+    is_ci: bool = False,
+    ci_email: str | None = None,
+    ci_password: str | None = None,
+    ci_totp_fn: Mock | None = None,
+    storage_state_path: Path | None = None,
+) -> tuple[GitHubOAuth2ProxyApplication, Mock]:
+    """Create a GitHubOAuth2ProxyApplication with a mocked Page."""
+    page = Mock()
+    app = GitHubOAuth2ProxyApplication(
+        page=page,
+        jupyterlab_url="https://app.example.com/lab",
+        storage_state_path=storage_state_path or Path("/tmp/test-state.json"),
+        is_ci=is_ci,
+        ci_email=ci_email,
+        ci_password=ci_password,
+        ci_totp_fn=ci_totp_fn,
+    )
+    return app, page
+
+
+class TestTryAuthSession(unittest.TestCase):
+    def test_returns_true_when_oauth_proxy_session_valid(self) -> None:
+        """No sign-in button visible → already authenticated."""
+        app, page = _make_app()
+        sign_in_button = Mock()
+        sign_in_button.is_visible.return_value = False
+        page.get_by_role.return_value = sign_in_button
+
+        with patch.object(app, "save_storage_state") as mock_save:
+            result = app._try_auth_session()
+
+        assert result is True
+        mock_save.assert_called_once()
+
+    def test_returns_true_when_github_cookies_valid_auto_redirect(self) -> None:
+        """Sign-in visible, click it, auto-redirect back to app domain."""
+        app, page = _make_app()
+        sign_in_button = Mock()
+        sign_in_button.is_visible.return_value = True
+        page.get_by_role.return_value = sign_in_button
+
+        # After clicking sign-in, URL goes to app domain (not github.com)
+        type(page).url = PropertyMock(return_value="https://app.example.com/lab")
+
+        with patch.object(app, "save_storage_state"), patch.object(app, "_navigate_with_retry"):
+            result = app._try_auth_session()
+
+        assert result is True
+        sign_in_button.click.assert_called_once()
+
+    def test_returns_false_when_github_cookies_expired(self) -> None:
+        """Sign-in visible, click it, lands on github.com/login → cookies expired."""
+        app, page = _make_app()
+        sign_in_button = Mock()
+        sign_in_button.is_visible.return_value = True
+        page.get_by_role.return_value = sign_in_button
+
+        # After clicking, URL is github login page
+        type(page).url = PropertyMock(return_value="https://github.com/login?client_id=abc")
+
+        with patch.object(app, "_navigate_with_retry"):
+            result = app._try_auth_session()
+
+        assert result is False
+
+    def test_returns_true_when_on_oauth_authorize_page(self) -> None:
+        """Sign-in visible, click it, lands on authorize page → handles it."""
+        app, page = _make_app()
+        sign_in_button = Mock()
+        sign_in_button.is_visible.return_value = True
+        page.get_by_role.return_value = sign_in_button
+
+        # First URL check: on authorize page; wait_for_url raises (still on github)
+        type(page).url = PropertyMock(return_value="https://github.com/login/oauth/authorize?client_id=abc")
+        page.wait_for_url.side_effect = Exception("timeout")
+
+        with (
+            patch.object(app, "save_storage_state"),
+            patch.object(app, "_navigate_with_retry"),
+            patch.object(app, "_handle_oauth_authorize_page") as mock_handle_oauth,
+        ):
+            result = app._try_auth_session()
+
+        assert result is True
+        mock_handle_oauth.assert_called_once()
+
+
+class TestLoginWithAuthSession(unittest.TestCase):
+    def test_succeeds_when_cookies_valid(self) -> None:
+        app, page = _make_app()
+        type(page).url = PropertyMock(return_value="https://app.example.com/lab")
+        with patch.object(app, "_try_auth_session", return_value=True):
+            # Should not raise
+            app.login_with_auth_session()
+
+    def test_raises_when_cookies_expired(self) -> None:
+        app, page = _make_app()
+        type(page).url = PropertyMock(return_value="https://github.com/login")
+
+        with patch.object(app, "_try_auth_session", return_value=False), self.assertRaises(RuntimeError) as ctx:
+            app.login_with_auth_session()
+
+        assert "GitHub authentication required" in str(ctx.exception)
+        assert "just auth-setup" in str(ctx.exception)
+
+
+class TestLoginWith2fa(unittest.TestCase):
+    def test_skips_2fa_when_cookies_valid(self) -> None:
+        """If _try_auth_session returns True, no credentials used."""
+        totp_fn = Mock()
+        app, page = _make_app(ci_totp_fn=totp_fn)
+
+        with patch.object(app, "_try_auth_session", return_value=True):
+            app.login_with_2fa("bot@example.com", "s3cret", totp_fn)
+
+        # No credential input or TOTP generation
+        page.fill.assert_not_called()
+        totp_fn.assert_not_called()
+
+    def test_full_2fa_flow_when_cookies_expired(self) -> None:
+        """Full flow: email + password + TOTP + OAuth authorize."""
+        totp_fn = Mock(return_value="123456")
+        app, page = _make_app(ci_totp_fn=totp_fn)
+
+        # After 2FA, land on OAuth authorize page, then app
+        url_sequence = iter(
+            [
+                "https://github.com/login",  # during _try_auth_session check
+                "https://github.com/login/oauth/authorize?client_id=abc",  # after 2FA
+                "https://github.com/login/oauth/authorize?client_id=abc",  # second read in if
+            ]
+        )
+        type(page).url = PropertyMock(side_effect=url_sequence)
+
+        # wait_for_url for TOTP page succeeds, then for redirect away from authorize raises
+        def wait_for_url_side_effect(url_pattern: object, **kwargs: object) -> None:
+            pass
+
+        page.wait_for_url.side_effect = wait_for_url_side_effect
+
+        with (
+            patch.object(app, "_try_auth_session", return_value=False),
+            patch.object(app, "save_storage_state") as mock_save,
+            patch.object(app, "_handle_oauth_authorize_page"),
+        ):
+            # Make the first wait_for_url (TOTP page) succeed,
+            # then the second (redirect away from two-factor) succeed,
+            # then the third (redirect away from github) raise to trigger _handle_oauth_authorize_page
+            page.wait_for_url.side_effect = [None, None, Exception("timeout")]
+
+            app.login_with_2fa("bot@example.com", "s3cret", totp_fn)
+
+        # Verify credentials were filled
+        page.fill.assert_any_call('input[name="login"]', "bot@example.com")
+        page.fill.assert_any_call('input[name="password"]', "s3cret")
+        page.click.assert_any_call('input[type="submit"]')
+        # Verify TOTP was generated and filled
+        totp_fn.assert_called_once()
+        page.fill.assert_any_call("#app_totp", "123456")
+        # Verify storage state was saved
+        mock_save.assert_called_once()
+
+    def test_2fa_direct_redirect_no_oauth_page(self) -> None:
+        """After 2FA, app auto-redirects (no OAuth authorize page)."""
+        totp_fn = Mock(return_value="654321")
+        app, page = _make_app(ci_totp_fn=totp_fn)
+
+        # After 2FA, URL is already on app domain
+        type(page).url = PropertyMock(return_value="https://app.example.com/lab")
+
+        with (
+            patch.object(app, "_try_auth_session", return_value=False),
+            patch.object(app, "save_storage_state") as mock_save,
+        ):
+            app.login_with_2fa("bot@example.com", "s3cret", totp_fn)
+
+        mock_save.assert_called_once()
+
+
+class TestEnsureAuthenticated(unittest.TestCase):
+    def test_ci_mode_dispatches_to_login_with_2fa(self) -> None:
+        totp_fn = Mock()
+        app, _ = _make_app(is_ci=True, ci_email="bot@example.com", ci_password="s3cret", ci_totp_fn=totp_fn)
+
+        with patch.object(app, "login_with_2fa") as mock_2fa:
+            app.ensure_authenticated()
+
+        mock_2fa.assert_called_once_with("bot@example.com", "s3cret", totp_fn)
+
+    def test_local_mode_dispatches_to_login_with_auth_session(self) -> None:
+        app, _ = _make_app(is_ci=False)
+
+        with patch.object(app, "login_with_auth_session") as mock_session:
+            app.ensure_authenticated()
+
+        mock_session.assert_called_once()
+
+    def test_ci_mode_raises_without_credentials(self) -> None:
+        app, _ = _make_app(is_ci=True)
+
+        with self.assertRaises(RuntimeError) as ctx:
+            app.ensure_authenticated()
+
+        assert "--ci --ci-dir" in str(ctx.exception)

--- a/libs/pytest-jupyter-deploy/tests/test_plugin.py
+++ b/libs/pytest-jupyter-deploy/tests/test_plugin.py
@@ -95,19 +95,27 @@ def test_e2e_deployment_fixture_yields_value(pytester: Any) -> None:
     result.assert_outcomes(passed=1)
 
 
-def test_handle_browser_args_noop_with_ci_flag() -> None:
-    """Test that handle_browser_context_args returns base args unchanged when --ci flag is set."""
-    # Mock request with --ci flag set
+def test_handle_browser_args_loads_storage_state_in_ci_mode(tmp_path: Path) -> None:
+    """Test that handle_browser_context_args loads storage state even in CI mode."""
+    # Create a mock auth file
+    auth_dir = tmp_path / constants.AUTH_DIR
+    auth_dir.mkdir()
+    auth_file = auth_dir / constants.GITHUB_OAUTH_STATE_FILE
+    auth_file.write_text(json.dumps({"cookies": [{"name": "test", "value": "data"}]}))
+
+    # Mock request (CI mode — no longer skips storage state)
     mock_request = Mock()
-    mock_request.config.getoption.return_value = True  # CI mode enabled
 
     base_args = {"viewport": {"width": 1920, "height": 1080}}
 
-    result = handle_browser_context_args(base_args, mock_request)
+    with patch("pytest_jupyter_deploy.plugin.Path.cwd", return_value=tmp_path):
+        result = handle_browser_context_args(base_args, mock_request)
 
-    # Should return base args unchanged (storage_state not added even if file exists)
-    assert result == base_args
-    mock_request.config.getoption.assert_called_once_with("--ci", default=False)
+    # CI mode should now also load storage state (cookies-first approach)
+    assert result == {
+        "viewport": {"width": 1920, "height": 1080},
+        "storage_state": str(auth_file),
+    }
 
 
 def test_handle_browser_args_reads_auth_file_and_return_combined_results(tmp_path: Path) -> None:
@@ -118,9 +126,8 @@ def test_handle_browser_args_reads_auth_file_and_return_combined_results(tmp_pat
     auth_file = auth_dir / constants.GITHUB_OAUTH_STATE_FILE
     auth_file.write_text(json.dumps({"cookies": [{"name": "test", "value": "data"}]}))
 
-    # Mock request with CI mode disabled
+    # Mock request
     mock_request = Mock()
-    mock_request.config.getoption.return_value = False  # CI mode disabled
 
     base_args = {"viewport": {"width": 1920, "height": 1080}}
 
@@ -133,14 +140,12 @@ def test_handle_browser_args_reads_auth_file_and_return_combined_results(tmp_pat
         "viewport": {"width": 1920, "height": 1080},
         "storage_state": str(auth_file),
     }
-    mock_request.config.getoption.assert_called_once_with("--ci", default=False)
 
 
 def test_handle_browser_args_noop_when_auth_file_is_missing(tmp_path: Path) -> None:
     """Test that handle_browser_context_args returns base args when auth file doesn't exist."""
-    # Mock request with CI mode disabled
+    # Mock request
     mock_request = Mock()
-    mock_request.config.getoption.return_value = False  # CI mode disabled
 
     base_args = {"viewport": {"width": 1920, "height": 1080}}
 
@@ -150,4 +155,3 @@ def test_handle_browser_args_noop_when_auth_file_is_missing(tmp_path: Path) -> N
 
     # Should return base args unchanged (no storage_state added)
     assert result == base_args
-    mock_request.config.getoption.assert_called_once_with("--ci", default=False)

--- a/scripts/ci_helpers.py
+++ b/scripts/ci_helpers.py
@@ -64,3 +64,12 @@ def put_secret_value(arn: str, value: str) -> None:
     region = arn_region(arn)
     client: SecretsManagerClient = boto3.client("secretsmanager", region_name=region)
     client.put_secret_value(SecretId=arn, SecretString=value)
+
+
+def run_jd_config(config_args: list[str], project_dir: str) -> None:
+    """Run jd config with the given arguments in a project directory."""
+    subprocess.run(
+        ["uv", "run", "jd", "config", *config_args],
+        cwd=project_dir,
+        check=True,
+    )

--- a/scripts/ci_restore.py
+++ b/scripts/ci_restore.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from ci_helpers import fetch_value, jd_output
+from ci_helpers import fetch_value, jd_output, run_jd_config
 
 
 def discover_project_id() -> str:
@@ -71,11 +71,7 @@ def fetch_secrets_and_configure(ci_dir: Path) -> None:
         print(f"  Fetched github_oauth_app_client_secret_{i}")
 
     print("Running jd config with fetched secrets...")
-    subprocess.run(
-        ["uv", "run", "jd", "config", *config_args],
-        cwd=ci_dir,
-        check=True,
-    )
+    run_jd_config(config_args, str(ci_dir))
 
 
 def main() -> None:

--- a/scripts/ci_restore.py
+++ b/scripts/ci_restore.py
@@ -56,7 +56,7 @@ def fetch_secrets_and_configure(ci_dir: Path) -> None:
     config_args: list[str] = []
 
     # Fetch bot account secrets
-    for var in ("github_bot_account_password", "github_bot_account_recovery_codes"):
+    for var in ("github_bot_account_password", "github_bot_account_recovery_codes", "github_bot_account_totp_secret"):
         arn = jd_output(f"{var}_secret_arn", ci_dir_str)
         val = fetch_value(arn)
         flag = f"--{var.replace('_', '-')}"

--- a/scripts/config_base_from_ci.py
+++ b/scripts/config_base_from_ci.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Configure a base template project using CI infrastructure values.
+
+Reads OAuth app metadata from the CI project (client_id, homepage_url → domain/subdomain),
+fetches the client secret from Secrets Manager, and runs `jd config` non-interactively.
+
+Usage: scripts/config_base.py <project-dir> <ci-dir> <oauth-app-num> [allowed-usernames]
+
+Examples:
+  scripts/config_base.py sandbox-base sandbox-ci 1
+  scripts/config_base.py sandbox-base sandbox-ci 1 '["bot-user","other-user"]'
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+import yaml
+from ci_helpers import fetch_value, jd_output, run_jd_config
+
+
+def jd_variable_map(var_name: str, ci_dir: str) -> dict[str, str]:
+    """Read a jd map variable and parse it as a Python dict."""
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-v", var_name, "--text", "-p", ci_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return ast.literal_eval(result.stdout.strip())
+
+
+def main() -> None:
+    if len(sys.argv) < 4:
+        print("Usage: scripts/config_base.py <project-dir> <ci-dir> <oauth-app-num> [allowed-usernames]")
+        print()
+        print("  project-dir:       Path to the base template project (from `just init-base`)")
+        print("  ci-dir:            Path to the CI infrastructure project (from `just ci-restore`)")
+        print("  oauth-app-num:     OAuth app number (1-5)")
+        print("  allowed-usernames: JSON array of GitHub usernames (default: bot account email)")
+        sys.exit(1)
+
+    project_dir = sys.argv[1]
+    ci_dir = sys.argv[2]
+    oauth_app_num = sys.argv[3]
+    allowed_usernames_arg = sys.argv[4] if len(sys.argv) > 4 else None
+
+    if oauth_app_num not in ("1", "2", "3", "4", "5"):
+        print(f"Error: OAuth app number must be 1-5, got: {oauth_app_num}")
+        sys.exit(1)
+
+    # 1. Read OAuth app metadata from CI project
+    print(f"Reading OAuth app #{oauth_app_num} metadata from CI ({ci_dir})...")
+    app_meta = jd_variable_map(f"github_oauth_app_{oauth_app_num}", ci_dir)
+    client_id = app_meta["client_id"]
+    homepage_url = app_meta["homepage_url"]
+
+    # Extract domain and subdomain from homepage_url (e.g. https://base.example.com)
+    parsed = urlparse(homepage_url)
+    hostname = parsed.hostname or ""
+    parts = hostname.split(".", 1)
+    if len(parts) != 2:
+        print(f"Error: Cannot extract subdomain.domain from homepage_url: {homepage_url}")
+        sys.exit(1)
+    subdomain = parts[0]
+    domain = parts[1]
+
+    print(f"  client_id:  {client_id}")
+    print(f"  domain:     {domain}")
+    print(f"  subdomain:  {subdomain}")
+
+    # 2. Fetch client secret from Secrets Manager
+    print(f"Fetching OAuth app #{oauth_app_num} client secret from CI...")
+    client_secret_arn = jd_output(f"github_oauth_app_client_secret_{oauth_app_num}_arn", ci_dir)
+    client_secret = fetch_value(client_secret_arn)
+    print("  client_secret: ****")
+
+    # 3. Read bot email for letsencrypt_email
+    print("Reading bot account email from CI...")
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "-p", ci_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    bot_email = result.stdout.strip()
+    print(f"  email: {bot_email}")
+
+    # 4. Determine allowed usernames
+    if allowed_usernames_arg:
+        allowed_usernames = allowed_usernames_arg
+    else:
+        # Default: allow the bot account (extract username from email)
+        bot_username = bot_email.split("@")[0] if "@" in bot_email else bot_email
+        allowed_usernames = f'["{bot_username}"]'
+
+    print(f"  allowed_usernames: {allowed_usernames}")
+
+    # 5. Pre-fill list variables in variables.yaml
+    # jd config CLI cannot pass empty lists (no --flag means None → prompts).
+    # Write list values directly into variables.yaml before calling jd config.
+    usernames_list = json.loads(allowed_usernames) if allowed_usernames else []
+    variables_yaml_path = Path(project_dir) / "variables.yaml"
+    variables_yaml = yaml.safe_load(variables_yaml_path.read_text())
+    variables_yaml["required"]["oauth_allowed_usernames"] = usernames_list
+    variables_yaml["required"]["oauth_allowed_teams"] = []
+    variables_yaml["required"]["oauth_allowed_org"] = ""
+    variables_yaml_path.write_text(yaml.dump(variables_yaml, default_flow_style=False, sort_keys=False))
+
+    # 6. Build jd config args (string and sensitive variables only)
+    config_args = [
+        "--domain",
+        domain,
+        "--subdomain",
+        subdomain,
+        "--letsencrypt-email",
+        bot_email,
+        "--oauth-app-client-id",
+        client_id,
+        "--oauth-app-client-secret",
+        client_secret,
+    ]
+
+    print(f"\nRunning jd config on {project_dir}...", flush=True)
+    run_jd_config(config_args, project_dir)
+
+    print(f"\nBase project configured at {project_dir}")
+    print(f"  URL: https://{subdomain}.{domain}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/env_setup_base.py
+++ b/scripts/env_setup_base.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
-"""Generate .env for base template E2E tests from a deployed project and CI infrastructure.
+"""Generate .env for base template E2E tests.
 
-Reads deployment variables from the base project via `jd show -v`,
-fetches OAuth credentials from CI infrastructure (SSM/Secrets Manager),
-and merges user-supplied options. Options override project-derived values.
+Two modes:
+  1. Existing project: reads deployment variables from the project via `jd show -v`
+  2. Fresh deploy: infers domain/subdomain/email from CI OAuth app metadata and bot account
+
+In both modes, OAuth credentials are fetched from CI infrastructure (SSM/Secrets Manager).
 
 Usage: scripts/env_setup_base.py <project-dir> <ci-dir> <oauth-app-num> [options]
 
-Options are comma-separated key=value pairs (same format as `just test-e2e`).
+Pass an empty string for <project-dir> to use fresh-deploy mode. In this mode, domain,
+subdomain, and email are derived from the OAuth app's homepage_url and the bot account
+email. Access control defaults to: allowed_org="", allowed_teams=[], allowed_usernames=[<bot>].
 
 Examples:
+  # From existing project:
   scripts/env_setup_base.py sandbox-e2e sandbox-ci 4
   scripts/env_setup_base.py sandbox-e2e sandbox-ci 4 user=botuser,safe-user=realuser
-  scripts/env_setup_base.py sandbox-e2e sandbox-ci 4 allowed-usernames=[],allowed-org=my-org
+
+  # Fresh deploy (no project):
+  scripts/env_setup_base.py "" sandbox-ci 4
+  scripts/env_setup_base.py "" sandbox-ci 4 user=botuser,safe-user=realuser
 """
 
 from __future__ import annotations
@@ -23,6 +31,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 from ci_helpers import fetch_value, jd_output
 
@@ -44,7 +53,10 @@ PROJECT_VAR_MAP = {
 # These are user-supplied values passed as key=value arguments
 # Options can override both project-derived and test-only variables
 OPTION_MAP = {
-    # Override project-derived access control variables
+    # Deployment variables (required in fresh-deploy mode, override in existing-project mode)
+    "domain": "JD_E2E_VAR_DOMAIN",
+    "subdomain": "JD_E2E_VAR_SUBDOMAIN",
+    "email": "JD_E2E_VAR_EMAIL",
     "allowed-usernames": "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES",
     "allowed-org": "JD_E2E_VAR_OAUTH_ALLOWED_ORG",
     "allowed-teams": "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
@@ -114,6 +126,47 @@ def jd_variable(var_name: str, project_dir: str) -> str:
     return normalize_list_value(result.stdout.strip())
 
 
+def infer_deployment_vars(ci_dir: str, oauth_app_num: str) -> dict[str, str]:
+    """Infer deployment variables from CI OAuth app metadata and bot account."""
+    # Read OAuth app metadata to get homepage_url → domain/subdomain
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-v", f"github_oauth_app_{oauth_app_num}", "--text", "-p", ci_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    app_meta = ast.literal_eval(result.stdout.strip())
+    homepage_url = app_meta["homepage_url"]
+
+    parsed = urlparse(homepage_url)
+    hostname = parsed.hostname or ""
+    parts = hostname.split(".", 1)
+    if len(parts) != 2:
+        print(f"Error: Cannot extract subdomain.domain from homepage_url: {homepage_url}")
+        sys.exit(1)
+    subdomain = parts[0]
+    domain = parts[1]
+
+    # Read bot email
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "-p", ci_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    bot_email = result.stdout.strip()
+    bot_username = bot_email.split("@")[0] if "@" in bot_email else bot_email
+
+    return {
+        "JD_E2E_VAR_DOMAIN": domain,
+        "JD_E2E_VAR_SUBDOMAIN": subdomain,
+        "JD_E2E_VAR_EMAIL": bot_email,
+        "JD_E2E_VAR_OAUTH_ALLOWED_ORG": "",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS": "[]",
+        "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES": json.dumps([bot_username]),
+    }
+
+
 def set_env_var(key: str, value: str) -> None:
     """Update or append a key=value pair in the .env file."""
     if ENV_FILE.exists():
@@ -171,15 +224,38 @@ def main() -> None:
     # Collect env vars that will be overridden by options (to skip project reads)
     option_env_vars = {OPTION_MAP[k] for k in parsed_options}
 
-    # 1. Read deployment variables from the base project
-    print(f"Reading deployment variables from {project_dir}...")
-    for jd_var, env_var in PROJECT_VAR_MAP.items():
-        if env_var in option_env_vars:
-            print(f"  {env_var} — skipped (overridden by option)")
-            continue
-        value = jd_variable(jd_var, project_dir)
-        set_env_var(env_var, value)
-        print(f"  {env_var}={value}")
+    # 1. Read deployment variables from the base project, or infer from CI
+    if project_dir:
+        print(f"Reading deployment variables from {project_dir}...")
+        for jd_var, env_var in PROJECT_VAR_MAP.items():
+            if env_var in option_env_vars:
+                print(f"  {env_var} — skipped (overridden by option)")
+                continue
+            value = jd_variable(jd_var, project_dir)
+            set_env_var(env_var, value)
+            print(f"  {env_var}={value}")
+    else:
+        print(f"Fresh-deploy mode — inferring deployment variables from CI ({ci_dir})...")
+        inferred = infer_deployment_vars(ci_dir, oauth_app_num)
+        for env_var, value in inferred.items():
+            if env_var in option_env_vars:
+                print(f"  {env_var} — skipped (overridden by option)")
+                continue
+            set_env_var(env_var, value)
+            print(f"  {env_var}={value}")
+
+    # 1b. Set bot username as JD_E2E_USER (unless overridden by option)
+    if "JD_E2E_USER" not in option_env_vars:
+        result = subprocess.run(
+            ["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "-p", ci_dir],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        bot_email = result.stdout.strip()
+        bot_username = bot_email.split("@")[0] if "@" in bot_email else bot_email
+        set_env_var("JD_E2E_USER", bot_username)
+        print(f"  JD_E2E_USER={bot_username} (from bot account)")
 
     # 2. Fetch OAuth credentials from CI infrastructure
     print(f"\nFetching OAuth app #{oauth_app_num} credentials from CI ({ci_dir})...")


### PR DESCRIPTION
This PR adds handling for 2fa login in the pytest plugin, so that E2E tests can run the authentication tests as a GitHub bot whose account has 2fa enabled.

Follows from #181 which added the ability to generate a 1-time password from a locally restored CI project.

### User experience
1. restore the ci project of the account: `just ci-restore`
2. retrieve bot authentication information with:
    2.1. `just auth-bot-email`
    2.2. `just auth-bot-username`
    2.3. `just-auth-bot-password`
    2.4. `just auth-bot-2fa`
3. init the base template project (from scratch): `just init-base <PROJECT>`
4. configure it from `ci-project`: `just config-base <PROJECT>`
5. get the bot username: `BOT_USER=$(just auth-bot-username sandbox-ci)`
6. set the `.env` needed for tests: `just env-setup-base sandbox-base sandbox-ci 1 user=$BOT_USER `; where `1` refers to oauth app 1.
7. `just test-e2e-base sandbox-base<TEST-SELECTOR> ci-dir=sandbox-ci`

### Implementation
1. update `<plugin>/oauth2_proxy/github:GitHubOAuth2ProxyApplication` class to support login via 2fa by
    1.1. inputing the username, password on `playwright`; click `Submit`
    1.2. then generate a 2fa using the utility and the `ci-project`
    1.3. input it; login
    1.4. save the webbrowser context
2. update `<plugin>/plugin` to accept a `--ci` flag and use 2fa from ci in this case (instead of relying on the browser context captured by `just setup-auth`)
3. add `just` methods to retrieve the bot username, init & config w/ `ci` project, 

### Testing
1. configure and deploy a `base` template in the CI account
2. delete the `.auth` dir
3. ran `test_application` E2E test, ensure it automatically logs on w/ 2fa
4. ran a few more E2E tests: `test_user` and `test_org_and_teams` in particular to ensure correct setup