### PR TITLE
fix: just method regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,13 +77,15 @@ mypy_path = [
     "libs/jupyter-deploy-tf-aws-ec2-base",
     "libs/jupyter-infra-tf-aws-iam-ci",
     "libs/pytest-jupyter-deploy",
+    "scripts",
 ]
 plugins = ["pydantic.mypy"]
 files = [
     "libs/jupyter-deploy",
     "libs/jupyter-deploy-tf-aws-ec2-base",
     "libs/jupyter-infra-tf-aws-iam-ci",
-    "libs/pytest-jupyter-deploy"
+    "libs/pytest-jupyter-deploy",
+    "scripts",
 ]
 # E2E tests excluded: conftest.py (pytest magic name, can't rename) causes
 # "Duplicate module" errors across templates sharing the tests/e2e/ structure.

--- a/scripts/config_base_from_ci.py
+++ b/scripts/config_base_from_ci.py
@@ -32,7 +32,8 @@ def jd_variable_map(var_name: str, ci_dir: str) -> dict[str, str]:
         text=True,
         check=True,
     )
-    return ast.literal_eval(result.stdout.strip())
+    value: dict[str, str] = ast.literal_eval(result.stdout.strip())
+    return value
 
 
 def main() -> None:

--- a/scripts/find_takedown_base.py
+++ b/scripts/find_takedown_base.py
@@ -19,8 +19,8 @@ from pathlib import Path
 from ci_restore_base import (
     find_project_by_subdomain,
     get_subdomain_from_ci,
-    reconfigure_secret,
     restore_project,
+    restore_secrets,
 )
 
 
@@ -73,8 +73,8 @@ def main() -> None:
 
     restore_project(project_id, project_dir)
 
-    print("\nRe-populating OAuth client secret from CI...")
-    reconfigure_secret(ci_dir, oauth_app_num, project_dir)
+    print("\nRestoring secrets from cloud provider...")
+    restore_secrets(project_dir)
 
     takedown_project(project_dir)
     delete_project_from_store(project_id)


### PR DESCRIPTION
This PR fixes a regression in the CI / `just` methods introduced by #193 

It also add `mypy` coverage to `scripts/` dir, which would have caught the regression had it been configured properly.