### PR TITLE
fix: secrets in oauth container, ci papercuts

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,151 @@
+# CI Infrastructure Setup
+
+This document describes the one-time setup required for the E2E CI workflows.
+
+## Prerequisites
+
+- AWS account with the CI infrastructure template deployed (`jupyter-infra-tf-aws-iam-ci`)
+- A dedicated GitHub bot account for automated testing
+- GitHub OAuth apps (1-5) registered under the bot account
+
+## Bot Account Setup
+
+### 1. Create the bot account
+
+Create a dedicated GitHub account for CI testing (e.g., `my-bot@example.com`). Save:
+- the recovery codes
+- the account password
+
+Then, install a few tools (Mac/Linux):
+```bash
+# homebrew
+brew install zbar oath-toolkit
+```
+
+Then enable 2FA [using a TOTP app](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication#configuring-two-factor-authentication-using-a-totp-app).
+However, do not actually set up an App. When you see "Scan the QR code", do NOT scan the QR code, instead right-click the QR code and save the image. It contains the 2FA secret. Once you have the QR code saved locally, use `zbarimg` to parse it.
+
+```bash
+# homebrew
+zbarimg <your-image-file>
+```
+You will see an output w/ the 2FA secret. Save this temporarily.
+
+You can then generate one-time password to access the bot account with:
+```bash
+oathtool -b --totp <2FA-seed>
+```
+
+We will store the password, 2FA secret and recovery codes in the CI infrastructure template (`github_bot_account_*` variables).
+
+### 2. Add bot to the test organization
+
+The bot account must be a member of the organization used for org/team E2E
+tests (the `JD_E2E_ORG` org, e.g. `jupyter-infra`). An org admin must send
+the invitation, and the bot must accept it.
+
+### 3. Create OAuth apps
+
+Create GitHub 5 OAuth apps under the bot account at:
+`Settings > Developer settings > OAuth Apps`.
+
+Each app corresponds to a deployment slot (subdomain). For each app, set:
+- **Homepage URL**: `https://<subdomain>.<domain>`
+- **Authorization callback URL**: `https://<subdomain>.<domain>/oauth2/callback`
+
+Store the client ID and client secret in the CI infrastructure template
+(`github_oauth_app_*` variables).
+
+### 4. Create the CI infrastructure project
+
+Deploy the CI infrastructure template (`jupyter-infra-tf-aws-iam-ci`) which
+stores bot credentials and OAuth app secrets in AWS (SSM Parameter Store and
+Secrets Manager). From the repo root:
+
+```bash
+just init-ci sandbox-ci
+# Fill in variables.yaml with bot credentials, OAuth app details, GitHub repo, etc.
+cd sandbox-ci
+jd config --help
+# Fill in variables.yaml with bot credentials, OAuth app details, GitHub repo, etc.
+jd config
+jd up
+```
+
+### 5. Deploy a base template project
+
+Steps 6 and 7 require a live deployment to authenticate against. Deploy a
+base template project using one of the OAuth apps:
+
+```bash
+just ci-deploy-base <app-num>
+```
+
+This runs `jd init` + `jd config` (using CI credentials) + `jd up` in one step.
+
+### 6. Grant OAuth app access to the organization
+
+GitHub organizations with third-party application restrictions require each
+OAuth app to be explicitly approved before it can access org data. Without
+this, org-based and team-based E2E tests will fail with "Authorization Failure".
+
+**An org admin must perform this step.** The bot account cannot do it alone
+(unless the bot is an org admin).
+
+To grant access using `auth-setup`:
+
+1. Ensure a base template project is deployed and the E2E container is running
+   (`just e2e-up`)
+2. Run `just auth-setup-base <project-dir>` — this opens a browser window
+3. Log in with the **admin's** GitHub account (not the bot)
+4. On the GitHub OAuth authorization page, find the target organization
+   and click **Grant**
+5. Close the browser (Ctrl+C) — you do NOT need to save this auth state,
+   only the grant matters
+
+Alternatively, an org admin can approve the app from the org settings:
+`Organization Settings > Third-party access > OAuth application policy`
+
+This only needs to be done once per OAuth app per organization. The approval
+persists across deployments as long as the OAuth app client ID stays the same.
+
+### 7. Authenticate the bot account
+
+The bot's browser session (Playwright storage state) is saved to Secrets
+Manager and reused across CI runs. To create or refresh it:
+
+1. Run `just auth-setup-base <project-dir>` — this opens a browser window
+2. Log in as the **bot account** (use `just auth-bot-password` and
+   `just auth-bot-2fa` to get credentials)
+3. After successful authentication, the session is saved to
+   `.auth/github-oauth-state.json`
+4. Export the auth state to Secrets Manager: `just auth-export sandbox-ci`
+
+### 8. Verify the setup
+
+Run the org/team E2E tests to verify everything works:
+
+```bash
+# clean up the local browser state
+rm -rf .auth
+
+# restore the ci and base projects
+just ci-restore
+just ci-restore-base <app-num>
+just env-setup-base sandbox-base sandbox-ci <app-num>
+
+# run tests
+just e2e-down
+just e2e-up
+just test-e2e-base sandbox-base "test_org_and_teams"
+```
+
+## Useful Commands
+
+| Command | Description |
+|---------|-------------|
+| `just auth-bot-email` | Print the bot account email |
+| `just auth-bot-username` | Print the bot account username |
+| `just auth-bot-password` | Print the bot account password |
+| `just auth-bot-2fa` | Generate a TOTP code for the bot |
+| `just auth-setup-base <dir>` | Interactive browser auth setup |

--- a/justfile
+++ b/justfile
@@ -543,17 +543,6 @@ test-e2e-ci project_dir="sandbox-e2e-ci" test_filter="" options="":
 auth-setup-base project_dir display="${DISPLAY:-}":
     @just auth-setup {{project_dir}} "{{display}}"
 
-# Initialize a new base template project directory
-init-base project_dir:
-    uv run jd init {{project_dir}}
-
-# Configure a base template project using CI OAuth app settings
-# Usage: just config-base-from-ci <project-dir> [ci-dir] [oauth-app-num] [allowed-usernames]
-# Example: just config-base-from-ci sandbox-base sandbox-ci 1
-# Example: just config-base-from-ci sandbox-base sandbox-ci 1 '["bot-user","admin"]'
-config-base-from-ci project_dir ci_dir="sandbox-ci" oauth_app_num="1" allowed_usernames="":
-    uv run python scripts/config_base_from_ci.py {{project_dir}} {{ci_dir}} {{oauth_app_num}} "{{allowed_usernames}}"
-
 # --- CI infrastructure commands ---
 
 # Ensure the host is running (start if stopped)
@@ -582,6 +571,30 @@ ensure-host-stopped project_dir:
     else
         echo "Host is not running, skipping stop."
     fi
+
+# Initialize a new CI infrastructure project
+# Usage: just init-ci [ci-dir]
+# Example: just init-ci sandbox-ci
+init-ci ci_dir="sandbox-ci":
+    mkdir -p {{ci_dir}}
+    uv run jd init {{ci_dir}} --engine terraform --provider aws --infrastructure iam --template ci
+
+# Deploy a new base template project from scratch using CI infrastructure
+# Usage: just ci-deploy-base <oauth-app-num> [ci-dir] [project-dir]
+# Example: just ci-deploy-base 3
+# Example: just ci-deploy-base 3 sandbox-ci sandbox-base
+ci-deploy-base oauth_app_num ci_dir="sandbox-ci" project_dir="sandbox-base":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -d "{{project_dir}}" ] && [ "$(ls -A {{project_dir}})" ]; then
+        echo "Error: {{project_dir}} already exists and is not empty."
+        echo "Remove it first to avoid overwriting an existing deployment."
+        exit 1
+    fi
+    mkdir -p {{project_dir}}
+    uv run jd init {{project_dir}}
+    uv run python scripts/config_base_from_ci.py {{project_dir}} {{ci_dir}} {{oauth_app_num}}
+    uv run jd up -y -p {{project_dir}}
 
 # Discover and restore CI project from S3 store
 ci-restore ci_dir="sandbox-ci":

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/services.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/services.tf
@@ -209,7 +209,6 @@ locals {
       content      = local.sync_acme_file
       content_type = "text/x-shellscript"
     }
