### PR TITLE
fix: E2E test sequence, webbrowser access in ci

### DIFF
--- a/.github/workflows/e2e-base-job.yml
+++ b/.github/workflows/e2e-base-job.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.5"
+          terraform_version: "1.5.7"
           terraform_wrapper: false
 
       - name: Configure AWS credentials

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.5"
+          terraform_version: "1.5.7"
 
       - name: Run terraform fmt check
         run: |

--- a/.github/workflows/pr-e2e-base-fresh.yml
+++ b/.github/workflows/pr-e2e-base-fresh.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.5"
+          terraform_version: "1.5.7"
           terraform_wrapper: false
 
       - name: Configure AWS credentials
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.5"
+          terraform_version: "1.5.7"
           terraform_wrapper: false
 
       - name: Configure AWS credentials
@@ -270,7 +270,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.5"
+          terraform_version: "1.5.7"
           terraform_wrapper: false
 
       - name: Configure AWS credentials

--- a/.github/workflows/pr-e2e-base.yml
+++ b/.github/workflows/pr-e2e-base.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.5.5"
+          terraform_version: "1.5.7"
           terraform_wrapper: false
 
       - name: Configure AWS credentials

--- a/justfile
+++ b/justfile
@@ -121,6 +121,9 @@ e2e-sync:
     echo "Installing Playwright browsers..."
     {{container-tool}} compose --project-directory {{justfile_directory()}} -f {{e2e-compose-file}} exec e2e bash -c "cd /workspace && uv run playwright install firefox"
 
+    # Make Playwright's Firefox discoverable by Python's webbrowser module (used by `jd open`)
+    {{container-tool}} compose --project-directory {{justfile_directory()}} -f {{e2e-compose-file}} exec e2e bash -c "mkdir -p ~/.local/bin && ln -sf ~/.cache/ms-playwright/firefox-*/firefox/firefox ~/.local/bin/firefox"
+
     echo "✓ E2E container synced successfully"
 
 # Run E2E tests in containerized environment
@@ -346,7 +349,7 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
     echo "Test filter: {{test_filter}}"
     echo "================================================"
 
-    {{container-tool}} compose --project-directory {{justfile_directory()}} -f {{e2e-compose-file}} exec -e XAUTHORITY=/home/testuser/.Xauthority e2e bash -c "cd /workspace && uv run pytest $PYTEST_ARGS"
+    {{container-tool}} compose --project-directory {{justfile_directory()}} -f {{e2e-compose-file}} exec -e XAUTHORITY=/home/testuser/.Xauthority e2e bash -c "cd /workspace && xvfb-run --auto-servernum uv run pytest $PYTEST_ARGS"
 
 # Setup GitHub OAuth authentication (one-time, requires X11 forwarding)
 # Usage: just auth-setup <project-dir> [display]

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_history.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_history.py
@@ -43,14 +43,14 @@ def test_history_list_up_shows_existing_logs(e2e_deployment: EndToEndDeployment)
     """Test that jd history list up shows existing logs with expected format.
 
     This test:
-    1. Ensures deployment exists with some history
+    1. Ensures deployment exists with up history (runs no-op jd up if needed)
     2. Runs jd history list up (table format)
     3. Verifies output is non-empty
     4. Verifies table contains expected columns
     5. Runs jd history list up --text
     6. Verifies plain text output shows file paths
     """
