### PR TITLE
feat: fresh app workflow

### DIFF
--- a/.github/workflows/e2e-base-job.yml
+++ b/.github/workflows/e2e-base-job.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: number
         default: 30
+      ref:
+        description: "Git ref to checkout (default: triggering ref)"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   test:
@@ -40,6 +45,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install UV and Python
         uses: ./.github/actions/install-uv

--- a/.github/workflows/pr-e2e-base-fresh.yml
+++ b/.github/workflows/pr-e2e-base-fresh.yml
@@ -19,6 +19,11 @@ on:
         required: false
         type: boolean
         default: false
+      ref:
+        description: "Git ref to checkout (e.g. refs/pull/185/merge for a fork PR)"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: e2e-${{ inputs.oauth-app-num }}
@@ -39,6 +44,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install UV and Python
         uses: ./.github/actions/install-uv
@@ -79,6 +86,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install UV and Python
         uses: ./.github/actions/install-uv
@@ -150,18 +159,22 @@ jobs:
     name: "Non-mutating tests"
     needs: deploy-gate
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       timeout-minutes: 120
 
   test-external-volumes:
     name: "Mutating: external volumes"
     needs: test-non-mutating
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_external_volumes
       mutate: true
       timeout-minutes: 30
@@ -170,9 +183,11 @@ jobs:
     name: "Mutating: config apply"
     needs: test-external-volumes
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_config_apply
       mutate: true
       timeout-minutes: 30
@@ -181,9 +196,11 @@ jobs:
     name: "Mutating: GPU"
     needs: test-config-apply
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_gpu
       mutate: true
       timeout-minutes: 60
@@ -192,9 +209,11 @@ jobs:
     name: "Mutating: pixi"
     needs: test-gpu
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_pixi
       mutate: true
       timeout-minutes: 60
@@ -203,9 +222,11 @@ jobs:
     name: "Mutating: uv"
     needs: test-pixi
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_uv
       mutate: true
       timeout-minutes: 60
@@ -231,6 +252,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install UV and Python
         uses: ./.github/actions/install-uv

