### PR TITLE
fix: store access error handling

### DIFF
--- a/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
@@ -34,6 +34,7 @@ from jupyter_deploy.exceptions import (
     ProjectNotFoundInStoreError,
     ProjectStoreAccessConfigurationError,
     ProjectStoreNotFoundError,
+    ProjectStoreReadError,
     ProviderPermissionError,
     ReadConfigurationError,
     ReadManifestError,
@@ -251,6 +252,17 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         else:
             hint_cmd += " <type>"
         console.print(f":bulb: Use [bold cyan]{hint_cmd}[/] to see available projects.")
+        raise typer.Exit(code=1) from None
+
+    except ProjectStoreReadError as e:
+        console.print(f":x: {e}", style="bold red")
+        console.line()
+        if e.hint:
+            console.print(f":bulb: {e.hint}", style="dim")
+        if e.store_type:
+            console.print(f"Store type: {e.store_type}", style="dim")
+        if e.store_id:
+            console.print(f"Store ID: {e.store_id}", style="dim")
         raise typer.Exit(code=1) from None
 
     except ProjectStoreAccessConfigurationError as e:

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_outputs.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_outputs.py
@@ -13,9 +13,12 @@ from jupyter_deploy.engine.terraform.tf_constants import (
     TF_OUTPUT_CMD,
     TF_OUTPUTS_FILENAME,
 )
+from jupyter_deploy.exceptions import ProjectStoreReadError
+from jupyter_deploy.handlers.base_project_handler import retrieve_store_config
 from jupyter_deploy.manifest import JupyterDeployManifest
 
 _BACKEND_INIT_ERROR = "Backend initialization required"
+_FAILED_TO_LOAD_STATE = "Failed to load state"
 
 
 class TerraformOutputsHandler(EngineOutputsHandler):
@@ -38,7 +41,16 @@ class TerraformOutputsHandler(EngineOutputsHandler):
         try:
             return cmd_utils.run_cmd_and_capture_output(output_cmd, exec_dir=self.engine_dir_path)
         except subprocess.CalledProcessError as e:
-            if _BACKEND_INIT_ERROR not in (e.stderr or "") or not (self.engine_dir_path / TF_BACKEND_FILENAME).exists():
+            stderr = e.stderr or ""
+            if _FAILED_TO_LOAD_STATE in stderr:
+                store_config = retrieve_store_config(self.project_path)
+                raise ProjectStoreReadError(
+                    "Failed to load remote state.",
+                    hint="Verify that your credentials have access to the project store.",
+                    store_type=store_config.store_type if store_config else None,
+                    store_id=store_config.store_id if store_config else None,
+                ) from e
+            if _BACKEND_INIT_ERROR not in stderr or not (self.engine_dir_path / TF_BACKEND_FILENAME).exists():
                 raise
             init_cmd = TF_INIT_CMD + [TF_INIT_RECONFIGURE_CMD_OPTION]
             cmd_utils.run_cmd_and_capture_output(init_cmd, exec_dir=self.engine_dir_path)

--- a/libs/jupyter-deploy/jupyter_deploy/exceptions.py
+++ b/libs/jupyter-deploy/jupyter_deploy/exceptions.py
@@ -428,6 +428,24 @@ class ProjectStoreAccessConfigurationError(JupyterDeployError, RuntimeError):
     pass
 
 
+class ProjectStoreReadError(JupyterDeployError, RuntimeError):
+    """Raised when reading from the project store fails (e.g., AccessDenied on remote state).
+
+    Attributes:
+        hint: Actionable hint for the user
+        store_type: The store type (if available)
+        store_id: The store ID (if available)
+    """
+
+    def __init__(
+        self, message: str, hint: str | None = None, store_type: str | None = None, store_id: str | None = None
+    ) -> None:
+        self.hint = hint
+        self.store_type = store_type
+        self.store_id = store_id
+        super().__init__(message)
+
+
 class ProjectNotFoundInStoreError(JupyterDeployError, RuntimeError):
     """Raised when a project is not found in the remote store.
 

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_outputs.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_outputs.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition, TemplateOutputDefinition
 from jupyter_deploy.engine.terraform.tf_outputs import TerraformOutputsHandler
 from jupyter_deploy.enum import ValueSource
+from jupyter_deploy.exceptions import ProjectStoreReadError
 
 
 class TestTerraformOutputsHandler(unittest.TestCase):
@@ -56,6 +57,47 @@ class TestRunOutputCmd(unittest.TestCase):
             handler._run_output_cmd()
 
         mock_run_cmd.assert_called_once()
+
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.retrieve_store_config")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.cmd_utils.run_cmd_and_capture_output")
+    def test_raises_project_store_read_error_on_failed_to_load_state(
+        self, mock_run_cmd: Mock, mock_retrieve_store_config: Mock
+    ) -> None:
+        state_error = subprocess.CalledProcessError(1, "terraform output -json")
+        state_error.stderr = "Error refreshing state: Failed to load state: AccessDenied: Access Denied"
+        mock_run_cmd.side_effect = state_error
+
+        mock_store_config = Mock()
+        mock_store_config.store_type = "s3"
+        mock_store_config.store_id = "my-bucket"
+        mock_retrieve_store_config.return_value = mock_store_config
+
+        handler = TerraformOutputsHandler(Path("/mock/project"), Mock())
+        with self.assertRaises(ProjectStoreReadError) as ctx:
+            handler._run_output_cmd()
+
+        self.assertIn("Failed to load remote state", str(ctx.exception))
+        self.assertIn("credentials", ctx.exception.hint or "")
+        self.assertEqual(ctx.exception.store_type, "s3")
+        self.assertEqual(ctx.exception.store_id, "my-bucket")
+        mock_run_cmd.assert_called_once()
+
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.retrieve_store_config")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.cmd_utils.run_cmd_and_capture_output")
+    def test_raises_project_store_read_error_without_store_config(
+        self, mock_run_cmd: Mock, mock_retrieve_store_config: Mock
+    ) -> None:
+        state_error = subprocess.CalledProcessError(1, "terraform output -json")
+        state_error.stderr = "Error refreshing state: Failed to load state: AccessDenied: Access Denied"
+        mock_run_cmd.side_effect = state_error
+        mock_retrieve_store_config.return_value = None
+
+        handler = TerraformOutputsHandler(Path("/mock/project"), Mock())
+        with self.assertRaises(ProjectStoreReadError) as ctx:
+            handler._run_output_cmd()
+
+        self.assertIsNone(ctx.exception.store_type)
+        self.assertIsNone(ctx.exception.store_id)
 
     @patch("jupyter_deploy.engine.terraform.tf_outputs.cmd_utils.run_cmd_and_capture_output")
     def test_does_not_retry_on_unrelated_error(self, mock_run_cmd: Mock) -> None:

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
@@ -337,7 +337,31 @@ def verify_executed_and_no_cell_error(cells_info: list[dict[str, str]], notebook
         raise RuntimeError(f"Notebook {notebook_path} execution failed with errors.")
 
 
-def copy_and_clean_notebook(base_url: str, notebook_path: str, suffix: str = "-clean") -> str:
+def _build_session_with_cookies(page: Page) -> requests.Session:
+    """Build a requests.Session with cookies from the Playwright browser context.
+
+    The Jupyter API is behind an OAuth2 proxy that requires authentication cookies.
+    This extracts cookies from the browser (which has already authenticated) and
+    attaches them to a requests session for server-side API calls.
+
+    Args:
+        page: Playwright Page instance (authenticated)
+
+    Returns:
+        A requests.Session with the browser's cookies attached
+    """
+    session = requests.Session()
+    for cookie in page.context.cookies():
+        session.cookies.set(
+            cookie["name"],
+            cookie["value"],
+            domain=cookie.get("domain", ""),
+            path=cookie.get("path", "/"),
+        )
+    return session
+
+
+def copy_and_clean_notebook(base_url: str, notebook_path: str, page: Page, suffix: str = "-clean") -> str:
     """Copy a notebook and clean its execution state using the Jupyter Contents API.
 
     This creates a fresh copy of the notebook with:
@@ -351,6 +375,7 @@ def copy_and_clean_notebook(base_url: str, notebook_path: str, suffix: str = "-c
     Args:
         base_url: The base URL of the Jupyter server
         notebook_path: Path to the notebook relative to /home/jovyan (e.g., "e2e-test/application_simple.ipynb")
+        page: Playwright Page instance (used to extract authentication cookies)
         suffix: Suffix to append to the filename before the extension (default: "-clean")
 
     Returns:
@@ -359,11 +384,13 @@ def copy_and_clean_notebook(base_url: str, notebook_path: str, suffix: str = "-c
     Raises:
         requests.HTTPError: If the GET or PUT request fails
     """
+    session = _build_session_with_cookies(page)
+
     # 1. GET the original notebook
     get_url = f"{base_url}/api/contents/{notebook_path}"
     logger.info(f"Fetching notebook via API: {get_url}")
 
-    response = requests.get(get_url)
+    response = session.get(get_url)
     response.raise_for_status()
 
     notebook_data = response.json()
@@ -396,7 +423,7 @@ def copy_and_clean_notebook(base_url: str, notebook_path: str, suffix: str = "-c
 
     put_body = {"type": "notebook", "format": "json", "content": content}
 
-    put_response = requests.put(put_url, json=put_body)
+    put_response = session.put(put_url, json=put_body)
     put_response.raise_for_status()
 
     logger.info(f"Successfully created cleaned notebook copy: {clean_path}")

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/remediation_strategy.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/remediation_strategy.py
@@ -110,7 +110,7 @@ class CopyCleanStrategy(RemediationStrategy):
 
         # Copy notebook to new path with cleaned execution state
         # This creates a new Y-doc room, avoiding corrupted session state
-        clean_path = copy_and_clean_notebook(base_url, notebook_path)
+        clean_path = copy_and_clean_notebook(base_url, notebook_path, page)
         logger.info(f"Created clean copy: {clean_path}")
 
         # Dismiss any error dialogs and close all tabs


### PR DESCRIPTION
This PR a/ improves error handling for store access (e.g. using the wrong creds, wrong AWS account), b/ pass session to `request` in plugin when trying to restore a notebook.

a/ closes:  #182 
b/ attempts to fix edge cases of failed [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/23931347590)

### Screenshot
<img width="473" height="85" alt="Screenshot 2026-04-03 at 12 26 25 PM" src="https://github.com/user-attachments/assets/69c50df2-692f-4296-a0b9-a111e803019a" />