-    e2e_deployment.ensure_deployed()
+    e2e_deployment.ensure_up_history()
 
     # Run jd history list up (table format)
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "list", "up"])
@@ -130,12 +130,12 @@ def test_history_show_up_command(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd history show up displays latest up log.
 
     This test:
-    1. Ensures deployment exists with up history
+    1. Ensures deployment exists with up history (runs no-op jd up if needed)
     2. Runs jd history show up
     3. Verifies output displays log content
     4. Verifies content contains terraform-related keywords
     """
-    e2e_deployment.ensure_deployed()
+    e2e_deployment.ensure_up_history()
 
     # Run jd history show up
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "show", "up"])
@@ -158,12 +158,12 @@ def test_history_show_up_command_slice(e2e_deployment: EndToEndDeployment) -> No
     """Test that jd history show up with -l and -s flags correctly slices log output.
 
     This test:
-    1. Ensures deployment exists with up history
+    1. Ensures deployment exists with up history (runs no-op jd up if needed)
     2. Runs jd history show up -l 20 -s 10
     3. Verifies output displays sliced log content
     4. Verifies output has expected line count (at most 20 lines)
     """
-    e2e_deployment.ensure_deployed()
+    e2e_deployment.ensure_up_history()
 
     # Run jd history show up -l 20 -s 10
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "history", "show", "up", "-l", "20", "-s", "10"])

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_handler.py
@@ -4,6 +4,7 @@ from jupyter_deploy import fs_utils
 from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import StoreType
+from jupyter_deploy.handlers.base_project_handler import write_store_config
 from jupyter_deploy.handlers.docs_generator import DocsGenerator
 from jupyter_deploy.infrastructure.enum import AWSInfrastructureType, InfrastructureType
 from jupyter_deploy.provider.enum import ProviderType
@@ -107,4 +108,16 @@ class InitHandler:
         dest_path = Path(project_dir)
         store_manager = StoreManagerFactory.get_manager(store_type=store_type, store_id=store_id)
         store_manager.pull(project_id, dest_path, display_manager)
+
+        # Persist store origin to .jd/store.yaml so that subsequent commands
+        # (jd show --info, jd config, jd up) can resolve the store without
+        # rediscovery.  The store_id is resolved during pull().
+        resolved_store_info = store_manager.resolve_store()
+        write_store_config(
+            dest_path,
+            store_type=store_type.value,
+            store_id=resolved_store_info.store_id,
+            project_id=project_id,
+        )
+
         return dest_path.resolve()

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/up_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/up_handler.py
@@ -112,12 +112,14 @@ class UpHandler(BaseProjectHandler):
         if not self._store_access_manager.is_configured():
             self._store_access_manager.configure(store_info, project_id, self.display_manager)
 
-        store_manager.push(self.project_path, project_id, self.display_manager)
-
-        # Persist discovered store-id and project-id to .jd/store.yaml
+        # Persist store-id and project-id to .jd/store.yaml BEFORE push,
+        # so the S3 snapshot includes it and restored projects get a complete
+        # store config without needing a second jd up.
         write_store_config(
             self.project_path,
             store_type=store_type.value,
             store_id=store_info.store_id,
             project_id=project_id,
         )
+
+        store_manager.push(self.project_path, project_id, self.display_manager)

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_up_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_up_handler.py
@@ -480,8 +480,8 @@ class TestUpHandlerPushToStore(unittest.TestCase):
         with self.assertRaises(PermissionError):
             handler.push_to_store()
 
-        # Push should have been called before write_store_config
-        mock_store_manager.push.assert_called_once()
+        # write_store_config runs before push, so push should NOT have been called
+        mock_store_manager.push.assert_not_called()
 
     @patch("jupyter_deploy.handlers.project.up_handler.StoreManagerFactory")
     @patch("jupyter_deploy.handlers.project.up_handler.TerraformOutputsHandler")
@@ -515,6 +515,7 @@ class TestUpHandlerPushToStore(unittest.TestCase):
 
         mock_store_factory.get_manager.assert_not_called()
 
+    @patch("jupyter_deploy.handlers.project.up_handler.write_store_config")
     @patch("jupyter_deploy.handlers.project.up_handler.StoreManagerFactory")
     @patch("jupyter_deploy.handlers.project.up_handler.TerraformOutputsHandler")
     @patch("jupyter_deploy.engine.terraform.tf_up.TerraformUpHandler")
@@ -527,6 +528,7 @@ class TestUpHandlerPushToStore(unittest.TestCase):
         mock_tf_handler_cls: Mock,
         mock_outputs_cls: Mock,
         mock_store_factory: Mock,
+        mock_write_config: Mock,
     ) -> None:
         handler = self._setup_handler(mock_cwd, mock_retrieve_manifest, mock_tf_handler_cls)
         handler._store_access_manager = Mock()
@@ -545,3 +547,5 @@ class TestUpHandlerPushToStore(unittest.TestCase):
             handler.push_to_store()
 
         self.assertEqual(str(ctx.exception), "S3 upload failed")
+        # write_store_config should have been called before push
+        mock_write_config.assert_called_once()

--- a/libs/jupyter-deploy/tests/unit/handlers/test_init_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_init_handler.py
@@ -268,9 +268,11 @@ class TestInitHandler(unittest.TestCase):
 
 
 class TestInitHandlerRestore(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.init_handler.write_store_config")
     @patch("jupyter_deploy.handlers.init_handler.StoreManagerFactory")
-    def test_restore_pulls_from_store(self, mock_factory: Mock) -> None:
+    def test_restore_pulls_from_store(self, mock_factory: Mock, mock_write_store_config: Mock) -> None:
         mock_store_manager = Mock()
+        mock_store_manager.resolve_store.return_value = Mock(store_id="discovered-bucket")
         mock_factory.get_manager.return_value = mock_store_manager
 
         result = InitHandler.restore(
@@ -284,9 +286,11 @@ class TestInitHandlerRestore(unittest.TestCase):
         mock_store_manager.pull.assert_called_once_with("tpl-abc123", Path("/tmp/restored"), ANY)
         self.assertEqual(result, Path("/tmp/restored").resolve())
 
+    @patch("jupyter_deploy.handlers.init_handler.write_store_config")
     @patch("jupyter_deploy.handlers.init_handler.StoreManagerFactory")
-    def test_restore_passes_store_id(self, mock_factory: Mock) -> None:
+    def test_restore_passes_store_id(self, mock_factory: Mock, mock_write_store_config: Mock) -> None:
         mock_store_manager = Mock()
+        mock_store_manager.resolve_store.return_value = Mock(store_id="my-bucket")
         mock_factory.get_manager.return_value = mock_store_manager
 
         InitHandler.restore(
@@ -298,3 +302,48 @@ class TestInitHandlerRestore(unittest.TestCase):
         )
 
         mock_factory.get_manager.assert_called_once_with(store_type=StoreType.S3_ONLY, store_id="my-bucket")
+
+    @patch("jupyter_deploy.handlers.init_handler.write_store_config")
+    @patch("jupyter_deploy.handlers.init_handler.StoreManagerFactory")
+    def test_restore_writes_store_config(self, mock_factory: Mock, mock_write_store_config: Mock) -> None:
+        mock_store_manager = Mock()
+        mock_store_manager.resolve_store.return_value = Mock(store_id="discovered-bucket")
+        mock_factory.get_manager.return_value = mock_store_manager
+
+        InitHandler.restore(
+            project_dir="/tmp/restored",
+            project_id="tpl-abc123",
+            store_type=StoreType.S3_ONLY,
+            display_manager=NullDisplay(),
+        )
+
+        mock_write_store_config.assert_called_once_with(
+            Path("/tmp/restored"),
+            store_type="s3-only",
+            store_id="discovered-bucket",
+            project_id="tpl-abc123",
+        )
+
+    @patch("jupyter_deploy.handlers.init_handler.write_store_config")
+    @patch("jupyter_deploy.handlers.init_handler.StoreManagerFactory")
+    def test_restore_writes_store_config_with_explicit_store_id(
+        self, mock_factory: Mock, mock_write_store_config: Mock
+    ) -> None:
+        mock_store_manager = Mock()
+        mock_store_manager.resolve_store.return_value = Mock(store_id="my-bucket")
+        mock_factory.get_manager.return_value = mock_store_manager
+
+        InitHandler.restore(
+            project_dir="/tmp/restored",
+            project_id="tpl-abc123",
+            store_type=StoreType.S3_ONLY,
+            display_manager=NullDisplay(),
+            store_id="my-bucket",
+        )
+
+        mock_write_store_config.assert_called_once_with(
+            Path("/tmp/restored"),
+            store_type="s3-only",
+            store_id="my-bucket",
+            project_id="tpl-abc123",
+        )

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/deployment.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/deployment.py
@@ -50,6 +50,7 @@ class EndToEndDeployment:
         self.destroy_timeout_seconds = destroy_timeout_seconds
         self._cli: JDCli | None = None
         self._is_deployed = False
+        self._has_up_history = False
         self._owns_project_resources = False
 
     @property
@@ -119,6 +120,20 @@ class EndToEndDeployment:
             # (since the file system inside the container sees it), and it is clean (empty)
             # we can proceed
             self._deploy_e2e_project()
+
+    def ensure_up_history(self) -> None:
+        """Ensure that `jd history list up` has at least one entry.
+
+        Restored projects have config history (from the restore's `jd config`)
+        but no up history. This runs a no-op `jd up -y` to create an up log
+        entry. The result is cached so the cost is paid at most once per run.
+        """
+        if self._has_up_history:
+            return
+
+        self.ensure_deployed()
+        self.cli.run_command(["jupyter-deploy", "up", "-y"], timeout_seconds=self.deploy_timeout_seconds)
+        self._has_up_history = True
 
     def ensure_host_running(self) -> None:
         """Call host status, attempts to call host start if not running."""
@@ -272,6 +287,7 @@ class EndToEndDeployment:
         self.cli.run_command(["jupyter-deploy", "up", "-y"], timeout_seconds=self.deploy_timeout_seconds)
 
         self._is_deployed = True
+        self._has_up_history = True
 
     def ensure_destroyed(self) -> None:
         """Ensure the deployment is torn down."""
@@ -527,6 +543,7 @@ class EndToEndDeployment:
         # Run jd up to apply changes
         timeout = timeout_seconds if timeout_seconds is not None else self.deploy_timeout_seconds
         self.cli.run_command(["jupyter-deploy", "up", "-y"], timeout_seconds=timeout)
+        self._has_up_history = True
 
     def get_str_variable_value(self, variable_name: str) -> str:
         """Call jupyter-deploy show CLI, return the parsed response as str."""

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
@@ -1,4 +1,4 @@
-# E2E test container for jupyter-deploy templates
+# E2E test container for jupyter-deploy templates (AWS)
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 # Install system dependencies
@@ -18,7 +18,7 @@ RUN apt-get update && \
 RUN wget -qO- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
     echo 'deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com bookworm main' | tee /etc/apt/sources.list.d/hashicorp.list && \
     apt-get update && \
-    apt-get install -y terraform && \
+    apt-get install -y terraform=1.5.7-1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install AWS CLI
@@ -90,6 +90,9 @@ RUN apt-get update && \
 
 # Switch to testuser
 USER testuser
+
+# Ensure ~/.local/bin is on PATH so symlinked tools (e.g. Playwright Firefox) are discoverable
+ENV PATH="/home/testuser/.local/bin:${PATH}"
 
 # Keep container running
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
This PR fixes a few issues w/ E2E tests when running in CI:
- add a method to ensure `jd up` was run locally before assertions again `jd history` on up logs
- make webbrowser accessible in test container of the CI
- fix paper cut where `.jd/store.yaml` was not persisted on time when `jd up` was run once
- pin `terraform` version in e2e test container to ensure compatibility between runs and environments

### Testing
- pushed to other branch, verify [workflow](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/23881866335) w/ full non-mutating e2e tests
- ran non-mutating e2e tests locally