### PR TITLE
test: PR-attachable e2e tests workflow

### DIFF
--- a/.github/workflows/e2e-base-job.yml
+++ b/.github/workflows/e2e-base-job.yml
@@ -66,16 +66,16 @@ jobs:
         run: just ci-restore sandbox-ci
 
       - name: Restore base project by subdomain
-        run: just ci-restore-base ${{ inputs.oauth-app-num }} sandbox-ci e2e-base
+        run: just ci-restore-base ${{ inputs.oauth-app-num }} sandbox-ci sandbox-e2e
 
       - name: Generate .env
-        run: just env-setup-base e2e-base sandbox-ci ${{ inputs.oauth-app-num }}
+        run: just env-setup-base sandbox-e2e sandbox-ci ${{ inputs.oauth-app-num }}
 
       - name: Import auth state
         run: just auth-import sandbox-ci
 
       - name: Ensure host is running
-        run: just ensure-host-running e2e-base
+        run: just ensure-host-running sandbox-e2e
 
       - name: Build test filter
         id: filter
@@ -103,7 +103,7 @@ jobs:
           echo "options=${OPTIONS}" >> "$GITHUB_OUTPUT"
 
       - name: Run E2E tests
-        run: just test-e2e-base e2e-base "${{ steps.filter.outputs.filter }}" "${{ steps.filter.outputs.options }}"
+        run: just test-e2e-base sandbox-e2e "${{ steps.filter.outputs.filter }}" "${{ steps.filter.outputs.options }}"
 
       - name: Export auth state
         if: always()

--- a/.github/workflows/e2e-base-job.yml
+++ b/.github/workflows/e2e-base-job.yml
@@ -1,0 +1,118 @@
+name: E2E base template job
+
+on:
+  workflow_call:
+    inputs:
+      oauth-app-num:
+        description: "OAuth app number (1-3)"
+        required: true
+        type: string
+      test-filter:
+        description: "Pytest -k filter (combined with per-job filter)"
+        required: false
+        type: string
+        default: ""
+      test-file-filter:
+        description: "Per-job test file filter (e.g. test_external_volumes)"
+        required: false
+        type: string
+        default: ""
+      mutate:
+        description: "Enable mutating test cases"
+        required: false
+        type: boolean
+        default: false
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: false
+        type: number
+        default: 30
+
+jobs:
+  test:
+    name: Run E2E tests
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.5"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          # To get this value: uv run jd show -o e2e_iam_role_arn --text -p sandbox-ci
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Restore base project by subdomain
+        run: just ci-restore-base ${{ inputs.oauth-app-num }} sandbox-ci e2e-base
+
+      - name: Generate .env
+        run: just env-setup-base e2e-base sandbox-ci ${{ inputs.oauth-app-num }}
+
+      - name: Import auth state
+        run: just auth-import sandbox-ci
+
+      - name: Ensure host is running
+        run: just ensure-host-running e2e-base
+
+      - name: Build test filter
+        id: filter
+        run: |
+          FILTER=""
+          # Per-job file filter
+          if [ -n "${{ inputs.test-file-filter }}" ]; then
+            FILTER="${{ inputs.test-file-filter }}"
+          fi
+          # User-provided -k filter
+          if [ -n "${{ inputs.test-filter }}" ]; then
+            if [ -n "$FILTER" ]; then
+              FILTER="${FILTER} and ${{ inputs.test-filter }}"
+            else
+              FILTER="${{ inputs.test-filter }}"
+            fi
+          fi
+          echo "filter=${FILTER}" >> "$GITHUB_OUTPUT"
+
+          # Build options
+          OPTIONS="ci-dir=sandbox-ci"
+          if [ "${{ inputs.mutate }}" = "true" ]; then
+            OPTIONS="mutate=true,${OPTIONS}"
+          fi
+          echo "options=${OPTIONS}" >> "$GITHUB_OUTPUT"
+
+      - name: Run E2E tests
+        run: just test-e2e-base e2e-base "${{ steps.filter.outputs.filter }}" "${{ steps.filter.outputs.options }}"
+
+      - name: Export auth state
+        if: always()
+        run: just auth-export sandbox-ci
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ inputs.test-file-filter || 'non-mutating' }}
+          path: test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/pr-e2e-base.yml
+++ b/.github/workflows/pr-e2e-base.yml
@@ -1,0 +1,133 @@
+name: E2E base template
+
+on:
+  workflow_dispatch:
+    inputs:
+      oauth-app-num:
+        description: "OAuth app number (1-3) — determines subdomain"
+        required: false
+        type: choice
+        options: ["1", "2", "3"]
+        default: "1"
+      test-filter:
+        description: "Pytest -k filter (applied to all jobs, empty = all tests)"
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: e2e-base
+  cancel-in-progress: false
+
+jobs:
+  test-non-mutating:
+    name: "Non-mutating tests"
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      timeout-minutes: 120
+
+  test-external-volumes:
+    name: "Mutating: external volumes"
+    needs: test-non-mutating
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_external_volumes
+      mutate: true
+      timeout-minutes: 30
+
+  test-config-apply:
+    name: "Mutating: config apply"
+    needs: test-external-volumes
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_config_apply
+      mutate: true
+      timeout-minutes: 30
+
+  test-gpu:
+    name: "Mutating: GPU"
+    needs: test-config-apply
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_gpu
+      mutate: true
+      timeout-minutes: 60
+
+  test-pixi:
+    name: "Mutating: pixi"
+    needs: test-gpu
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_pixi
+      mutate: true
+      timeout-minutes: 60
+
+  test-uv:
+    name: "Mutating: uv"
+    needs: test-pixi
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_uv
+      mutate: true
+      timeout-minutes: 60
+
+  cleanup:
+    name: "Cleanup: stop host"
+    needs:
+      - test-non-mutating
+      - test-external-volumes
+      - test-config-apply
+      - test-gpu
+      - test-pixi
+      - test-uv
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.5"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Restore base project
+        run: just ci-restore-base ${{ inputs.oauth-app-num }} sandbox-ci e2e-base
+
+      - name: Stop host
+        run: just ensure-host-stopped e2e-base

