### PR TITLE
feat: e2e docker build

### DIFF
--- a/.github/.e2e.dockerignore
+++ b/.github/.e2e.dockerignore
@@ -1,0 +1,11 @@
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+test-results
+.git
+.ruff_cache
+.mypy_cache
+sandbox*
+.auth
+.env

--- a/.github/Dockerfile.e2e
+++ b/.github/Dockerfile.e2e
@@ -1,0 +1,44 @@
+# CI-optimized E2E image: extends base image with Python deps, Playwright, and workspace code.
+#
+# Layer strategy (dep-first COPY):
+#   1. Copy dependency manifests only → uv sync (cached when deps unchanged)
+#   2. Install Playwright browsers (cached when version unchanged)
+#   3. Copy full workspace source (cheap, changes every run)
+#
+# The base image is built from libs/pytest-jupyter-deploy (system packages, Terraform, AWS CLI).
+# This image adds everything that `just e2e-sync` would normally install at runtime.
+
+ARG BASE_IMAGE=jupyter-deploy-e2e:latest
+FROM ${BASE_IMAGE}
+
+# --- Dependency layer (cached when uv.lock / pyproject.toml unchanged) ---
+# Copy manifests and create stub files that hatchling validates (LICENSE, README.md).
+# Stubs avoid copying actual content that would bust the cache on every edit.
+USER root
+COPY --chown=testuser:testuser uv.lock pyproject.toml /workspace/
+COPY --chown=testuser:testuser libs/jupyter-deploy/pyproject.toml /workspace/libs/jupyter-deploy/
+COPY --chown=testuser:testuser libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml /workspace/libs/jupyter-deploy-tf-aws-ec2-base/
+COPY --chown=testuser:testuser libs/jupyter-infra-tf-aws-iam-ci/pyproject.toml /workspace/libs/jupyter-infra-tf-aws-iam-ci/
+COPY --chown=testuser:testuser libs/pytest-jupyter-deploy/pyproject.toml /workspace/libs/pytest-jupyter-deploy/
+RUN for lib in jupyter-deploy jupyter-deploy-tf-aws-ec2-base jupyter-infra-tf-aws-iam-ci pytest-jupyter-deploy; do \
+        touch /workspace/libs/$lib/LICENSE /workspace/libs/$lib/README.md; \
+    done && chown -R testuser /workspace/libs
+USER testuser
+
+RUN cd /workspace && uv sync --all-packages
+
+# --- Playwright layer (cached when playwright version unchanged) ---
+RUN cd /workspace && uv run playwright install firefox && \
+    mkdir -p ~/.local/bin && \
+    ln -sf ~/.cache/ms-playwright/firefox-*/firefox/firefox ~/.local/bin/firefox
+
+# --- Source code layer (changes every run, but cheap) ---
+USER root
+COPY --chown=testuser:testuser . /workspace/
+USER testuser
+
+# Re-run uv sync to register the full source packages (editable installs).
+# The heavy download/build work was done above; this just updates .pth files.
+RUN cd /workspace && uv sync --all-packages
+
+CMD ["sleep", "infinity"]

--- a/.github/workflows/e2e-base-canary.yml
+++ b/.github/workflows/e2e-base-canary.yml
@@ -1,0 +1,18 @@
+name: E2E canary (base template)
+
+on:
+  schedule:
+    # Weekly: Sunday midnight UTC
+    - cron: '0 0 * * 0'
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  canary:
+    uses: ./.github/workflows/pr-e2e-base-fresh.yml
+    with:
+      oauth-app-num: "3"
+    secrets: inherit

--- a/.github/workflows/e2e-base-job.yml
+++ b/.github/workflows/e2e-base-job.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ""
+      ecr-tag:
+        description: "ECR image tag to pull (skip docker build + e2e-sync when set)"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   test:
@@ -86,6 +91,10 @@ jobs:
       - name: Ensure host is running
         run: just ensure-host-running sandbox-e2e
 
+      - name: Pull pre-built E2E image
+        if: inputs.ecr-tag != ''
+        run: just ci-e2e-pull ${{ inputs.oauth-app-num }} ${{ inputs.ecr-tag }}
+
       - name: Build test filter
         id: filter
         run: |
@@ -109,6 +118,9 @@ jobs:
           if [ "${{ inputs.mutate }}" = "true" ]; then
             OPTIONS="mutate=true,${OPTIONS}"
           fi
+          if [ -n "${{ inputs.ecr-tag }}" ]; then
+            OPTIONS="skip-build=true,${OPTIONS}"
+          fi
           echo "options=${OPTIONS}" >> "$GITHUB_OUTPUT"
 
       - name: Run E2E tests
