### PR TITLE
release: v0.5.0

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/__init__.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/__init__.py
@@ -4,4 +4,4 @@ Relies on traefik for proxy, letsencrypt to generate the TLS certificate
 and external oauth provider.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.5.0"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/main.tf
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/engine/main.tf
@@ -15,7 +15,7 @@ resource "random_id" "postfix" {
 
 locals {
   template_name    = "tf-aws-ec2-base"
-  template_version = "0.4.2"
+  template_version = "0.5.0"
 
   default_tags = {
     Source       = "jupyter-deploy"

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/manifest.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 template:
   name: tf-aws-ec2-base
   engine: terraform
-  version: 0.4.2
+  version: 0.5.0
 requirements:
 - name: terraform
 - name: awscli

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pixi.jupyter.toml.tftpl
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pixi.jupyter.toml.tftpl
@@ -11,7 +11,7 @@ platforms = [
     "linux-64",
 %{ endif ~}
 ]
-version = "0.4.2"
+version = "0.5.0"
 
 [tasks]
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pyproject.kernel.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter-pixi/pyproject.kernel.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-uv-kernel"
-version = "0.4.2"
+version = "0.5.0"
 description = "A jupyter kernel configuration managed by UV"
 requires-python = ">=3.12"
 dependencies = [

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter"
-version = "0.4.2"
+version = "0.5.0"
 description = "A basic image with jupyterlab and server-documents"
 requires-python = ">=3.12"
 dependencies = [

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.kernel.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.kernel.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-kernel"
-version = "0.4.2"
+version = "0.5.0"
 description = "A placeholder additional jupyter kernel configuration"
 requires-python = ">=3.12"
 dependencies = []

--- a/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-tf-aws-ec2-base"
-version = "0.4.2"
+version = "0.5.0"
 description = "Base terraform template to deploy a JupyterLab application on an AWS EC2 instance."
 readme = "README.md"
 authors = [

--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy"
-version = "0.4.2"
+version = "0.5.0"
 description = "CLI based tool to deploy Jupyter applications that integrates with infrastructure as code frameworks."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/libs/pytest-jupyter-deploy/pyproject.toml
+++ b/libs/pytest-jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-jupyter-deploy"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pytest plugin for E2E testing of jupyter-deploy templates"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-monorepo"
-version = "0.4.2"
+version = "0.5.0"
 description = "Monorepo for Jupyter deploy packages"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -367,7 +367,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-deploy"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "libs/jupyter-deploy" }
 dependencies = [
     { name = "click" },
@@ -439,7 +439,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-monorepo"
-version = "0.4.2"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jupyter-deploy", extra = ["aws"] },
@@ -486,7 +486,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-tf-aws-ec2-base"
-version = "0.4.2"
+version = "0.5.0"
 source = { editable = "libs/jupyter-deploy-tf-aws-ec2-base" }
 dependencies = [
     { name = "boto3" },
@@ -981,7 +981,7 @@ wheels = [
 
 [[package]]
 name = "pytest-jupyter-deploy"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "libs/pytest-jupyter-deploy" }
 dependencies = [
     { name = "jupyter-deploy" },


### PR DESCRIPTION
Release PR for:
- jupyter-deploy: 0.4.2 -> 0.5.0
- pytest-jupyter-deploy: 0.1.0 -> 0.2.0
- jupyter-deploy-tf-aws-ec2-base: 0.4.2 -> 0.5.0

Order of release:
- pytest plugin
- jupyter-deploy

Then we will need further testing now that the base template E2E tests in the release flow.