-
     # Docker and service configuration files
     "deployment-docker/docker-compose.yml" = {
       content      = local.docker_compose_file
@@ -276,6 +275,11 @@ locals {
   # Compute hash of all deployment script files
   # This hash triggers SSM association re-execution when scripts change
   scripts_files_hash = sha256(join("\n", [for k, v in local.all_script_files : v.content]))
+
+  # Compute hash of SSM-embedded scripts (cloud-init + volume-init)
+  # These are not in all_script_files but are embedded directly in the SSM document.
+  # Changes to these (e.g. volume configuration) must also trigger re-execution.
+  ssm_embedded_hash = sha256(join("\n", [local.cloud_init_file, local.cloudinit_volumes_script]))
 }
 
 # Generate the cloudinit_volumes_script directly in services.tf
@@ -494,6 +498,7 @@ resource "aws_ssm_document" "instance_startup" {
 resource "terraform_data" "scripts_files_trigger" {
   input = {
     scripts_files_hash = local.scripts_files_hash
+    ssm_embedded_hash  = local.ssm_embedded_hash
     instance_type      = var.instance_type
   }
 }

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/cloudinit.sh.tftpl
@@ -155,14 +155,18 @@ chmod 600 /opt/docker/acme.json
 
 mkdir -p /var/log/services
 
-# Create the AUTHED_ENTITIES file
-echo "[org]" > /etc/AUTHED_ENTITIES
-echo "${allowed_github_org}" >> /etc/AUTHED_ENTITIES
-echo "" >> /etc/AUTHED_ENTITIES
-echo "[teams]" >> /etc/AUTHED_ENTITIES
-echo "${allowed_github_teams}" >> /etc/AUTHED_ENTITIES
-echo "" >> /etc/AUTHED_ENTITIES
-echo "[users]" >> /etc/AUTHED_ENTITIES
-echo "${allowed_github_usernames}" >> /etc/AUTHED_ENTITIES
-chmod 600 /etc/AUTHED_ENTITIES
-chown service-user:service-user /etc/AUTHED_ENTITIES
+# Create the AUTHED_ENTITIES file only on first boot.
+# Runtime changes (jd users/organization/teams commands) modify this file
+# directly via update-auth.sh and must survive host restarts.
+if [ ! -f /etc/AUTHED_ENTITIES ]; then
+    echo "[org]" > /etc/AUTHED_ENTITIES
+    echo "${allowed_github_org}" >> /etc/AUTHED_ENTITIES
+    echo "" >> /etc/AUTHED_ENTITIES
+    echo "[teams]" >> /etc/AUTHED_ENTITIES
+    echo "${allowed_github_teams}" >> /etc/AUTHED_ENTITIES
+    echo "" >> /etc/AUTHED_ENTITIES
+    echo "[users]" >> /etc/AUTHED_ENTITIES
+    echo "${allowed_github_usernames}" >> /etc/AUTHED_ENTITIES
+    chmod 600 /etc/AUTHED_ENTITIES
+    chown service-user:service-user /etc/AUTHED_ENTITIES
+fi

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/refresh-oauth-cookie.sh
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/commands/refresh-oauth-cookie.sh
@@ -3,11 +3,12 @@ set -e
 
 exec > >(tee -a /var/log/jupyter-deploy/refresh-oauth-cookie.log) 2>&1
 
-OAUTH_SECRET=$(openssl rand -base64 32 | tr -- '+/' '-_')
-
-if grep -q "^OAUTH_SECRET=" /opt/docker/.env; then
-    sed -i "s/^OAUTH_SECRET=.*/OAUTH_SECRET=${OAUTH_SECRET}/" /opt/docker/.env
-else
-    echo "OAUTH_SECRET=${OAUTH_SECRET}" >> /opt/docker/.env
-fi
+mkdir -p /opt/docker/secrets
+# Generate 32 raw bytes for AES encryption — cookie-secret-file requires
+# raw binary (not base64), exactly 16, 24, or 32 bytes (AES-128/192/256).
+dd if=/dev/urandom bs=32 count=1 2>/dev/null > /opt/docker/secrets/cookie-secret
+# This script runs as root (via SSM), but the oauth container runs as
+# service-user — chown so the mounted file is readable inside the container.
+chown service-user:service-user /opt/docker/secrets/cookie-secret
+chmod 600 /opt/docker/secrets/cookie-secret
 echo "Updated OAuth cookie secret."

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-compose.yml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-compose.yml.tftpl
@@ -96,10 +96,14 @@ services:
       start_period: 5s
     volumes:
       - ./static:/var/www/static:ro
+      - ./secrets:/var/run/secrets:ro
     labels:
       - "traefik.enable=true"
       # Main service definition
       - "traefik.http.services.oauth.loadbalancer.server.port=4180"
+      - "traefik.http.services.oauth.loadbalancer.healthcheck.path=/ping"
+      - "traefik.http.services.oauth.loadbalancer.healthcheck.interval=5s"
+      - "traefik.http.services.oauth.loadbalancer.healthcheck.timeout=3s"
       # oauth-middleware
       - "traefik.http.middlewares.oauth-auth.forwardauth.address=http://oauth:4180/oauth2/auth"
       - "traefik.http.middlewares.oauth-auth.forwardauth.trustForwardHeader=true"
@@ -142,7 +146,7 @@ services:
     environment:
       - OAUTH2_PROXY_PROVIDER=${oauth_provider}
       - OAUTH2_PROXY_CLIENT_ID=${github_client_id}
-      - OAUTH2_PROXY_CLIENT_SECRET=$${GITHUB_CLIENT_SECRET}
+      - OAUTH2_PROXY_CLIENT_SECRET_FILE=/var/run/secrets/client-secret
       - OAUTH2_PROXY_SCOPE=read:user,user:email,read:org
       # This allows any email domain, but access is restricted by org/team/user restrictions below
       # Safety checks in docker-startup.sh prevent empty auth restrictions
@@ -153,8 +157,9 @@ services:
       - OAUTH2_PROXY_REDIRECT_URL=https://${full_domain}/oauth2/callback
       - OAUTH2_PROXY_HTTP_ADDRESS=0.0.0.0:4180
       - OAUTH2_PROXY_COOKIE_DOMAINS=${full_domain}
-      - OAUTH2_PROXY_COOKIE_SECRET=$${OAUTH_SECRET}
+      - OAUTH2_PROXY_COOKIE_SECRET_FILE=/var/run/secrets/cookie-secret
       - OAUTH2_PROXY_COOKIE_SECURE=true
+      - OAUTH2_PROXY_COOKIE_REFRESH=1h
       - OAUTH2_PROXY_REVERSE_PROXY=true
       - OAUTH2_PROXY_UPSTREAMS=https://${full_domain}/,file:///var/www/static/#/oauth2-static/
       - OAUTH2_PROXY_WHITELIST_DOMAINS=${full_domain}

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-startup.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/docker-startup.sh.tftpl
@@ -57,7 +57,6 @@ tee /opt/docker/.env >/dev/null << EOFENV
 SERVICE_UID=$(id -u service-user)
 SERVICE_GID=$(id -g service-user)
 DOCKER_GID=$(getent group docker | cut -d: -f3)
-GITHUB_CLIENT_SECRET=$${GITHUB_CLIENT_SECRET}
 JUPYTER_MEM_LIMIT_MB=$${JUPYTER_MEM_LIMIT_MB}
 JUPYTER_MEM_RESERVATION_MB=$${JUPYTER_MEM_RESERVATION_MB}
 AUTHED_USERS_CONTENT=$${AUTHED_USERS_CONTENT}
@@ -65,6 +64,13 @@ AUTHED_ORG_CONTENT=$${AUTHED_ORG_CONTENT}
 AUTHED_TEAMS_CONTENT=$${AUTHED_TEAMS_CONTENT}
 EOFENV
 echo "Saved environment file /opt/docker/.env"
+
+echo "Writing oauth app client secret to /opt/docker/secrets/..."
+mkdir -p /opt/docker/secrets
+printf '%s' "$${GITHUB_CLIENT_SECRET}" > /opt/docker/secrets/client-secret
+chown service-user:service-user /opt/docker/secrets/client-secret
+chmod 600 /opt/docker/secrets/client-secret
+echo "Wrote oauth app client secret"
 
 echo "Generating OAuth cookie secret..."
 sh /usr/local/bin/refresh-oauth-cookie.sh

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/deployment.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/deployment.py
@@ -157,13 +157,18 @@ class EndToEndDeployment:
             if not self._is_host_stopped():
                 raise RuntimeError("Host is not stopped")
 
-    def ensure_server_running(self) -> None:
+    def ensure_server_running(self, wait_after_restart: bool = False) -> None:
         """Ensure the Jupyter server is running.
 
         This method attempts to get the server into a running state by:
         1. Checking if server is already available (fast path)
         2. If server check fails (host not running), start the host first
         3. If server is not available but host is running, restart the server
+
+        Args:
+            wait_after_restart: If True, poll for IN_SERVICE after a restart
+                instead of checking once. Useful in CI where containers may
+                need extra time to initialize after a cold start.
 
         Raises:
             RuntimeError: If the server cannot be made available
@@ -187,7 +192,10 @@ class EndToEndDeployment:
 
         # Step 3: Attempt to restart the server
         self.cli.run_command(["jupyter-deploy", "server", "restart"])
-        if not self._is_server_available():
+
+        if wait_after_restart:
+            self._wait_for_server_in_service()
+        elif not self._is_server_available():
             raise RuntimeError("Jupyter Server failed to start after restart")
 
     def ensure_server_stopped_and_host_is_running(self) -> None:
@@ -314,6 +322,25 @@ class EndToEndDeployment:
         """Return True if the server is available (IN_SERVICE), False otherwise."""
         status = self.cli.get_server_status()
         return status == "IN_SERVICE"
+
+    def _wait_for_server_in_service(self, timeout_seconds: int = 180, interval_seconds: int = 10) -> None:
+        """Poll server status until IN_SERVICE or timeout.
+
+        Args:
+            timeout: Maximum wait time in seconds (default: 5 minutes)
+            interval: Seconds between polls (default: 10)
+
+        Raises:
+            RuntimeError: If the server does not reach IN_SERVICE within timeout
+        """
+        elapsed = 0
+        while elapsed < timeout_seconds:
+            if self._is_server_available():
+                return
+            time.sleep(interval_seconds)
+            elapsed += interval_seconds
+        status = self.cli.get_server_status()
+        raise RuntimeError(f"Server did not reach IN_SERVICE within {timeout_seconds}s (last status: {status})")
 
     def _is_server_stopped(self) -> bool:
         """Return True if the server is stopped (STOPPED), False otherwise."""

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebooks/notebook_utils.py
@@ -358,6 +358,11 @@ def _build_session_with_cookies(page: Page) -> requests.Session:
             domain=cookie.get("domain", ""),
             path=cookie.get("path", "/"),
         )
+        # Jupyter requires the _xsrf cookie value echoed back as a header on
+        # mutating requests (PUT/POST/DELETE). GET is exempt, but without this
+        # header write operations return 403.
+        if cookie["name"] == "_xsrf":
+            session.headers["X-XSRFToken"] = cookie["value"]
     return session
 
 

--- a/scripts/config_base_from_ci.py
+++ b/scripts/config_base_from_ci.py
@@ -39,7 +39,7 @@ def main() -> None:
     if len(sys.argv) < 4:
         print("Usage: scripts/config_base.py <project-dir> <ci-dir> <oauth-app-num> [allowed-usernames]")
         print()
-        print("  project-dir:       Path to the base template project (from `just init-base`)")
+        print("  project-dir:       Path to the base template project (from `jd init`)")
         print("  ci-dir:            Path to the CI infrastructure project (from `just ci-restore`)")
         print("  oauth-app-num:     OAuth app number (1-5)")
         print("  allowed-usernames: JSON array of GitHub usernames (default: bot account email)")

--- a/scripts/env_setup_base.py
+++ b/scripts/env_setup_base.py
@@ -44,9 +44,9 @@ PROJECT_VAR_MAP = {
     "domain": "JD_E2E_VAR_DOMAIN",
     "subdomain": "JD_E2E_VAR_SUBDOMAIN",
     "letsencrypt_email": "JD_E2E_VAR_EMAIL",
-    "oauth_allowed_org": "JD_E2E_VAR_OAUTH_ALLOWED_ORG",
-    "oauth_allowed_teams": "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
-    "oauth_allowed_usernames": "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES",
+    # Auth variables (org, teams, usernames) are intentionally omitted —
+    # they're reset to clean defaults in step 1b to avoid reading stale
+    # state left by a previous failed test run.
 }
 
 # Mapping from option keys to env var names
@@ -244,18 +244,32 @@ def main() -> None:
             set_env_var(env_var, value)
             print(f"  {env_var}={value}")
 
-    # 1b. Set bot username as JD_E2E_USER (unless overridden by option)
+    # 1b. Derive bot username from CI and set JD_E2E_USER + allowed usernames
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "-p", ci_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    bot_email = result.stdout.strip()
+    bot_username = bot_email.split("@")[0] if "@" in bot_email else bot_email
+
     if "JD_E2E_USER" not in option_env_vars:
-        result = subprocess.run(
-            ["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "-p", ci_dir],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        bot_email = result.stdout.strip()
-        bot_username = bot_email.split("@")[0] if "@" in bot_email else bot_email
         set_env_var("JD_E2E_USER", bot_username)
         print(f"  JD_E2E_USER={bot_username} (from bot account)")
+
+    if "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES" not in option_env_vars:
+        allowed_usernames = json.dumps([bot_username])
+        set_env_var("JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES", allowed_usernames)
+        print(f"  JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES={allowed_usernames} (from bot account)")
+
+    if "JD_E2E_VAR_OAUTH_ALLOWED_ORG" not in option_env_vars:
+        set_env_var("JD_E2E_VAR_OAUTH_ALLOWED_ORG", "")
+        print("  JD_E2E_VAR_OAUTH_ALLOWED_ORG= (reset to empty)")
+
+    if "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS" not in option_env_vars:
+        set_env_var("JD_E2E_VAR_OAUTH_ALLOWED_TEAMS", "[]")
+        print("  JD_E2E_VAR_OAUTH_ALLOWED_TEAMS=[] (reset to empty)")
 
     # 2. Fetch OAuth credentials from CI infrastructure
     print(f"\nFetching OAuth app #{oauth_app_num} credentials from CI ({ci_dir})...")


### PR DESCRIPTION
This PR fixes various minor issues in the CI runs:
1. add `.github/README.d` to explain how to setup the ci, including grant permission to the oauth apps
2. add `just` method to create a base project from CI, and to create a ci project
3. fix issues in terraform logic to:
    3.1. ensure the `cloudinit` SSM document updates whenever the auth (usernames, org, teams) are changed
    3.2. do NOT overwrite the auth settings on host restart (ie no-op in `cloudinit` if /etcd auth file already exists
4. add waiter for server to be actually ready in plugin util, use in `test_application`
5. fix env vars handling in `just setup-env-base` to ignore current app state and use the CI settings instead

Also in this PR:
1. tighten up `oauth` container security by passing secrets as file instead of env var (visible w/ `docker inspect oauth`)
2. pass `cookie_refresh=1h` setting which re-verify that the user still belongs to the approved orgs/teams

### Testing
- clean webbrowser context (`.auth`), run the org/teams, users and application test against canary app