--- a/.github/workflows/pr-e2e-base.yml
+++ b/.github/workflows/pr-e2e-base.yml
@@ -16,7 +16,7 @@ on:
         default: ""
 
 concurrency:
-  group: e2e-base
+  group: e2e-${{ inputs.oauth-app-num }}
   cancel-in-progress: false
 
 jobs:
@@ -127,7 +127,7 @@ jobs:
         run: just ci-restore sandbox-ci
 
       - name: Restore base project
-        run: just ci-restore-base ${{ inputs.oauth-app-num }} sandbox-ci e2e-base
+        run: just ci-restore-base ${{ inputs.oauth-app-num }} sandbox-ci sandbox-e2e
 
       - name: Stop host
-        run: just ensure-host-stopped e2e-base
+        run: just ensure-host-stopped sandbox-e2e

--- a/justfile
+++ b/justfile
@@ -553,9 +553,41 @@ config-base-from-ci project_dir ci_dir="sandbox-ci" oauth_app_num="1" allowed_us
 
 # --- CI infrastructure commands ---
 
+# Ensure the host is running (start if stopped)
+# Usage: just ensure-host-running <project-dir>
+ensure-host-running project_dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    STATUS=$(uv run jd host status -p {{project_dir}} 2>&1 || true)
+    echo "$STATUS"
+    if echo "$STATUS" | grep -q "running"; then
+        echo "Host is already running."
+    else
+        echo "Host is not running, starting..."
+        uv run jd host start -p {{project_dir}}
+    fi
+
+# Ensure the host is stopped (stop if running)
+# Usage: just ensure-host-stopped <project-dir>
+ensure-host-stopped project_dir:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    STATUS=$(uv run jd host status -p {{project_dir}} 2>&1 || true)
+    echo "$STATUS"
+    if echo "$STATUS" | grep -q "running"; then
+        uv run jd host stop -p {{project_dir}}
+    else
+        echo "Host is not running, skipping stop."
+    fi
+
 # Discover and restore CI project from S3 store
 ci-restore ci_dir="sandbox-ci":
     uv run python scripts/ci_restore.py {{ci_dir}}
+
+# Find and restore a base template project from S3 by OAuth app subdomain
+# Usage: just ci-restore-base <oauth-app-num> [ci-dir] [project-dir]
+ci-restore-base oauth_app_num ci_dir="sandbox-ci" project_dir="sandbox-base":
+    uv run python scripts/ci_restore_base.py {{ci_dir}} {{oauth_app_num}} {{project_dir}}
 
 # Export local auth state to Secrets Manager
 auth-export ci_dir="sandbox-ci":