@@ -125,3 +137,8 @@ jobs:
           name: test-results-${{ inputs.test-file-filter || 'non-mutating' }}
           path: test-results/
           if-no-files-found: ignore
+
+      - name: Upload test results to S3
+        if: failure()
+        continue-on-error: true
+        run: just ci-upload-test-results ${{ inputs.oauth-app-num }}

--- a/.github/workflows/e2e-build-image.yml
+++ b/.github/workflows/e2e-build-image.yml
@@ -1,0 +1,69 @@
+name: Build E2E image
+
+on:
+  workflow_call:
+    inputs:
+      oauth-app-num:
+        description: "OAuth app number (determines which ECR repo)"
+        required: true
+        type: string
+      ref:
+        description: "Git ref to checkout (default: triggering ref)"
+        required: false
+        type: string
+        default: ""
+    outputs:
+      ecr-tag:
+        description: "ECR image tag for test jobs to pull"
+        value: ${{ jobs.build.outputs.ecr-tag }}
+
+jobs:
+  build:
+    name: Build and push E2E image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      ecr-tag: ${{ github.sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Pull previous image for cache
+        run: just ci-e2e-pull ${{ inputs.oauth-app-num }} || true
+
+      - name: Build CI E2E image
+        run: |
+          ECR_URL=$(just ci-e2e-ecr-url ${{ inputs.oauth-app-num }})
+          just ci-e2e-build "$ECR_URL:latest"
+
+      - name: Push to ECR
+        run: just ci-e2e-push ${{ inputs.oauth-app-num }} ${{ github.sha }}

--- a/.github/workflows/pr-e2e-base-fresh.yml
+++ b/.github/workflows/pr-e2e-base-fresh.yml
@@ -1,6 +1,27 @@
 name: E2E base template (fresh deploy)
 
 on:
+  workflow_call:
+    inputs:
+      oauth-app-num:
+        description: "OAuth app number (1-3) — determines subdomain"
+        required: true
+        type: string
+      test-filter:
+        description: "Pytest -k filter (applied to all jobs, empty = all tests)"
+        required: false
+        type: string
+        default: ""
+      skip-deployment:
+        description: "Skip cleanup + deploy, run tests only (project must already be in S3)"
+        required: false
+        type: boolean
+        default: false
+      ref:
+        description: "Git ref to checkout (e.g. refs/pull/185/merge for a fork PR)"
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       oauth-app-num:
@@ -34,6 +55,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # --- Build E2E image (runs in parallel with cleanup) ---
+
+  build-image:
+    name: "Build E2E image"
+    uses: ./.github/workflows/e2e-build-image.yml
+    secrets: inherit
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      ref: ${{ inputs.ref }}
+
   # --- Deploy bookend ---
 
   cleanup-existing:
@@ -79,7 +110,7 @@ jobs:
 
   deploy:
     name: "Deploy from scratch"
-    needs: cleanup-existing
+    needs: [build-image, cleanup-existing]
     if: ${{ !inputs.skip-deployment }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -124,8 +155,11 @@ jobs:
       - name: Import auth state
         run: just auth-import sandbox-ci
 
+      - name: Pull pre-built E2E image
+        run: just ci-e2e-pull ${{ inputs.oauth-app-num }} ${{ needs.build-image.outputs.ecr-tag }}
+
       - name: Deploy and verify
-        run: just test-e2e-base sandbox-e2e "test_deployment" "mutate=true,ci-dir=sandbox-ci"
+        run: just test-e2e-base sandbox-e2e "test_deployment" "mutate=true,skip-build=true,ci-dir=sandbox-ci"
 
       - name: Export auth state
         if: always()
@@ -139,11 +173,16 @@ jobs:
           path: test-results/
           if-no-files-found: ignore
 
+      - name: Upload test results to S3
+        if: failure()
+        continue-on-error: true
+        run: just ci-upload-test-results ${{ inputs.oauth-app-num }}
+
   # --- Gate: allows test chain to start when deploy succeeded or was skipped ---
 
   deploy-gate:
     name: "Deploy gate"
-    needs: [cleanup-existing, deploy]
+    needs: [build-image, cleanup-existing, deploy]
     if: always() && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -163,76 +202,82 @@ jobs:
 
   test-non-mutating:
     name: "Non-mutating tests"
-    needs: deploy-gate
+    needs: [build-image, deploy-gate]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       timeout-minutes: 120
 
   test-external-volumes:
     name: "Mutating: external volumes"
-    needs: test-non-mutating
+    needs: [build-image, test-non-mutating]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_external_volumes
       mutate: true
       timeout-minutes: 30
 
   test-config-apply:
     name: "Mutating: config apply"
-    needs: test-external-volumes
+    needs: [build-image, test-external-volumes]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_config_apply
       mutate: true
       timeout-minutes: 30
 
   test-gpu:
     name: "Mutating: GPU"
-    needs: test-config-apply
+    needs: [build-image, test-config-apply]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_gpu
       mutate: true
       timeout-minutes: 60
 
   test-pixi:
     name: "Mutating: pixi"
-    needs: test-gpu
+    needs: [build-image, test-gpu]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_pixi
       mutate: true
       timeout-minutes: 60
 
   test-uv:
     name: "Mutating: uv"
-    needs: test-pixi
+    needs: [build-image, test-pixi]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_uv
       mutate: true
       timeout-minutes: 60

--- a/.github/workflows/pr-e2e-base.yml
+++ b/.github/workflows/pr-e2e-base.yml
@@ -29,77 +29,92 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build-image:
+    name: "Build E2E image"
+    uses: ./.github/workflows/e2e-build-image.yml
+    secrets: inherit
+    with:
+      oauth-app-num: ${{ inputs.oauth-app-num }}
+      ref: ${{ inputs.ref }}
+
   test-non-mutating:
     name: "Non-mutating tests"
+    needs: build-image
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       timeout-minutes: 120
 
   test-external-volumes:
     name: "Mutating: external volumes"
-    needs: test-non-mutating
+    needs: [build-image, test-non-mutating]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_external_volumes
       mutate: true
       timeout-minutes: 30
 
   test-config-apply:
     name: "Mutating: config apply"
-    needs: test-external-volumes
+    needs: [build-image, test-external-volumes]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_config_apply
       mutate: true
       timeout-minutes: 30
 
   test-gpu:
     name: "Mutating: GPU"
-    needs: test-config-apply
+    needs: [build-image, test-config-apply]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_gpu
       mutate: true
       timeout-minutes: 60
 
   test-pixi:
     name: "Mutating: pixi"
-    needs: test-gpu
+    needs: [build-image, test-gpu]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_pixi
       mutate: true
       timeout-minutes: 60
 
   test-uv:
     name: "Mutating: uv"
-    needs: test-pixi
+    needs: [build-image, test-pixi]
     uses: ./.github/workflows/e2e-base-job.yml
     secrets: inherit
     with:
       oauth-app-num: ${{ inputs.oauth-app-num }}
       test-filter: ${{ inputs.test-filter }}
       ref: ${{ inputs.ref }}
+      ecr-tag: ${{ needs.build-image.outputs.ecr-tag }}
       test-file-filter: test_uv
       mutate: true
       timeout-minutes: 60

--- a/justfile
+++ b/justfile
@@ -204,9 +204,13 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         fi
     fi
 
-    # Parse ci-dir from options early (needed for override file)
+    # Parse skip-build and ci-dir from options early (needed before compose up)
+    SKIP_BUILD="false"
     CI_DIR=""
     OPTIONS_STR_EARLY="{{options}}"
+    if echo "$OPTIONS_STR_EARLY" | grep -q "skip-build=true"; then
+        SKIP_BUILD="true"
+    fi
     if echo "$OPTIONS_STR_EARLY" | grep -qE "ci-dir="; then
         CI_DIR=$(echo "$OPTIONS_STR_EARLY" | grep -oE "ci-dir=[^,]+" | cut -d'=' -f2)
         if [ ! -d "$CI_DIR" ]; then
@@ -234,9 +238,13 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
     {{container-tool}} compose --project-directory {{justfile_directory()}} -f {{e2e-compose-file}} down
     {{container-tool}} compose --project-directory {{justfile_directory()}} -f {{e2e-compose-file}} -f "$OVERRIDE_FILE" up -d
 
-    # Re-sync files after restart (container loses synced files when restarted)
-    echo "Re-syncing project files after mount..."
-    just e2e-sync
+    if [ "$SKIP_BUILD" != "true" ]; then
+        # Re-sync files after restart (container loses synced files when restarted)
+        echo "Re-syncing project files after mount..."
+        just e2e-sync
+    else
+        echo "Skipping e2e-sync (using pre-built image)"
+    fi
 
     # Check if container is running
     if ! {{container-tool}} ps --filter "name={{e2e-container-name}}" --format "{{{{.Status}}}}" | grep -q "Up"; then
@@ -291,7 +299,7 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         echo "Options: $OPTIONS_STR"
 
         # List of recognized options (for validation)
-        RECOGNIZED_OPTIONS="mutate destroy log-level ci-dir"
+        RECOGNIZED_OPTIONS="mutate destroy log-level ci-dir skip-build"
 
         # Validate all options are recognized
         IFS=',' read -ra OPTS <<< "$OPTIONS_STR"
@@ -339,6 +347,12 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         if [ -n "$CI_DIR" ]; then
             PYTEST_ARGS="$PYTEST_ARGS --ci --ci-dir $CI_DIR"
             echo "  - CI mode: enabled (ci-dir=$CI_DIR)"
+        fi
+
+        # Parse skip-build option (use pre-built image, skip docker build + e2e-sync)
+        if echo "$OPTIONS_STR" | grep -q "skip-build=true"; then
+            SKIP_BUILD="true"
+            echo "  - skip-build: enabled (using pre-built image)"
         fi
     fi
 
@@ -638,6 +652,115 @@ auth-bot-email ci_dir="sandbox-ci":
 # Print the GitHub bot account username (email prefix before @)
 auth-bot-username ci_dir="sandbox-ci":
     @just auth-bot-email {{ci_dir}} | cut -d'@' -f1
+
+# Get the ECR repository URL for a given OAuth app number
+ci-e2e-ecr-url oauth_app_num ci_dir="sandbox-ci":
+    @uv run jd show -o ecr_repository_url_{{oauth_app_num}} --text -p {{ci_dir}}
+
+# Get the test results S3 bucket name
+ci-test-results-bucket ci_dir="sandbox-ci":
+    @uv run jd show -o test_results_bucket_name --text -p {{ci_dir}}
+
+# Upload test results to S3
+# Usage: just ci-upload-test-results <oauth-app-num> [ci-dir] [results-dir]
+ci-upload-test-results oauth_app_num ci_dir="sandbox-ci" results_dir="test-results":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ ! -d "{{results_dir}}" ] || [ -z "$(ls -A {{results_dir}} 2>/dev/null)" ]; then
+        echo "No test results to upload ({{results_dir}} is empty or missing)"
+        exit 0
+    fi
+
+    TIMESTAMP=$(date -u +"%Y-%m-%d-%H-%M")
+    BUCKET=$(just ci-test-results-bucket {{ci_dir}})
+    S3_PATH="s3://${BUCKET}/${TIMESTAMP}/{{oauth_app_num}}/"
+
+    echo "Uploading test results to ${S3_PATH}..."
+    aws s3 cp "{{results_dir}}/" "$S3_PATH" --recursive
+    echo "✓ Uploaded to ${S3_PATH}"
+
+# Build the CI E2E image (base + workspace code + deps + playwright baked in)
+# This replaces `just e2e-up` + `just e2e-sync` with a single self-contained image.
+# Usage: just ci-e2e-build                          # local: no cache
+# Usage: just ci-e2e-build <ecr-url>:latest         # CI: use ECR :latest as layer cache
+ci-e2e-build cache_from="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    BASE_DOCKERFILE=$(uv run python -c \
+        "from pytest_jupyter_deploy.image import IMAGE_PATH; print(IMAGE_PATH / 'Dockerfile')")
+    BASE_DIR=$(dirname "$BASE_DOCKERFILE")
+
+    echo "Building base E2E image..."
+    {{container-tool}} build \
+        -f "$BASE_DOCKERFILE" \
+        --build-arg USER_UID={{HOST_UID}} \
+        --build-arg USER_GID={{HOST_GID}} \
+        -t jupyter-deploy-e2e:base \
+        "$BASE_DIR"
+
+    echo "Building CI E2E image..."
+    CACHE_ARG=""
+    if [ -n "{{cache_from}}" ]; then
+        CACHE_ARG="--cache-from={{cache_from}}"
+        echo "Using cache from: {{cache_from}}"
+    fi
+
+    {{container-tool}} build \
+        -f .github/Dockerfile.e2e \
+        --build-arg BASE_IMAGE=jupyter-deploy-e2e:base \
+        $CACHE_ARG \
+        -t jupyter-deploy-e2e:latest \
+        .
+
+    echo "✓ CI E2E image built: jupyter-deploy-e2e:latest"
+
+# Push the CI E2E image to ECR
+# Usage: just ci-e2e-push <oauth-app-num> [extra-tag]
+# Pushes as :latest, and also as :<extra-tag> if provided (e.g. git sha)
+ci-e2e-push oauth_app_num extra_tag="" ci_dir="sandbox-ci":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    ECR_URL=$(just ci-e2e-ecr-url {{oauth_app_num}} {{ci_dir}})
+    ECR_REGISTRY=$(echo "$ECR_URL" | cut -d'/' -f1)
+    REGION=$(uv run jd show -o region --text -p {{ci_dir}})
+
+    echo "Logging in to ECR..."
+    aws ecr get-login-password --region "$REGION" \
+        | {{container-tool}} login --username AWS --password-stdin "$ECR_REGISTRY"
+
+    echo "Pushing to $ECR_URL..."
+    {{container-tool}} tag jupyter-deploy-e2e:latest "$ECR_URL:latest"
+    {{container-tool}} push "$ECR_URL:latest"
+
+    if [ -n "{{extra_tag}}" ]; then
+        {{container-tool}} tag jupyter-deploy-e2e:latest "$ECR_URL:{{extra_tag}}"
+        {{container-tool}} push "$ECR_URL:{{extra_tag}}"
+        echo "✓ Pushed $ECR_URL:latest and $ECR_URL:{{extra_tag}}"
+    else
+        echo "✓ Pushed $ECR_URL:latest"
+    fi
+
+# Pull a CI E2E image from ECR and tag as jupyter-deploy-e2e:latest
+# Usage: just ci-e2e-pull <oauth-app-num> [tag]
+ci-e2e-pull oauth_app_num tag="latest" ci_dir="sandbox-ci":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    ECR_URL=$(just ci-e2e-ecr-url {{oauth_app_num}} {{ci_dir}})
+    ECR_REGISTRY=$(echo "$ECR_URL" | cut -d'/' -f1)
+    REGION=$(uv run jd show -o region --text -p {{ci_dir}})
+
+    echo "Logging in to ECR..."
+    aws ecr get-login-password --region "$REGION" \
+        | {{container-tool}} login --username AWS --password-stdin "$ECR_REGISTRY"
+
+    echo "Pulling $ECR_URL:{{tag}}..."
+    {{container-tool}} pull "$ECR_URL:{{tag}}"
+    {{container-tool}} tag "$ECR_URL:{{tag}}" jupyter-deploy-e2e:latest
+    echo "✓ Pulled and tagged as jupyter-deploy-e2e:latest"
 
 # Generate .env for base template E2E tests
 # Two modes:

--- a/libs/jupyter-infra-tf-aws-iam-ci/README.md
+++ b/libs/jupyter-infra-tf-aws-iam-ci/README.md
@@ -3,7 +3,8 @@
 The Jupyter Deploy AWS IAM CI template is an open-source infrastructure template that manages
 AWS resources needed by the E2E CI pipeline for [jupyter-deploy](https://github.com/jupyter-infra/jupyter-deploy).
 It uses Terraform as the infrastructure-as-code engine and creates IAM roles for GitHub Actions OIDC federation,
-Secrets Manager secrets for sensitive CI data, and SSM parameters for non-secret configuration.
+Secrets Manager secrets for sensitive CI data, SSM parameters for non-secret configuration,
+ECR repositories for pre-built E2E test images, and an S3 bucket for test result storage.
 
 This template creates two IAM roles (E2E and release), each scoped to a specific GitHub Actions environment
 via OIDC trust policies. The roles are hardened with deny statements that prevent self-modification
@@ -75,6 +76,8 @@ This project:
 - seeds secret values via `local-exec` provisioner to keep them out of Terraform state
 - applies resource-based deny policies on OAuth client secrets (deny write except maintainers)
 - applies resource-based deny policies on bot account secrets (deny all except maintainers)
+- creates 5 ECR repositories for pre-built E2E test container images (one per OAuth app, KMS-encrypted, lifecycle policy keeps last 5 images)
+- creates an S3 bucket for E2E test result uploads (KMS-encrypted, public access blocked, 90-day object expiration)
 - tags all resources with `Source`, `Template`, `Version`, and `DeploymentId`
 
 ## Requirements
@@ -94,6 +97,8 @@ This project:
 | `iam_role` | `template/engine/modules/iam_role` |
 | `secret` | `template/engine/modules/secret` |
 | `ssm_parameter` | `template/engine/modules/ssm_parameter` |
+| `ecr_repository` | `template/engine/modules/ecr_repository` |
+| `s3_bucket` | `template/engine/modules/s3_bucket` |
 
 ## Resources
 | Name | Type |
@@ -106,6 +111,12 @@ This project:
 | [aws_secretsmanager_secret_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
 | [aws_ssm_parameter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [aws_ecr_repository](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_ecr_lifecycle_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_partition](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -127,6 +138,7 @@ This project:
 | github_bot_account_totp_secret | `string` | Required (sensitive) | TOTP seed (base32) for the GitHub bot account 2FA |
 | github_oauth_app_1..5 | `map(string)` | Required | OAuth app metadata: client_id, app_id, app_url, callback_url |
 | github_oauth_app_client_secret_1..5 | `string` | Required (sensitive) | GitHub OAuth app client secrets |
+| test_results_bucket_prefix | `string` | `jd-ci-e2e-results` | Prefix for the S3 bucket that stores E2E test results (3-28 chars) |
 
 ## Outputs
 | Name | Description |
@@ -142,6 +154,8 @@ This project:
 | `github_bot_account_email_arn` | ARN of the SSM parameter for GitHub bot account email |
 | `github_oauth_app_client_id_1..5_arn` | ARNs of the SSM parameters for OAuth app client IDs |
 | `github_oauth_app_client_secret_1..5_arn` | ARNs of the secrets for OAuth app client secrets |
+| `ecr_repository_url_1..5` | URLs of the ECR repositories for pre-built E2E test images |
+| `test_results_bucket_name` | Name of the S3 bucket for E2E test result uploads |
 
 ## License
 

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/ecr.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/ecr.tf
@@ -1,0 +1,48 @@
+# ECR repositories for pre-built E2E test container images (1 per OAuth app).
+# Each OAuth app maps to a concurrency group, so separate repos prevent
+# image tag conflicts between concurrent workflow runs.
+
+module "ecr_e2e_image_1" {
+  source = "./modules/ecr_repository"
+  name   = "${var.secret_name_prefix}-${local.doc_postfix}/e2e-image-1"
+  tags = merge(local.default_tags, {
+    OAuthAppId  = var.github_oauth_app_1["app_id"]
+    CallbackUrl = var.github_oauth_app_1["callback_url"]
+  })
+}
+
+module "ecr_e2e_image_2" {
+  source = "./modules/ecr_repository"
+  name   = "${var.secret_name_prefix}-${local.doc_postfix}/e2e-image-2"
+  tags = merge(local.default_tags, {
+    OAuthAppId  = var.github_oauth_app_2["app_id"]
+    CallbackUrl = var.github_oauth_app_2["callback_url"]
+  })
+}
+
+module "ecr_e2e_image_3" {
+  source = "./modules/ecr_repository"
+  name   = "${var.secret_name_prefix}-${local.doc_postfix}/e2e-image-3"
+  tags = merge(local.default_tags, {
+    OAuthAppId  = var.github_oauth_app_3["app_id"]
+    CallbackUrl = var.github_oauth_app_3["callback_url"]
+  })
+}
+
+module "ecr_e2e_image_4" {
+  source = "./modules/ecr_repository"
+  name   = "${var.secret_name_prefix}-${local.doc_postfix}/e2e-image-4"
+  tags = merge(local.default_tags, {
+    OAuthAppId  = var.github_oauth_app_4["app_id"]
+    CallbackUrl = var.github_oauth_app_4["callback_url"]
+  })
+}
+
+module "ecr_e2e_image_5" {
+  source = "./modules/ecr_repository"
+  name   = "${var.secret_name_prefix}-${local.doc_postfix}/e2e-image-5"
+  tags = merge(local.default_tags, {
+    OAuthAppId  = var.github_oauth_app_5["app_id"]
+    CallbackUrl = var.github_oauth_app_5["callback_url"]
+  })
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/ecr_repository/main.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/ecr_repository/main.tf
@@ -1,0 +1,33 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [{
+      rulePriority = 1
+      description  = "Keep last ${var.max_image_count} images"
+      selection = {
+        tagStatus   = "any"
+        countType   = "imageCountMoreThan"
+        countNumber = var.max_image_count
+      }
+      action = {
+        type = "expire"
+      }
+    }]
+  })
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/ecr_repository/outputs.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/ecr_repository/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_url" {
+  description = "URL of the ECR repository."
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  description = "ARN of the ECR repository."
+  value       = aws_ecr_repository.this.arn
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/ecr_repository/variables.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/ecr_repository/variables.tf
@@ -1,0 +1,15 @@
+variable "name" {
+  description = "Name of the ECR repository."
+  type        = string
+}
+
+variable "max_image_count" {
+  description = "Maximum number of images to retain. Older images are expired by the lifecycle policy."
+  type        = number
+  default     = 5
+}
+
+variable "tags" {
+  description = "Tags to apply to the repository."
+  type        = map(string)
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/s3_bucket/main.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/s3_bucket/main.tf
@@ -1,0 +1,44 @@
+resource "aws_s3_bucket" "this" {
+  bucket_prefix = var.bucket_name_prefix
+  force_destroy = var.force_destroy
+
+  tags = merge(
+    var.tags,
+    {
+      Name = var.bucket_name_prefix
+    }
+  )
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  count  = var.expiration_days > 0 ? 1 : 0
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    id     = "expire-after-${var.expiration_days}-days"
+    status = "Enabled"
+
+    expiration {
+      days = var.expiration_days
+    }
+  }
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/s3_bucket/outputs.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/s3_bucket/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "The name of the S3 bucket."
+  value       = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the S3 bucket."
+  value       = aws_s3_bucket.this.arn
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/s3_bucket/variables.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/modules/s3_bucket/variables.tf
@@ -1,0 +1,39 @@
+variable "bucket_name_prefix" {
+  description = <<-EOT
+    The prefix for the S3 bucket name. AWS will append a random suffix to ensure global uniqueness.
+    Must be lowercase alphanumeric with hyphens, 3-37 characters, cannot start or end with hyphen.
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.bucket_name_prefix))
+    error_message = "The bucket_name_prefix must contain only lowercase alphanumeric characters and hyphens."
+  }
+
+  validation {
+    condition     = can(regex("^[a-z0-9].*[a-z0-9]$", var.bucket_name_prefix))
+    error_message = "The bucket_name_prefix cannot start or end with a hyphen."
+  }
+
+  validation {
+    condition     = length(var.bucket_name_prefix) >= 3 && length(var.bucket_name_prefix) <= 37
+    error_message = "The bucket_name_prefix must be between 3 and 37 characters (AWS limit for bucket_prefix)."
+  }
+}
+
+variable "force_destroy" {
+  description = "Whether to force destroy the bucket even if it contains objects."
+  type        = bool
+  default     = true
+}
+
+variable "expiration_days" {
+  description = "Number of days after which objects are automatically deleted. Set to 0 to disable."
+  type        = number
+  default     = 0
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources."
+  type        = map(string)
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/outputs.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/outputs.tf
@@ -99,3 +99,35 @@ output "github_oauth_app_client_secret_5_arn" {
   description = "ARN of the Secrets Manager secret for GitHub OAuth app #5 client secret."
   value       = module.github_oauth_app_client_secret_5.secret_arn
 }
+
+# ECR repositories for pre-built E2E images (x5)
+output "ecr_repository_url_1" {
+  description = "URL of the ECR repository for E2E image (OAuth app #1)."
+  value       = module.ecr_e2e_image_1.repository_url
+}
+
+output "ecr_repository_url_2" {
+  description = "URL of the ECR repository for E2E image (OAuth app #2)."
+  value       = module.ecr_e2e_image_2.repository_url
+}
+
+output "ecr_repository_url_3" {
+  description = "URL of the ECR repository for E2E image (OAuth app #3)."
+  value       = module.ecr_e2e_image_3.repository_url
+}
+
+output "ecr_repository_url_4" {
+  description = "URL of the ECR repository for E2E image (OAuth app #4)."
+  value       = module.ecr_e2e_image_4.repository_url
+}
+
+output "ecr_repository_url_5" {
+  description = "URL of the ECR repository for E2E image (OAuth app #5)."
+  value       = module.ecr_e2e_image_5.repository_url
+}
+
+# S3 bucket for E2E test results
+output "test_results_bucket_name" {
+  description = "Name of the S3 bucket for E2E test result uploads."
+  value       = module.test_results_bucket.bucket_name
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/presets/defaults-all.tfvars
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/presets/defaults-all.tfvars
@@ -1,6 +1,7 @@
 region                       = "us-east-1"
 secret_name_prefix           = "jupyter-infra-ci"
 github_ci_iam_roles_prefix   = "jupyter-infra-ci"
+test_results_bucket_prefix   = "jd-ci-e2e-results"
 create_oidc_provider         = true
 iam_managed_policies_e2e     = ["AdministratorAccess"]
 iam_managed_policies_release = ["AdministratorAccess"]

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/s3.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/s3.tf
@@ -1,0 +1,9 @@
+# S3 bucket for E2E test result uploads (screenshots from failed tests).
+# Objects expire after 90 days to keep storage costs bounded.
+
+module "test_results_bucket" {
+  source             = "./modules/s3_bucket"
+  bucket_name_prefix = "${var.test_results_bucket_prefix}-${local.doc_postfix}"
+  expiration_days    = 90
+  tags               = local.default_tags
+}

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/secrets_policy.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/secrets_policy.tf
@@ -122,8 +122,10 @@ resource "aws_secretsmanager_secret_policy" "bot_protected_restricted" {
         }
       },
       {
-        # Explicit action list — deliberately excludes PutResourcePolicy/DeleteResourcePolicy
-        # (to avoid locking out access permanently; policy-edit is denied on GitHub roles
+        # Explicit action list — deliberately excludes DescribeSecret (needed
+        # by CI for Terraform state refresh), ListSecretVersionIds (read-only
+        # metadata), and PutResourcePolicy/DeleteResourcePolicy (to avoid
+        # locking out access permanently; policy-edit is denied on GitHub roles
         # via identity-based policy).
         Sid       = "DenyWriteExceptMaintainers"
         Effect    = "Deny"

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/variables.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/variables.tf
@@ -110,6 +110,35 @@ variable "create_oidc_provider" {
   type        = bool
 }
 
+variable "test_results_bucket_prefix" {
+  description = <<-EOT
+    Prefix for the S3 bucket that stores E2E test results (screenshots from failed tests).
+
+    Terraform will append the deployment ID and AWS will append a random suffix
+    to ensure global uniqueness across all AWS accounts.
+
+    Must be lowercase alphanumeric with hyphens, 3-28 characters, cannot start or end with hyphen.
+
+    Example: jd-ci-e2e-results
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.test_results_bucket_prefix))
+    error_message = "The test_results_bucket_prefix must contain only lowercase alphanumeric characters and hyphens."
+  }
+
+  validation {
+    condition     = can(regex("^[a-z0-9].*[a-z0-9]$", var.test_results_bucket_prefix))
+    error_message = "The test_results_bucket_prefix cannot start or end with a hyphen."
+  }
+
+  validation {
+    condition     = length(var.test_results_bucket_prefix) >= 3 && length(var.test_results_bucket_prefix) <= 28
+    error_message = "The test_results_bucket_prefix must be between 3 and 28 characters to allow for the deployment ID suffix (max 37 characters for bucket_prefix)."
+  }
+}
+
 variable "github_bot_account_email" {
   description = <<-EOT
     Email address of the GitHub bot account used by E2E CI.

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/variables.yaml
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/variables.yaml
@@ -37,3 +37,4 @@ defaults:
   iam_managed_policies_e2e: ["AdministratorAccess"]
   iam_managed_policies_release: ["AdministratorAccess"]
   maintainer_roles: ["Admin"]
+  test_results_bucket_prefix: jd-ci-e2e-results

--- a/libs/jupyter-infra-tf-aws-iam-ci/tests/e2e/configurations/base.yaml
+++ b/libs/jupyter-infra-tf-aws-iam-ci/tests/e2e/configurations/base.yaml
@@ -50,3 +50,4 @@ defaults:
   iam_managed_policies_e2e: ["AdministratorAccess"]
   iam_managed_policies_release: ["AdministratorAccess"]
   maintainer_roles: ["Admin"]
+  test_results_bucket_prefix: jd-ci-e2e-results


### PR DESCRIPTION
This PR updates the CI template, adds utilities and updates github workflows to build the `jupyter-deploy-e2e` test image only once and reuse in subsequent jobs of the workflow. This avoids having to rebuild at each step.

### Implementation
1. update to `ci` template:
    1.1. add `/modules/ecr` to `ci` template w/ life-cycle policy (keep latest 5 images), service-managed kms encryption
    1.2. add `/modules/s3` to `ci` template w/ life-cycle policy (90 days), service-managed kms encryption, unique bucket name
    1.3. add `outputs.tf`, `variables.tf` and update `variables.yaml`
    1.4. update `README.md` to reflect the changes
2. add `just` methods
    2.1. to retrieve the ECR repo URL from a/ local sandbox dir and b/ app-num
    2.2. to retrieve the bucket name from sandbox dir
    2.3. to build / push / pull ECR image based on a/ local sandbox dir, b/ app-num
    2.4. to upload artifacts to test results bucket
3. update github workflows
    3.1. add a `Dockerfile` in `.github`, which copies over the current state of the repo files
    3.2. first, build the e2e image & push it to the corresponding ECR
    3.3. all test steps then just `docker pull` the image instead of building
    3.4. on failure, attempts to push to the test results S3 bucket
4. add a base-canary workflow that triggers the fresh deploy weekly on app 3 w/ a cron schedule
    
### Testing
- update the ci template in the ci account
- pushed to a branch (now deleted), verified [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/24145431819)