--- a/.github/workflows/pr-e2e-base-fresh.yml
+++ b/.github/workflows/pr-e2e-base-fresh.yml
@@ -1,0 +1,262 @@
+name: E2E base template (fresh deploy)
+
+on:
+  workflow_dispatch:
+    inputs:
+      oauth-app-num:
+        description: "OAuth app number (1-3) — determines subdomain"
+        required: false
+        type: choice
+        options: ["1", "2", "3"]
+        default: "1"
+      test-filter:
+        description: "Pytest -k filter (applied to all jobs, empty = all tests)"
+        required: false
+        type: string
+        default: ""
+      skip-deployment:
+        description: "Skip cleanup + deploy, run tests only (project must already be in S3)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: e2e-${{ inputs.oauth-app-num }}
+  cancel-in-progress: false
+
+jobs:
+  # --- Deploy bookend ---
+
+  cleanup-existing:
+    name: "Cleanup existing deployment"
+    if: ${{ !inputs.skip-deployment }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.5"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Find and take down previous deployment
+        run: just find-takedown-base ${{ inputs.oauth-app-num }} sandbox-ci sandbox-e2e
+
+  deploy:
+    name: "Deploy from scratch"
+    needs: cleanup-existing
+    if: ${{ !inputs.skip-deployment }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.5"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Generate .env (fresh deploy mode)
+        run: just env-setup-base "" sandbox-ci ${{ inputs.oauth-app-num }}
+
+      - name: Import auth state
+        run: just auth-import sandbox-ci
+
+      - name: Deploy and verify
+        run: just test-e2e-base sandbox-e2e "test_deployment" "mutate=true,ci-dir=sandbox-ci"
+
+      - name: Export auth state
+        if: always()
+        run: just auth-export sandbox-ci
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-deploy
+          path: test-results/
+          if-no-files-found: ignore
+
+  # --- Gate: allows test chain to start when deploy succeeded or was skipped ---
+
+  deploy-gate:
+    name: "Deploy gate"
+    needs: [cleanup-existing, deploy]
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Check deploy result
+        run: |
+          if [ "${{ inputs.skip-deployment }}" = "true" ]; then
+            echo "Deployment skipped — proceeding to tests"
+          elif [ "${{ needs.deploy.result }}" = "success" ]; then
+            echo "Deployment succeeded — proceeding to tests"
+          else
+            echo "Deployment failed or was cancelled — aborting test chain"
+            exit 1
+          fi
+
+  # --- Test chain (same as pr-e2e-base.yml) ---
+
+  test-non-mutating:
+    name: "Non-mutating tests"
+    needs: deploy-gate
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      timeout-minutes: 120
+
+  test-external-volumes:
+    name: "Mutating: external volumes"
+    needs: test-non-mutating
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_external_volumes
+      mutate: true
+      timeout-minutes: 30
+
+  test-config-apply:
+    name: "Mutating: config apply"
+    needs: test-external-volumes
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_config_apply
+      mutate: true
+      timeout-minutes: 30
+
+  test-gpu:
+    name: "Mutating: GPU"
+    needs: test-config-apply
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_gpu
+      mutate: true
+      timeout-minutes: 60
+
+  test-pixi:
+    name: "Mutating: pixi"
+    needs: test-gpu
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_pixi
+      mutate: true
+      timeout-minutes: 60
+
+  test-uv:
+    name: "Mutating: uv"
+    needs: test-pixi
+    uses: ./.github/workflows/e2e-base-job.yml
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      test-filter: ${{ inputs.test-filter }}
+      test-file-filter: test_uv
+      mutate: true
+      timeout-minutes: 60
+
+  # --- Cleanup: stop host (deployment stays in S3 for auditability) ---
+
+  cleanup:
+    name: "Cleanup: stop host"
+    needs:
+      - test-non-mutating
+      - test-external-volumes
+      - test-config-apply
+      - test-gpu
+      - test-pixi
+      - test-uv
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.5"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Restore base project
+        run: just ci-restore-base ${{ inputs.oauth-app-num }} sandbox-ci sandbox-e2e
+
+      - name: Stop host
+        run: just ensure-host-stopped sandbox-e2e

--- a/.github/workflows/pr-e2e-base.yml
+++ b/.github/workflows/pr-e2e-base.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ""
+      ref:
+        description: "Git ref to checkout (e.g. refs/pull/185/merge for a fork PR)"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: e2e-${{ inputs.oauth-app-num }}
@@ -23,18 +28,22 @@ jobs:
   test-non-mutating:
     name: "Non-mutating tests"
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       timeout-minutes: 120
 
   test-external-volumes:
     name: "Mutating: external volumes"
     needs: test-non-mutating
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_external_volumes
       mutate: true
       timeout-minutes: 30
@@ -43,9 +52,11 @@ jobs:
     name: "Mutating: config apply"
     needs: test-external-volumes
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_config_apply
       mutate: true
       timeout-minutes: 30
@@ -54,9 +65,11 @@ jobs:
     name: "Mutating: GPU"
     needs: test-config-apply
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_gpu
       mutate: true
       timeout-minutes: 60
@@ -65,9 +78,11 @@ jobs:
     name: "Mutating: pixi"
     needs: test-gpu
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_pixi
       mutate: true
       timeout-minutes: 60
@@ -76,9 +91,11 @@ jobs:
     name: "Mutating: uv"
     needs: test-pixi
     uses: ./.github/workflows/e2e-base-job.yml
+    secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
+      ref: ${{ inputs.ref }}
       test-file-filter: test_uv
       mutate: true
       timeout-minutes: 60
@@ -102,6 +119,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install UV and Python
         uses: ./.github/actions/install-uv

--- a/justfile
+++ b/justfile
@@ -589,6 +589,12 @@ ci-restore ci_dir="sandbox-ci":
 ci-restore-base oauth_app_num ci_dir="sandbox-ci" project_dir="sandbox-base":
     uv run python scripts/ci_restore_base.py {{ci_dir}} {{oauth_app_num}} {{project_dir}}
 
+# Find a base template project by subdomain, take it down (jd down), and delete from S3 store
+# Exits successfully if no matching project is found (nothing to take down)
+# Usage: just find-takedown-base <oauth-app-num> [ci-dir] [project-dir]
+find-takedown-base oauth_app_num ci_dir="sandbox-ci" project_dir="sandbox-e2e":
+    uv run python scripts/find_takedown_base.py {{ci_dir}} {{oauth_app_num}} {{project_dir}}
+
 # Export local auth state to Secrets Manager
 auth-export ci_dir="sandbox-ci":
     uv run python scripts/sync_auth_state.py export {{ci_dir}}

--- a/scripts/ci_restore_base.py
+++ b/scripts/ci_restore_base.py
@@ -70,13 +70,19 @@ def get_project_subdomain(project_id: str) -> str | None:
     return None
 
 
-def find_project_by_subdomain(subdomain: str) -> str:
-    """Find the project ID whose subdomain matches."""
+def find_project_by_subdomain(subdomain: str, *, allow_missing: bool = False) -> str | None:
+    """Find the project ID whose subdomain matches.
+
+    Returns the project ID, or None if allow_missing is True and no match is found.
+    Exits with an error if allow_missing is False and no match is found.
+    """
     project_ids = list_project_ids()
     # Only check base template projects
     base_projects = [pid for pid in project_ids if pid.startswith("tf-aws-ec2-base-")]
 
     if not base_projects:
+        if allow_missing:
+            return None
         print("Error: No base template projects found in S3 store")
         sys.exit(1)
 
@@ -85,6 +91,8 @@ def find_project_by_subdomain(subdomain: str) -> str:
         if project_subdomain == subdomain:
             return project_id
 
+    if allow_missing:
+        return None
     print(f"Error: No base template project found with subdomain '{subdomain}'")
     print(f"Checked projects: {base_projects}")
     sys.exit(1)
@@ -133,6 +141,7 @@ def main() -> None:
 
     print("Searching for matching project in S3 store...")
     project_id = find_project_by_subdomain(subdomain)
+    assert project_id is not None  # allow_missing=False guarantees this
     print(f"  Found project: {project_id}")
 
     restore_project(project_id, project_dir)

--- a/scripts/find_takedown_base.py
+++ b/scripts/find_takedown_base.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Find a base template project in S3 by subdomain, take it down, and delete it.
+
+Looks up the subdomain from the CI OAuth app, finds the matching base template
+project in the S3 store, restores it locally, runs `jd down -y`, and deletes
+the project from the store.
+
+Exits 0 if no matching project is found (nothing to take down).
+
+Usage: scripts/find_takedown_base.py <ci-dir> <oauth-app-num> [project-dir]
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from ci_restore_base import (
+    find_project_by_subdomain,
+    get_subdomain_from_ci,
+    reconfigure_secret,
+    restore_project,
+)
+
+
+def takedown_project(project_dir: Path) -> None:
+    """Run jd down -y to destroy the deployment."""
+    print(f"Taking down deployment in {project_dir}...")
+    subprocess.run(
+        ["uv", "run", "jd", "down", "-y", "-p", str(project_dir)],
+        check=True,
+    )
+
+
+def delete_project_from_store(project_id: str) -> None:
+    """Delete a project from the S3 store."""
+    print(f"Deleting project {project_id} from S3 store...")
+    subprocess.run(
+        ["uv", "run", "jd", "projects", "delete", project_id, "--store-type", "s3-only", "-y"],
+        check=True,
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print("Usage: scripts/find_takedown_base.py <ci-dir> <oauth-app-num> [project-dir]")
+        print()
+        print("  ci-dir:        Path to the CI infrastructure project (from just ci-restore)")
+        print("  oauth-app-num: OAuth app number (1-5) — determines subdomain to match")
+        print("  project-dir:   Directory to restore into for takedown (default: e2e-base)")
+        sys.exit(1)
+
+    ci_dir = sys.argv[1]
+    oauth_app_num = sys.argv[2]
+    project_dir = Path(sys.argv[3]) if len(sys.argv) > 3 else Path("e2e-base")
+
+    if oauth_app_num not in ("1", "2", "3", "4", "5"):
+        print(f"Error: OAuth app number must be 1-5, got: {oauth_app_num}")
+        sys.exit(1)
+
+    print(f"Looking up subdomain for OAuth app #{oauth_app_num}...")
+    subdomain = get_subdomain_from_ci(ci_dir, oauth_app_num)
+    print(f"  Expected subdomain: {subdomain}")
+
+    print("Searching for matching project in S3 store...")
+    project_id = find_project_by_subdomain(subdomain, allow_missing=True)
+    if project_id is None:
+        print(f"  No base template project found with subdomain '{subdomain}' — nothing to take down.")
+        return
+
+    print(f"  Found project: {project_id}")
+
+    restore_project(project_id, project_dir)
+
+    print("\nRe-populating OAuth client secret from CI...")
+    reconfigure_secret(ci_dir, oauth_app_num, project_dir)
+
+    takedown_project(project_dir)
+    delete_project_from_store(project_id)
+
+    print(f"\nProject {project_id} taken down and deleted (subdomain: {subdomain})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a second GitHub workflow which tests against a fresh deployment of the base template.

We'll use it for a/ PR (to test a fresh deployment), b/ releases, c/ canary.

### Maintainer experience
- start the workflow against a PR branch
- `just find-takedown-base <oauth-app-number> <ci-dir> <project-dir>` -> looks up a base project in the store by subdomain lookup, restores it, rusn `jd down`, removes it from the store

### Implementation
- add a `pr-e2e-base-fresh` GitHub workflow, which:
    - restore and teardown the deployment (if exists)
    - generate the `.env` from ci
    - run the `test_deployment` E2E test which deploys the project from scratch using `.env`
    - run all the other E2E tests in separate jobs (sequentially)
    - stop the host at the end

### Testing
- tested `just find-takedown-base` against existing deployment in test account --> worked as expected
- created a canary app w/ `just setup-env-base sandbox-ci 3` and then `just test-e2e-base sandbox-e2e test_deployment mutate=true,ci_dir=sandbox-ci` --> successfully deployed and passed the test
- stopped the canary app w/ `just ensure-host-stopped` --> worked as expected

### Next step
- run the CI workflow against app 1 (existing but stopped)