### PR TITLE
fix: e2e workflows

### DIFF
--- a/.github/workflows/pr-e2e-base-fresh.yml
+++ b/.github/workflows/pr-e2e-base-fresh.yml
@@ -25,6 +25,10 @@ on:
         type: string
         default: ""
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: e2e-${{ inputs.oauth-app-num }}
   cancel-in-progress: false

--- a/.github/workflows/pr-e2e-base.yml
+++ b/.github/workflows/pr-e2e-base.yml
@@ -20,6 +20,10 @@ on:
         type: string
         default: ""
 
+permissions:
+  id-token: write
+  contents: read
+
 concurrency:
   group: e2e-${{ inputs.oauth-app-num }}
   cancel-in-progress: false

--- a/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
@@ -89,7 +89,10 @@ docstring-code-format = true
 docstring-code-line-length = 40
 
 [tool.pytest.ini_options]
-addopts = "--cov=jupyter_deploy_tf_aws_ec2_base --cov-report=term-missing --cov-report=xml --cov-report=html --browser firefox"
+# Do NOT add --browser here — the justfile passes it for E2E runs, and
+# duplicating it causes pytest-playwright to parametrize every test twice
+# ([firefox0] + [firefox1]), doubling execution time.
+addopts = "--cov=jupyter_deploy_tf_aws_ec2_base --cov-report=term-missing --cov-report=xml --cov-report=html"
 testpaths = [
     "tests/unit",
 ]

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/secrets_policy.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/secrets_policy.tf
@@ -77,7 +77,6 @@ resource "aws_secretsmanager_secret_policy" "bot_auth_restricted" {
           "secretsmanager:PutSecretValue",
           "secretsmanager:UpdateSecret",
           "secretsmanager:DeleteSecret",
-          "secretsmanager:ListSecretVersionIds",
           "secretsmanager:RestoreSecret",
           "secretsmanager:TagResource",
           "secretsmanager:UntagResource",
@@ -97,7 +96,10 @@ resource "aws_secretsmanager_secret_policy" "bot_auth_restricted" {
   })
 }
 
-# Bot protected secrets (recovery codes): deny all access to everyone except maintainers
+# Bot protected secrets (recovery codes): deny secret value and writes to
+# everyone except maintainers. DescribeSecret and ListSecretVersionIds are not
+# denied — CI roles need DescribeSecret for Terraform state refresh during
+# jd config, and ListSecretVersionIds is read-only metadata.
 resource "aws_secretsmanager_secret_policy" "bot_protected_restricted" {
   for_each   = local.bot_account_protected_secret_arns_map
   secret_arn = each.value
@@ -106,20 +108,30 @@ resource "aws_secretsmanager_secret_policy" "bot_protected_restricted" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid       = "DenyAllExceptMaintainers"
+        Sid       = "DenyReadExceptMaintainers"
         Effect    = "Deny"
         Principal = "*"
-        # Explicit action list instead of secretsmanager:* — deliberately
-        # excludes PutResourcePolicy/DeleteResourcePolicy to avoid locking
-        # out access permanently (policy-edit is denied on GitHub roles via
-        # identity-based policy instead).
         Action = [
           "secretsmanager:GetSecretValue",
+        ]
+        Resource = "*"
+        Condition = {
+          ArnNotLike = {
+            "aws:PrincipalArn" = local.secrets_admin_principal_arns
+          }
+        }
+      },
+      {
+        # Explicit action list — deliberately excludes PutResourcePolicy/DeleteResourcePolicy
+        # (to avoid locking out access permanently; policy-edit is denied on GitHub roles
+        # via identity-based policy).
+        Sid       = "DenyWriteExceptMaintainers"
+        Effect    = "Deny"
+        Principal = "*"
+        Action = [
           "secretsmanager:PutSecretValue",
           "secretsmanager:UpdateSecret",
           "secretsmanager:DeleteSecret",
-          "secretsmanager:DescribeSecret",
-          "secretsmanager:ListSecretVersionIds",
           "secretsmanager:RestoreSecret",
           "secretsmanager:TagResource",
           "secretsmanager:UntagResource",

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/docker-compose.yml
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/docker-compose.yml
@@ -33,7 +33,11 @@ services:
       # broken region instead of falling back to ~/.aws/config. The justfile resolves
       # this from `aws configure get region` and writes it to .env.
       - AWS_REGION=${AWS_REGION}
-      - AWS_PROFILE=${AWS_PROFILE:-default}
+      # Bare passthrough: set in container only if defined on host. Do NOT default
+      # to "default" — boto3 raises ProfileNotFound when AWS_PROFILE is explicitly
+      # set but ~/.aws/config doesn't exist (e.g. CI runners). When unset, boto3
+      # falls back to the default profile gracefully or uses env var credentials.
+      - AWS_PROFILE
       - AWS_CONFIG_FILE=/home/testuser/.aws/config
       - AWS_SHARED_CREDENTIALS_FILE=/home/testuser/.aws/credentials
     network_mode: host

--- a/scripts/ci_restore.py
+++ b/scripts/ci_restore.py
@@ -55,13 +55,19 @@ def fetch_secrets_and_configure(ci_dir: Path) -> None:
     ci_dir_str = str(ci_dir)
     config_args: list[str] = []
 
-    # Fetch bot account secrets
-    for var in ("github_bot_account_password", "github_bot_account_recovery_codes", "github_bot_account_totp_secret"):
+    # Fetch bot account secrets (recovery codes excluded — protected by explicit deny,
+    # and not needed at runtime; only used as break-glass for account recovery)
+    for var in ("github_bot_account_password", "github_bot_account_totp_secret"):
         arn = jd_output(f"{var}_secret_arn", ci_dir_str)
         val = fetch_value(arn)
         flag = f"--{var.replace('_', '-')}"
         config_args.extend([flag, val])
         print(f"  Fetched {var}")
+
+    # Recovery codes: pass masked placeholder — the actual value is protected by
+    # an explicit deny policy and isn't needed for E2E operations
+    config_args.extend(["--github-bot-account-recovery-codes", "****"])
+    print("  Skipped github_bot_account_recovery_codes (protected secret)")
 
     # Fetch OAuth app client secrets
     for i in range(1, 6):


### PR DESCRIPTION
This PR fixes permission and configuration issues on the GitHub workflows for e2e tests:
- bypass fetch secret for bot recovery code in `ci-restore` (the CI job does NOT have permission to read that secret)
- add the `permission` block in workflow files to allow `id-token: write`
- update ci template secret policy to no longer deny innocuous read/list operation (but still deny `GetSecretValue`), which is necessary for `terraform plan` (called in `ci-restore` via `jd config`)

Also in this PR:
- fixed `playwright` misconfiguration that led to running all browser-based E2E tests twice!!

### Testing
- pushed to a tmp branch in the main repo (`fix/e2e-workflows`)
- added a `.github/workflows/test-permission.yml` and pushed to trigger the e2e workflow:
```yaml
name: Test permissions (temporary)

on:
  push:
    branches:
      - fix/e2e-workflows

permissions:
  id-token: write
  contents: read

jobs:
  test-reusable:
    name: "Test reusable workflow permissions"
    uses: ./.github/workflows/e2e-base-job.yml
    secrets: inherit
    with:
      oauth-app-num: "1"
      test-filter: "test_application"
      timeout-minutes: 30
```
- verified that the test passed, see [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/23851543464/job/69532761173)