--- a/scripts/ci_restore_base.py
+++ b/scripts/ci_restore_base.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Find and restore a base template project from S3 by matching the subdomain
+derived from a CI OAuth app.
+
+Usage: scripts/ci_restore_base.py <ci-dir> <oauth-app-num> [project-dir]
+
+The script:
+1. Reads OAuth app metadata from the CI project to extract the expected subdomain
+2. Lists all projects in the S3 store
+3. Finds the one whose var:subdomain matches
+4. Restores it via jd init --restore-project
+5. Re-populates the OAuth client secret via jd config
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+
+from ci_helpers import fetch_value, jd_output, run_jd_config
+
+
+def get_subdomain_from_ci(ci_dir: str, oauth_app_num: str) -> str:
+    """Read the expected subdomain from the CI OAuth app's homepage_url."""
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-v", f"github_oauth_app_{oauth_app_num}", "--text", "-p", ci_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    app_meta = ast.literal_eval(result.stdout.strip())
+    homepage_url = app_meta["homepage_url"]
+    parsed = urlparse(homepage_url)
+    hostname = parsed.hostname or ""
+    parts = hostname.split(".", 1)
+    if len(parts) != 2:
+        print(f"Error: Cannot extract subdomain from homepage_url: {homepage_url}")
+        sys.exit(1)
+    return parts[0]
+
+
+def list_project_ids() -> list[str]:
+    """List all project IDs in the S3 store."""
+    result = subprocess.run(
+        ["uv", "run", "jd", "projects", "list", "--store-type", "s3-only", "--text"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
+
+
+def get_project_subdomain(project_id: str) -> str | None:
+    """Read the var:subdomain from a project's S3 metadata."""
+    result = subprocess.run(
+        ["uv", "run", "jd", "projects", "show", project_id, "--store-type", "s3-only", "--text"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    for line in result.stdout.splitlines():
+        m = re.match(r"^var:subdomain:\s*(.+)$", line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def find_project_by_subdomain(subdomain: str) -> str:
+    """Find the project ID whose subdomain matches."""
+    project_ids = list_project_ids()
+    # Only check base template projects
+    base_projects = [pid for pid in project_ids if pid.startswith("tf-aws-ec2-base-")]
+
+    if not base_projects:
+        print("Error: No base template projects found in S3 store")
+        sys.exit(1)
+
+    for project_id in base_projects:
+        project_subdomain = get_project_subdomain(project_id)
+        if project_subdomain == subdomain:
+            return project_id
+
+    print(f"Error: No base template project found with subdomain '{subdomain}'")
+    print(f"Checked projects: {base_projects}")
+    sys.exit(1)
+
+
+def restore_project(project_id: str, project_dir: Path) -> None:
+    """Restore a project from S3 store."""
+    if project_dir.exists():
+        shutil.rmtree(project_dir)
+
+    print(f"Restoring project to {project_dir}...")
+    subprocess.run(
+        ["uv", "run", "jd", "init", str(project_dir), "--restore-project", project_id, "--store-type", "s3-only"],
+        check=True,
+    )
+
+
+def reconfigure_secret(ci_dir: str, oauth_app_num: str, project_dir: Path) -> None:
+    """Re-populate the OAuth client secret from CI secrets (masked after restore)."""
+    client_secret_arn = jd_output(f"github_oauth_app_client_secret_{oauth_app_num}_arn", ci_dir)
+    client_secret = fetch_value(client_secret_arn)
+    print("  Fetched OAuth client secret from CI")
+    run_jd_config(["--oauth-app-client-secret", client_secret], str(project_dir))
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print("Usage: scripts/ci_restore_base.py <ci-dir> <oauth-app-num> [project-dir]")
+        print()
+        print("  ci-dir:        Path to the CI infrastructure project (from just ci-restore)")
+        print("  oauth-app-num: OAuth app number (1-5) — determines subdomain to match")
+        print("  project-dir:   Directory to restore into (default: e2e-base)")
+        sys.exit(1)
+
+    ci_dir = sys.argv[1]
+    oauth_app_num = sys.argv[2]
+    project_dir = Path(sys.argv[3]) if len(sys.argv) > 3 else Path("e2e-base")
+
+    if oauth_app_num not in ("1", "2", "3", "4", "5"):
+        print(f"Error: OAuth app number must be 1-5, got: {oauth_app_num}")
+        sys.exit(1)
+
+    print(f"Looking up subdomain for OAuth app #{oauth_app_num}...")
+    subdomain = get_subdomain_from_ci(ci_dir, oauth_app_num)
+    print(f"  Expected subdomain: {subdomain}")
+
+    print("Searching for matching project in S3 store...")
+    project_id = find_project_by_subdomain(subdomain)
+    print(f"  Found project: {project_id}")
+
+    restore_project(project_id, project_dir)
+
+    print()
+    print("Re-populating OAuth client secret from CI...")
+    reconfigure_secret(ci_dir, oauth_app_num, project_dir)
+
+    print(f"\nBase project restored at {project_dir} (subdomain: {subdomain})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR creates the GitHub workflow to run E2E tests against a PR branch, first re-using an existing base template deployment in the account.

### Maintainer experience
- expose an action to run E2E tests against any branch, therefore attachable to a PR

### Implementation
The workflow:
- restores the account `ci` project to `sandbox-ci` from the store
- restores the base project to `sandbox-e2e` from the store, w/ a lookup on the subdomain
- runs the E2E tests sequentially as separate, individually restartable jobs
- exports the auth context to the `ci` secret
- stops the host at the end 

### Testing
- tested the `just` method locally
- need to merge to `main` to test the actual workflow against subsequent branches