### PR TITLE
fix: release step skip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,7 @@ jobs:
   mark-release:
     name: Create GitHub Release
     needs: [prod-pypi-publish, build]
+    if: always() && needs.prod-pypi-publish.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This PR fixes the configuration to ensure the `Create Release` step is no longer skipped on release.

See [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/24360178305) 