### PR TITLE
Chore/release configs

### DIFF
--- a/.github/AGENT.md
+++ b/.github/AGENT.md
@@ -6,10 +6,13 @@
 |----------|---------|---------|
 | `ci.yml` | push/PR | Lint + unit tests |
 | `lint.yml`, `test.yml` | `workflow_call` | Reusable lint/test jobs |
-| `release.yml` | `workflow_dispatch` | Publish one of the packages to PyPI |
+| `release-cli.yml` | `workflow_dispatch` | Release `jupyter-deploy` CLI to PyPI (with E2E gate) |
+| `release-base.yml` | `workflow_dispatch` | Release `jupyter-deploy-tf-aws-ec2-base` to PyPI (with E2E gate) |
+| `release-plugin.yml` | `workflow_dispatch` | Release `pytest-jupyter-deploy` to PyPI |
+| `e2e-cli.yml` | `workflow_call` | CLI release E2E gate — smoke tests + functional tests against app #2 |
 | `e2e-base.yml` | `workflow_dispatch` | E2E tests against an existing deployment |
 | `e2e-base-fresh.yml` | `workflow_dispatch` / `workflow_call` | Deploy from scratch + full E2E chain |
-| `e2e-base-release.yml` | `workflow_call` | Release gate — calls fresh workflow with Test PyPI install |
+| `e2e-base-release.yml` | `workflow_call` | Base template release E2E gate — calls fresh workflow with Test PyPI install |
 | `e2e-base-canary.yml` | `schedule` / `workflow_dispatch` | Weekly canary — calls fresh workflow |
 | `e2e-base-job.yml` | `workflow_call` | Reusable E2E job (called by the above) |
 

--- a/.github/e2e-cli/Dockerfile
+++ b/.github/e2e-cli/Dockerfile
@@ -1,0 +1,81 @@
+# CI-optimized E2E image for CLI release testing.
+# Extends base image with Python deps, Playwright, and workspace code.
+#
+# Layer strategy (dep-first COPY):
+#   1. Copy dependency manifests only → uv sync (cached when deps unchanged)
+#   2. Install Playwright browsers (cached when version unchanged)
+#   3. Copy full workspace source (cheap, changes every run)
+#
+# The base image is built from libs/pytest-jupyter-deploy (system packages, Terraform, AWS CLI).
+# This image adds everything that `just e2e-sync` would normally install at runtime.
+
+ARG BASE_IMAGE=jupyter-deploy-e2e:latest
+FROM ${BASE_IMAGE}
+
+# Install mode: "workspace" (default) installs from local source via uv sync.
+# "pypi" installs the CLI from Test PyPI using a template pyproject.
+ARG INSTALL_MODE=workspace
+# Install variant (only applies when INSTALL_MODE=pypi):
+#   "bare" — CLI only, no AWS deps, no template
+#   "aws"  — CLI with [aws] extra + base template from workspace
+ARG INSTALL_VARIANT=aws
+ARG PKG_VERSION=""
+ARG EXTRA_INDEX_URL=https://test.pypi.org/simple/
+
+# --- Dependency layer (cached when pyproject.toml unchanged) ---
+# Copy manifests and create stub files that hatchling validates (LICENSE, README.md).
+# Stubs avoid copying actual content that would bust the cache on every edit.
+# No uv.lock — resolve deps freely to match what users get on `pip install`.
+USER root
+COPY --chown=testuser:testuser pyproject.toml /workspace/
+COPY --chown=testuser:testuser libs/jupyter-deploy/pyproject.toml /workspace/libs/jupyter-deploy/
+COPY --chown=testuser:testuser libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml /workspace/libs/jupyter-deploy-tf-aws-ec2-base/
+COPY --chown=testuser:testuser libs/jupyter-infra-tf-aws-iam-ci/pyproject.toml /workspace/libs/jupyter-infra-tf-aws-iam-ci/
+COPY --chown=testuser:testuser libs/pytest-jupyter-deploy/pyproject.toml /workspace/libs/pytest-jupyter-deploy/
+RUN for lib in jupyter-deploy jupyter-deploy-tf-aws-ec2-base jupyter-infra-tf-aws-iam-ci pytest-jupyter-deploy; do \
+        touch /workspace/libs/$lib/LICENSE /workspace/libs/$lib/README.md; \
+    done && chown -R testuser /workspace/libs
+USER testuser
+
+RUN cd /workspace && uv sync --all-packages
+
+# --- Playwright layer (cached when playwright version unchanged) ---
+RUN cd /workspace && uv run playwright install firefox && \
+    mkdir -p ~/.local/bin && \
+    ln -sf ~/.cache/ms-playwright/firefox-*/firefox/firefox ~/.local/bin/firefox
+
+# --- Source code layer (changes every run, but cheap) ---
+USER root
+COPY --chown=testuser:testuser . /workspace/
+USER testuser
+
+# Copy template pyproject files for release mode.
+COPY --chown=testuser:testuser .github/e2e-cli/pyproject.bare.toml /workspace/.github/e2e-cli/pyproject.bare.toml
+COPY --chown=testuser:testuser .github/e2e-cli/pyproject.aws.toml /workspace/.github/e2e-cli/pyproject.aws.toml
+
+# Workspace mode: re-run uv sync to register editable packages.
+# Release mode: render template, uv sync (resolves the CLI from the configured index),
+# then install Playwright.
+#   bare variant: CLI from Test PyPI, plugin from workspace, no AWS deps
+#   aws variant:  CLI[aws] from Test PyPI, base template + plugin from workspace
+RUN if [ "$INSTALL_MODE" = "pypi" ]; then \
+        cd /workspace && \
+        rm -rf .venv && \
+        uv cache clean && \
+        sed -e "s|{{PKG_VERSION}}|${PKG_VERSION}|g" \
+            -e "s|{{EXTRA_INDEX_URL}}|${EXTRA_INDEX_URL}|g" \
+            .github/e2e-cli/pyproject.${INSTALL_VARIANT}.toml > pyproject.toml && \
+        rm -f .github/e2e-cli/pyproject.bare.toml .github/e2e-cli/pyproject.aws.toml && \
+        # Strip workspace sources — uv errors on them outside workspace context
+        sed -i '/\[tool\.uv\.sources\.jupyter-deploy\]/,+1d' libs/pytest-jupyter-deploy/pyproject.toml && \
+        sed -i '/\[tool\.uv\.sources\.\(jupyter-deploy\|pytest-jupyter-deploy\)\]/,+1d' libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml && \
+        uv sync && \
+        .venv/bin/playwright install firefox && \
+        ln -sf ~/.cache/ms-playwright/firefox-*/firefox/firefox ~/.local/bin/firefox; \
+    else \
+        cd /workspace && \
+        rm -f .github/e2e-cli/pyproject.bare.toml .github/e2e-cli/pyproject.aws.toml && \
+        uv sync --all-packages; \
+    fi
+
+CMD ["sleep", "infinity"]

--- a/.github/e2e-cli/Dockerfile.dockerignore
+++ b/.github/e2e-cli/Dockerfile.dockerignore
@@ -1,0 +1,11 @@
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+test-results
+.git
+.ruff_cache
+.mypy_cache
+sandbox*
+.auth
+.env

--- a/.github/e2e-cli/pyproject.aws.toml
+++ b/.github/e2e-cli/pyproject.aws.toml
@@ -1,0 +1,24 @@
+# Template for CLI release E2E testing — aws track (with [aws] extra + base template).
+# Placeholders are replaced at build time by the Dockerfile:
+#   {{PKG_VERSION}}     — version to pin from EXTRA_INDEX_URL
+#   {{EXTRA_INDEX_URL}} — index for the package under test (default: Test PyPI)
+[project]
+name = "e2e-jd-release-aws"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+    "jupyter-deploy[aws]=={{PKG_VERSION}}",
+    "jupyter-deploy-tf-aws-ec2-base",
+    "pytest-jupyter-deploy[ui]",
+    "pytest-cov",
+]
+
+[[tool.uv.index]]
+name = "extra"
+url = "{{EXTRA_INDEX_URL}}"
+explicit = true
+
+[tool.uv.sources]
+jupyter-deploy = { index = "extra" }
+pytest-jupyter-deploy = { path = "libs/pytest-jupyter-deploy", editable = true }
+jupyter-deploy-tf-aws-ec2-base = { path = "libs/jupyter-deploy-tf-aws-ec2-base", editable = true }

--- a/.github/e2e-cli/pyproject.aws.toml
+++ b/.github/e2e-cli/pyproject.aws.toml
@@ -3,7 +3,7 @@
 #   {{PKG_VERSION}}     — version to pin from EXTRA_INDEX_URL
 #   {{EXTRA_INDEX_URL}} — index for the package under test (default: Test PyPI)
 [project]
-name = "e2e-jd-release-aws"
+name = "e2e-cli-release-aws"
 version = "0.0.0"
 requires-python = ">=3.12"
 dependencies = [

--- a/.github/e2e-cli/pyproject.bare.toml
+++ b/.github/e2e-cli/pyproject.bare.toml
@@ -3,7 +3,7 @@
 #   {{PKG_VERSION}}     — version to pin from EXTRA_INDEX_URL
 #   {{EXTRA_INDEX_URL}} — index for the package under test (default: Test PyPI)
 [project]
-name = "e2e-jd-release-bare"
+name = "e2e-cli-release-bare"
 version = "0.0.0"
 requires-python = ">=3.12"
 dependencies = [

--- a/.github/e2e-cli/pyproject.bare.toml
+++ b/.github/e2e-cli/pyproject.bare.toml
@@ -1,0 +1,22 @@
+# Template for CLI release E2E testing — bare track (no AWS deps).
+# Placeholders are replaced at build time by the Dockerfile:
+#   {{PKG_VERSION}}     — version to pin from EXTRA_INDEX_URL
+#   {{EXTRA_INDEX_URL}} — index for the package under test (default: Test PyPI)
+[project]
+name = "e2e-jd-release-bare"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = [
+    "jupyter-deploy=={{PKG_VERSION}}",
+    "pytest-jupyter-deploy[ui]",
+    "pytest-cov",
+]
+
+[[tool.uv.index]]
+name = "extra"
+url = "{{EXTRA_INDEX_URL}}"
+explicit = true
+
+[tool.uv.sources]
+jupyter-deploy = { index = "extra" }
+pytest-jupyter-deploy = { path = "libs/pytest-jupyter-deploy", editable = true }

--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -1,0 +1,359 @@
+name: E2E release gate (CLI)
+
+on:
+  workflow_call:
+    inputs:
+      pkg-version:
+        description: "Package version (from build job)"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+# CLI release E2E always targets OAuth app #2 (release-base deployment)
+concurrency:
+  group: e2e-2
+  cancel-in-progress: false
+
+jobs:
+  # --- Build images (parallel: bare + aws) ---
+
+  build-image-bare:
+    name: "Build image (bare)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Pull previous image for cache
+        run: just ci-e2e-cli-pull bare || true
+
+      - name: Build CLI E2E image (bare)
+        run: |
+          ECR_URL=$(just ci-e2e-base-ecr-url 2)
+          BUILD_ARGS="--build-arg INSTALL_MODE=pypi"
+          BUILD_ARGS="$BUILD_ARGS --build-arg INSTALL_VARIANT=bare"
+          BUILD_ARGS="$BUILD_ARGS --build-arg PKG_VERSION=${{ inputs.pkg-version }}"
+          just ci-e2e-cli-build "$ECR_URL:jd-bare" "$BUILD_ARGS"
+
+      - name: Push to ECR
+        run: just ci-e2e-cli-push bare
+
+  build-image-aws:
+    name: "Build image (aws)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Pull previous image for cache
+        run: just ci-e2e-cli-pull aws || true
+
+      - name: Build CLI E2E image (aws)
+        run: |
+          ECR_URL=$(just ci-e2e-base-ecr-url 2)
+          BUILD_ARGS="--build-arg INSTALL_MODE=pypi"
+          BUILD_ARGS="$BUILD_ARGS --build-arg INSTALL_VARIANT=aws"
+          BUILD_ARGS="$BUILD_ARGS --build-arg PKG_VERSION=${{ inputs.pkg-version }}"
+          just ci-e2e-cli-build "$ECR_URL:jd-aws" "$BUILD_ARGS"
+
+      - name: Push to ECR
+        run: just ci-e2e-cli-push aws
+
+  # --- Smoke tests (parallel: bare + aws) ---
+
+  smoke-bare:
+    name: "Smoke tests (bare)"
+    needs: [build-image-bare]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Pull bare image
+        run: just ci-e2e-cli-pull bare
+
+      - name: Run bare smoke tests
+        run: |
+          docker run --rm jupyter-deploy-e2e-cli:latest \
+            bash -c '. .venv/bin/activate && \
+              pytest libs/jupyter-deploy/tests/e2e/ \
+                -k "not aws_installation" --no-cov -v'
+
+  smoke-aws:
+    name: "Smoke tests (aws)"
+    needs: [build-image-aws]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Pull aws image
+        run: just ci-e2e-cli-pull aws
+
+      - name: Run aws smoke tests
+        run: |
+          docker run --rm jupyter-deploy-e2e-cli:latest \
+            bash -c '. .venv/bin/activate && \
+              pytest libs/jupyter-deploy/tests/e2e/ \
+                -k "not bare_installation" --no-cov -v'
+
+  # --- Gate: smoke tests must pass before functional tests ---
+
+  smoke-gate:
+    name: "Smoke gate"
+    needs: [smoke-bare, smoke-aws]
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: All smoke tests passed
+        run: echo "Smoke tests passed for both bare and aws tracks"
+
+  # --- Functional tests (aws image against app #2 deployment) ---
+
+  aws-functional-test:
+    name: "AWS functional test (cli marker)"
+    needs: [smoke-gate, build-image-aws]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Restore base project (app 2)
+        run: just ci-restore-base 2 sandbox-ci sandbox-e2e
+
+      # yamllint disable-line rule:line-length
+      - name: Generate .env
+        run: >-
+          just env-setup-base sandbox-e2e sandbox-ci 2
+          "safe-user=ellisonbg,org=jupyter-infra,safe-org=jupyter-server,team=jupyter-deploy-e2e-app-access,safe-team=jupyter-deploy-e2e-app-no-access,larger-instance=t3.xlarge,larger-log-retention-days=270,cpu-instance=t3.medium,gpu-instance=g6.xlarge"
+
+      - name: Import auth state
+        run: just auth-import sandbox-ci
+
+      - name: Pull aws image
+        run: just ci-e2e-cli-pull aws
+
+      - name: Run CLI functional tests
+        env:
+          E2E_DIR: libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e
+        run: |
+          mkdir -p test-results
+          docker run --rm \
+            --env-file .env \
+            -v "${{ github.workspace }}/sandbox-e2e:/workspace/sandbox-e2e" \
+            -v "${{ github.workspace }}/test-results:/workspace/test-results" \
+            -v "${{ github.workspace }}/.auth:/workspace/.auth" \
+            -e AWS_ACCESS_KEY_ID \
+            -e AWS_SECRET_ACCESS_KEY \
+            -e AWS_SESSION_TOKEN \
+            -e AWS_REGION=us-west-2 \
+            jupyter-deploy-e2e-cli:latest \
+            bash -c ". .venv/bin/activate && \
+              xvfb-run --auto-servernum \
+              pytest $E2E_DIR -m cli \
+                --e2e-tests-dir=$E2E_DIR \
+                --e2e-existing-project=sandbox-e2e \
+                --no-cov --verbose \
+                --browser firefox \
+                --screenshot only-on-failure"
+
+      - name: Upload test artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-aws-functional
+          path: test-results/
+          if-no-files-found: ignore
+
+      - name: Upload test results to S3
+        if: failure()
+        continue-on-error: true
+        run: just ci-upload-test-results 2
+
+  # --- Cleanup: stop host (cli tests are non-mutating but defensive) ---
+
+  cleanup:
+    name: "Cleanup: stop host"
+    needs: [aws-functional-test]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: e2e
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: "3.13"
+
+      - name: Install just
+        uses: extractions/setup-just@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+          terraform_wrapper: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
+          aws-region: us-west-2
+
+      - name: Restore CI project
+        run: just ci-restore sandbox-ci
+
+      - name: Restore base project
+        run: just ci-restore-base 2 sandbox-ci sandbox-e2e
+
+      - name: Stop host
+        run: just ensure-host-stopped sandbox-e2e

--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -160,11 +160,7 @@ jobs:
         run: just ci-e2e-cli-pull bare
 
       - name: Run bare smoke tests
-        run: |
-          docker run --rm jupyter-deploy-e2e-cli:latest \
-            bash -c '. .venv/bin/activate && \
-              pytest libs/jupyter-deploy/tests/e2e/ \
-                -k "not aws_installation" --no-cov -v'
+        run: just test-smoke-cli bare jupyter-deploy-e2e-cli:latest
 
   smoke-aws:
     name: "Smoke tests (aws)"
@@ -206,11 +202,7 @@ jobs:
         run: just ci-e2e-cli-pull aws
 
       - name: Run aws smoke tests
-        run: |
-          docker run --rm jupyter-deploy-e2e-cli:latest \
-            bash -c '. .venv/bin/activate && \
-              pytest libs/jupyter-deploy/tests/e2e/ \
-                -k "not bare_installation" --no-cov -v'
+        run: just test-smoke-cli aws jupyter-deploy-e2e-cli:latest
 
   # --- Gate: smoke tests must pass before functional tests ---
 
@@ -229,7 +221,7 @@ jobs:
     name: "AWS functional test (cli marker)"
     needs: [smoke-gate, build-image-aws]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     environment: e2e
     permissions:
       id-token: write
@@ -270,90 +262,11 @@ jobs:
           just env-setup-base sandbox-e2e sandbox-ci 2
           "safe-user=ellisonbg,org=jupyter-infra,safe-org=jupyter-server,team=jupyter-deploy-e2e-app-access,safe-team=jupyter-deploy-e2e-app-no-access,larger-instance=t3.xlarge,larger-log-retention-days=270,cpu-instance=t3.medium,gpu-instance=g6.xlarge"
 
-      - name: Import auth state
-        run: just auth-import sandbox-ci
-
       - name: Pull aws image
         run: just ci-e2e-cli-pull aws
 
       - name: Run CLI functional tests
-        env:
-          E2E_DIR: libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e
-        run: |
-          mkdir -p test-results
-          docker run --rm \
-            --env-file .env \
-            -v "${{ github.workspace }}/sandbox-e2e:/workspace/sandbox-e2e" \
-            -v "${{ github.workspace }}/test-results:/workspace/test-results" \
-            -v "${{ github.workspace }}/.auth:/workspace/.auth" \
-            -e AWS_ACCESS_KEY_ID \
-            -e AWS_SECRET_ACCESS_KEY \
-            -e AWS_SESSION_TOKEN \
-            -e AWS_REGION=us-west-2 \
-            jupyter-deploy-e2e-cli:latest \
-            bash -c ". .venv/bin/activate && \
-              xvfb-run --auto-servernum \
-              pytest $E2E_DIR -m cli \
-                --e2e-tests-dir=$E2E_DIR \
-                --e2e-existing-project=sandbox-e2e \
-                --no-cov --verbose \
-                --browser firefox \
-                --screenshot only-on-failure"
+        run: just test-e2e-cli sandbox-e2e
 
-      - name: Upload test artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results-aws-functional
-          path: test-results/
-          if-no-files-found: ignore
-
-      - name: Upload test results to S3
-        if: failure()
-        continue-on-error: true
-        run: just ci-upload-test-results 2
-
-  # --- Cleanup: stop host (cli tests are non-mutating but defensive) ---
-
-  cleanup:
-    name: "Cleanup: stop host"
-    needs: [aws-functional-test]
-    if: always()
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: e2e
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install UV and Python
-        uses: ./.github/actions/install-uv
-        with:
-          python-version: "3.13"
-
-      - name: Install just
-        uses: extractions/setup-just@v2
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: "1.5.7"
-          terraform_wrapper: false
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::997498698382:role/jupyter-infra-ci-e2e-6a3e2625
-          aws-region: us-west-2
-
-      - name: Restore CI project
-        run: just ci-restore sandbox-ci
-
-      - name: Restore base project
-        run: just ci-restore-base 2 sandbox-ci sandbox-e2e
-
-      - name: Stop host
-        run: just ensure-host-stopped sandbox-e2e
+  # No cleanup job needed — all cli-marked tests are read-only (terraform state
+  # queries, local history reads, config in temp dirs). None start the host.

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -1,0 +1,178 @@
+name: Release base template (jupyter-deploy-tf-aws-ec2-base)
+
+run-name: Release jupyter-deploy-tf-aws-ec2-base
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      pkg-name: ${{ steps.get-version.outputs.pkg-name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: '3.13'
+          working-directory: '.'
+
+      - name: Build package
+        run: |
+          cd libs/jupyter-deploy-tf-aws-ec2-base
+          uv build
+
+      - name: Get package version
+        id: get-version
+        run: |
+          cd libs/jupyter-deploy-tf-aws-ec2-base
+          echo version=$(uv version --short) >> $GITHUB_OUTPUT
+          echo pkg-name="$(uv version | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  lint:
+    name: Run linters
+    needs: [build]
+    uses: ./.github/workflows/lint.yml
+    with:
+      working-directory: libs/jupyter-deploy-tf-aws-ec2-base
+
+  test:
+    name: Run tests
+    needs: [lint]
+    uses: ./.github/workflows/test.yml
+    with:
+      working-directory: libs/jupyter-deploy-tf-aws-ec2-base
+
+  test-pypi-publish:
+    name: Publish to Test PyPI
+    needs: [test, build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: test-release
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: List build artifacts
+        run: ls -la dist/
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Publish to Test PyPI
+        run: |
+          uv publish \
+            --publish-url https://test.pypi.org/legacy/ \
+            --check-url https://test.pypi.org/simple \
+            --trusted-publishing always
+
+  test-pypi-install:
+    name: Check installation of the Test PyPI build
+    needs: [test-pypi-publish, build]
+    runs-on: ubuntu-latest
+    env:
+      PKG_NAME: ${{ needs.build.outputs.pkg-name }}
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Test installation from Test PyPI
+        run: |
+          uv venv
+          # Wait a bit for the package to be available
+          sleep 60
+          uv pip install \
+            --extra-index-url https://test.pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
+            ${{ env.PKG_NAME }}==${{ env.VERSION }}
+
+  e2e-base-release:
+    name: E2E release gate (base template)
+    needs: [test-pypi-install, build]
+    uses: ./.github/workflows/e2e-base-release.yml
+    secrets: inherit
+    with:
+      pkg-version: ${{ needs.build.outputs.version }}
+
+  prod-pypi-publish:
+    name: Publish to PyPI
+    needs: [e2e-base-release, build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: release
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: List build artifacts
+        run: ls -la dist/
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Publish to PyPI
+        run: |
+          uv publish \
+            --trusted-publishing always
+
+  mark-release:
+    name: Create GitHub Release
+    needs: [prod-pypi-publish, build]
+    if: always() && needs.prod-pypi-publish.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      PKG_NAME: ${{ needs.build.outputs.pkg-name }}
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: '3.13'
+          working-directory: '.'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          generateReleaseNotes: true
+          tag: ${{ env.PKG_NAME }}==${{ env.VERSION }}
+          commit: ${{ github.sha }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,23 +1,9 @@
-name: release
+name: Release CLI (jupyter-deploy)
 
-run-name: Release ${{ inputs.working-directory }}
+run-name: Release jupyter-deploy
 
 on:
-  workflow_call:
-    inputs:
-      working-directory:
-        required: true
-        type: string
-        description: "From which folder this pipeline executes"
   workflow_dispatch:
-    inputs:
-      working-directory:
-        required: true
-        type: choice
-        options:
-          - libs/jupyter-deploy
-          - libs/jupyter-deploy-tf-aws-ec2-base
-          - libs/pytest-jupyter-deploy
 
 permissions:
   id-token: write
@@ -42,13 +28,13 @@ jobs:
 
       - name: Build package
         run: |
-          cd ${{ inputs.working-directory }}
+          cd libs/jupyter-deploy
           uv build
 
       - name: Get package version
         id: get-version
         run: |
-          cd ${{ inputs.working-directory }}
+          cd libs/jupyter-deploy
           echo version=$(uv version --short) >> $GITHUB_OUTPUT
           echo pkg-name="$(uv version | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
 
@@ -61,19 +47,17 @@ jobs:
 
   lint:
     name: Run linters
-    needs:
-      - build
+    needs: [build]
     uses: ./.github/workflows/lint.yml
     with:
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: libs/jupyter-deploy
 
   test:
     name: Run tests
-    needs:
-      - lint
+    needs: [lint]
     uses: ./.github/workflows/test.yml
     with:
-      working-directory: ${{ inputs.working-directory }}
+      working-directory: libs/jupyter-deploy
 
   test-pypi-publish:
     name: Publish to Test PyPI
@@ -114,32 +98,27 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v3
 
-      - name: Test installation from Test PyPi
+      - name: Test installation from Test PyPI
         run: |
           uv venv
           # Wait a bit for the package to be available
-          sleep 30
+          sleep 60
           uv pip install \
             --extra-index-url https://test.pypi.org/simple/ \
             --index-strategy unsafe-best-match \
             ${{ env.PKG_NAME }}==${{ env.VERSION }}
 
-  e2e-base-release:
-    name: E2E release gate (base template)
+  e2e-cli-release:
+    name: E2E release gate (CLI)
     needs: [test-pypi-install, build]
-    if: inputs.working-directory == 'libs/jupyter-deploy-tf-aws-ec2-base'
-    uses: ./.github/workflows/e2e-base-release.yml
+    uses: ./.github/workflows/e2e-cli.yml
     secrets: inherit
     with:
       pkg-version: ${{ needs.build.outputs.version }}
 
   prod-pypi-publish:
     name: Publish to PyPI
-    needs: [e2e-base-release, test-pypi-install, build]
-    if: >-
-      always() &&
-      needs.test-pypi-install.result == 'success' &&
-      (needs.e2e-base-release.result == 'success' || needs.e2e-base-release.result == 'skipped')
+    needs: [e2e-cli-release, build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,0 +1,170 @@
+name: Release plugin (pytest-jupyter-deploy)
+
+run-name: Release pytest-jupyter-deploy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      pkg-name: ${{ steps.get-version.outputs.pkg-name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: '3.13'
+          working-directory: '.'
+
+      - name: Build package
+        run: |
+          cd libs/pytest-jupyter-deploy
+          uv build
+
+      - name: Get package version
+        id: get-version
+        run: |
+          cd libs/pytest-jupyter-deploy
+          echo version=$(uv version --short) >> $GITHUB_OUTPUT
+          echo pkg-name="$(uv version | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  lint:
+    name: Run linters
+    needs: [build]
+    uses: ./.github/workflows/lint.yml
+    with:
+      working-directory: libs/pytest-jupyter-deploy
+
+  test:
+    name: Run tests
+    needs: [lint]
+    uses: ./.github/workflows/test.yml
+    with:
+      working-directory: libs/pytest-jupyter-deploy
+
+  test-pypi-publish:
+    name: Publish to Test PyPI
+    needs: [test, build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: test-release
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: List build artifacts
+        run: ls -la dist/
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Publish to Test PyPI
+        run: |
+          uv publish \
+            --publish-url https://test.pypi.org/legacy/ \
+            --check-url https://test.pypi.org/simple \
+            --trusted-publishing always
+
+  test-pypi-install:
+    name: Check installation of the Test PyPI build
+    needs: [test-pypi-publish, build]
+    runs-on: ubuntu-latest
+    env:
+      PKG_NAME: ${{ needs.build.outputs.pkg-name }}
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Test installation from Test PyPI
+        run: |
+          uv venv
+          # Wait a bit for the package to be available
+          sleep 60
+          uv pip install \
+            --extra-index-url https://test.pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
+            ${{ env.PKG_NAME }}==${{ env.VERSION }}
+
+  prod-pypi-publish:
+    name: Publish to PyPI
+    needs: [test-pypi-install, build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: release
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: List build artifacts
+        run: ls -la dist/
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Publish to PyPI
+        run: |
+          uv publish \
+            --trusted-publishing always
+
+  mark-release:
+    name: Create GitHub Release
+    needs: [prod-pypi-publish, build]
+    if: always() && needs.prod-pypi-publish.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      PKG_NAME: ${{ needs.build.outputs.pkg-name }}
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: '3.13'
+          working-directory: '.'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          generateReleaseNotes: true
+          tag: ${{ env.PKG_NAME }}==${{ env.VERSION }}
+          commit: ${{ github.sha }}

--- a/justfile
+++ b/justfile
@@ -204,9 +204,10 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         fi
     fi
 
-    # Parse skip-sync and ci-dir from options early (needed before compose up)
+    # Parse skip-sync, ci-dir, and image from options early (needed before compose up)
     SKIP_SYNC="false"
     CI_DIR=""
+    IMAGE="jupyter-deploy-e2e-base:latest"
     OPTIONS_STR_EARLY="{{options}}"
     if echo "$OPTIONS_STR_EARLY" | grep -q "skip-sync=true"; then
         SKIP_SYNC="true"
@@ -219,6 +220,9 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         fi
         echo "CI directory: $CI_DIR"
     fi
+    if echo "$OPTIONS_STR_EARLY" | grep -qE "image="; then
+        IMAGE=$(echo "$OPTIONS_STR_EARLY" | grep -oE "image=[^,]+" | cut -d'=' -f2)
+    fi
 
     # Create temporary override file to mount the project directory, test-results,
     # optionally CI dir, and image override for pre-built CI images.
@@ -227,7 +231,7 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         echo "services:"
         echo "  e2e:"
         if [ "$SKIP_SYNC" = "true" ]; then
-            echo "    image: jupyter-deploy-e2e-base:latest"
+            echo "    image: $IMAGE"
         fi
         echo "    volumes:"
         echo "      - ./{{project_dir}}:/workspace/{{project_dir}}"
@@ -238,7 +242,7 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
     } > "$OVERRIDE_FILE"
 
     if [ "$SKIP_SYNC" = "true" ]; then
-        echo "Using pre-built image: jupyter-deploy-e2e-base:latest"
+        echo "Using pre-built image: $IMAGE"
     fi
 
     # Stop and restart container with new mounts (ensures clean mount state)
@@ -285,12 +289,18 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         echo "       and: libs/jupyter-infra-{{template}}/tests/e2e"
         exit 1
     fi
+    # Default marker (can be overridden with marker= option)
+    MARKER="e2e"
+    if echo "{{options}}" | grep -qE "marker="; then
+        MARKER=$(echo "{{options}}" | grep -oE "marker=[^,]+" | cut -d'=' -f2)
+    fi
+
     if [ "$IS_DEPLOYMENT_FROM_SCRATCH" = "true" ]; then
         # Deploy from scratch - don't pass --e2e-existing-project (uses default config "base")
-        PYTEST_ARGS="$E2E_TESTS_DIR -m e2e --e2e-tests-dir=$E2E_TESTS_DIR"
+        PYTEST_ARGS="$E2E_TESTS_DIR -m $MARKER --e2e-tests-dir=$E2E_TESTS_DIR"
     else
         # Use existing project
-        PYTEST_ARGS="$E2E_TESTS_DIR -m e2e --e2e-tests-dir=$E2E_TESTS_DIR --e2e-existing-project={{project_dir}}"
+        PYTEST_ARGS="$E2E_TESTS_DIR -m $MARKER --e2e-tests-dir=$E2E_TESTS_DIR --e2e-existing-project={{project_dir}}"
     fi
 
     # Add test filter if provided
@@ -307,7 +317,7 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
         echo "Options: $OPTIONS_STR"
 
         # List of recognized options (for validation)
-        RECOGNIZED_OPTIONS="mutate destroy log-level ci-dir skip-sync"
+        RECOGNIZED_OPTIONS="mutate destroy log-level ci-dir skip-sync marker image"
 
         # Validate all options are recognized
         IFS=',' read -ra OPTS <<< "$OPTIONS_STR"
@@ -380,7 +390,7 @@ test-e2e project_dir="sandbox-e2e" test_filter="" options="" template=default-te
     echo "Test filter: {{test_filter}}"
     echo "================================================"
 
-    {{container-tool}} compose --project-directory {{justfile_directory()}} -f {{e2e-compose-file}} exec -e XAUTHORITY=/home/testuser/.Xauthority e2e bash -c "cd /workspace && xvfb-run --auto-servernum bash -c '$PYTEST_CMD $PYTEST_ARGS'"
+    {{container-tool}} compose --project-directory {{justfile_directory()}} -f {{e2e-compose-file}} exec -e XAUTHORITY=/home/testuser/.Xauthority -e PYTHONUNBUFFERED=1 e2e bash -c "cd /workspace && xvfb-run --auto-servernum bash -c '$PYTEST_CMD $PYTEST_ARGS'"
 
 # Setup GitHub OAuth authentication (one-time, requires X11 forwarding)
 # Usage: just auth-setup <project-dir> [display]
@@ -864,6 +874,61 @@ ci-e2e-cli-pull variant ci_dir="sandbox-ci":
     {{container-tool}} pull "$ECR_URL:$TAG"
     {{container-tool}} tag "$ECR_URL:$TAG" jupyter-deploy-e2e-cli:latest
     echo "✓ Pulled and tagged as jupyter-deploy-e2e-cli:latest"
+
+# Run CLI smoke tests in a pre-built CLI E2E image
+# For the bare track, the default workspace image has all deps (including boto3),
+# so the bare installation tests would fail. When no custom image is provided,
+# this recipe auto-builds a pypi bare image from the published PyPI version.
+# Usage: just test-smoke-cli bare                              # auto-builds pypi bare image
+# Usage: just test-smoke-cli aws                               # uses default workspace image
+# Usage: just test-smoke-cli bare my-image:tag                 # custom image (skip build)
+test-smoke-cli variant image="" log_level="INFO":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if [ "{{variant}}" = "bare" ]; then
+        FILTER='-k "not aws_installation"'
+    elif [ "{{variant}}" = "aws" ]; then
+        FILTER='-k "not bare_installation"'
+    else
+        echo "Error: variant must be 'bare' or 'aws', got '{{variant}}'"
+        exit 1
+    fi
+
+    # Resolve image: use provided image, or auto-build a pypi variant image
+    IMAGE="{{image}}"
+    if [ -z "$IMAGE" ]; then
+        VERSION=$(cd libs/jupyter-deploy && uv version --short)
+        echo "Building pypi {{variant}} image (jupyter-deploy==$VERSION from PyPI)..."
+        just ci-e2e-cli-build "" \
+            "--build-arg INSTALL_MODE=pypi --build-arg INSTALL_VARIANT={{variant}} --build-arg PKG_VERSION=$VERSION --build-arg EXTRA_INDEX_URL=https://pypi.org/simple/"
+        IMAGE="jupyter-deploy-e2e-cli:latest"
+    fi
+
+    echo "Running CLI smoke tests ({{variant}} track, image=$IMAGE)..."
+    {{container-tool}} run --rm \
+        -e PYTHONUNBUFFERED=1 \
+        "$IMAGE" \
+        bash -c ". .venv/bin/activate && \
+            pytest libs/jupyter-deploy/tests/e2e/ \
+                $FILTER --no-cov -v --log-cli-level={{log_level}}"
+
+# Run CLI functional tests (cli marker) against an existing deployment
+# Uses the pre-built CLI E2E image via test-e2e with skip-sync
+# Usage: just test-e2e-cli <project-dir> [test-filter] [options]
+# Example: just test-e2e-cli sandbox-e2e                     # run all cli tests
+# Example: just test-e2e-cli sandbox-e2e test_show            # run specific tests
+# Example: just test-e2e-cli sandbox-e2e "" log-level=debug   # with debug logging
+# Example: just test-e2e-cli sandbox-e2e "" ci-dir=sandbox-ci # CI mode
+test-e2e-cli project_dir test_filter="" options="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Prepend CLI-specific options, then append any user-supplied options
+    CLI_OPTS="skip-sync=true,marker=cli,image=jupyter-deploy-e2e-cli"
+    if [ -n "{{options}}" ]; then
+        CLI_OPTS="$CLI_OPTS,{{options}}"
+    fi
+    just test-e2e "{{project_dir}}" "{{test_filter}}" "$CLI_OPTS" tf-aws-ec2-base
 
 # Generate .env for base template E2E tests
 # Two modes:

--- a/justfile
+++ b/justfile
@@ -781,6 +781,90 @@ ci-e2e-base-pull oauth_app_num tag="latest" ci_dir="sandbox-ci":
     {{container-tool}} tag "$ECR_URL:{{tag}}" jupyter-deploy-e2e-base:latest
     echo "✓ Pulled and tagged as jupyter-deploy-e2e-base:latest"
 
+# --- CLI release E2E commands ---
+
+# Build the CLI release E2E image
+# Reuses the same base image as ci-e2e-base-build, but layers .github/e2e-cli/Dockerfile.
+# Usage: just ci-e2e-cli-build                           # local: no cache, workspace mode
+# Usage: just ci-e2e-cli-build <ecr-url>:jd-aws          # CI: use ECR tag as layer cache
+# Usage: just ci-e2e-cli-build "" "--build-arg INSTALL_MODE=pypi --build-arg INSTALL_VARIANT=bare --build-arg PKG_VERSION=..."
+ci-e2e-cli-build cache_from="" extra_args="":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    BASE_DOCKERFILE=$(uv run python -c \
+        "from pytest_jupyter_deploy.image import IMAGE_PATH; print(IMAGE_PATH / 'Dockerfile')")
+    BASE_DIR=$(dirname "$BASE_DOCKERFILE")
+
+    echo "Building base E2E image..."
+    {{container-tool}} build \
+        -f "$BASE_DOCKERFILE" \
+        --build-arg USER_UID={{HOST_UID}} \
+        --build-arg USER_GID={{HOST_GID}} \
+        -t jupyter-deploy-e2e:base \
+        "$BASE_DIR"
+
+    echo "Building CLI E2E image..."
+    CACHE_ARG=""
+    if [ -n "{{cache_from}}" ]; then
+        CACHE_ARG="--cache-from={{cache_from}}"
+        echo "Using cache from: {{cache_from}}"
+    fi
+
+    {{container-tool}} build \
+        -f .github/e2e-cli/Dockerfile \
+        --build-arg BASE_IMAGE=jupyter-deploy-e2e:base \
+        $CACHE_ARG \
+        {{extra_args}} \
+        -t jupyter-deploy-e2e-cli:latest \
+        .
+
+    echo "✓ CLI E2E image built: jupyter-deploy-e2e-cli:latest"
+
+# Push the CLI E2E image to ECR (reuses e2e-image-2 repo with jd-bare/jd-aws tags)
+# Usage: just ci-e2e-cli-push <variant> [ci-dir]
+# Example: just ci-e2e-cli-push bare
+# Example: just ci-e2e-cli-push aws
+ci-e2e-cli-push variant ci_dir="sandbox-ci":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    ECR_URL=$(just ci-e2e-base-ecr-url 2 {{ci_dir}})
+    ECR_REGISTRY=$(echo "$ECR_URL" | cut -d'/' -f1)
+    REGION=$(uv run jd show -o region --text -p {{ci_dir}})
+    TAG="jd-{{variant}}"
+
+    echo "Logging in to ECR..."
+    aws ecr get-login-password --region "$REGION" \
+        | {{container-tool}} login --username AWS --password-stdin "$ECR_REGISTRY"
+
+    echo "Pushing to $ECR_URL:$TAG..."
+    {{container-tool}} tag jupyter-deploy-e2e-cli:latest "$ECR_URL:$TAG"
+    {{container-tool}} push "$ECR_URL:$TAG"
+    echo "✓ Pushed $ECR_URL:$TAG"
+
+# Pull a CLI E2E image from ECR and tag as jupyter-deploy-e2e-cli:latest
+# Usage: just ci-e2e-cli-pull <variant> [ci-dir]
+# Example: just ci-e2e-cli-pull bare
+# Example: just ci-e2e-cli-pull aws
+ci-e2e-cli-pull variant ci_dir="sandbox-ci":
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    ECR_URL=$(just ci-e2e-base-ecr-url 2 {{ci_dir}})
+    ECR_REGISTRY=$(echo "$ECR_URL" | cut -d'/' -f1)
+    REGION=$(uv run jd show -o region --text -p {{ci_dir}})
+    TAG="jd-{{variant}}"
+
+    echo "Logging in to ECR..."
+    aws ecr get-login-password --region "$REGION" \
+        | {{container-tool}} login --username AWS --password-stdin "$ECR_REGISTRY"
+
+    echo "Pulling $ECR_URL:$TAG..."
+    {{container-tool}} pull "$ECR_URL:$TAG"
+    {{container-tool}} tag "$ECR_URL:$TAG" jupyter-deploy-e2e-cli:latest
+    echo "✓ Pulled and tagged as jupyter-deploy-e2e-cli:latest"
+
 # Generate .env for base template E2E tests
 # Two modes:
 #   Existing project: reads deployment variables from the project via `jd show -v`

--- a/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml
@@ -98,6 +98,7 @@ testpaths = [
 ]
 markers = [
     "e2e: End-to-end tests using playwright (deselect with '-m \"not e2e\"')",
+    "cli: Non-mutating CLI tests for release validation (select with '-m cli')",
 ]
 
 [tool.coverage.run]

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_interactive.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_interactive.py
@@ -4,6 +4,7 @@ import ast
 import os
 
 import pexpect
+import pytest
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 from pytest_jupyter_deploy.undeployed_project import undeployed_project
@@ -20,6 +21,7 @@ REQUIRED_DEPLOYMENT_VARS = [
 ]
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(REQUIRED_DEPLOYMENT_VARS)
 def test_config_interactive(e2e_deployment: EndToEndDeployment) -> None:
     """Test that terraform prompts work correctly in interactive mode.
@@ -153,6 +155,7 @@ def test_config_interactive(e2e_deployment: EndToEndDeployment) -> None:
         )
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(REQUIRED_DEPLOYMENT_VARS)
 def test_config_interactive_verbose(e2e_deployment: EndToEndDeployment) -> None:
     """Test that terraform prompts work correctly in interactive mode with --verbose flag.

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_set.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_set.py
@@ -2,10 +2,12 @@
 
 import ast
 
+import pytest
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 
 
+@pytest.mark.cli
 def test_config_help_show_variables(e2e_deployment: EndToEndDeployment) -> None:
     """Test that config help retrieves the list of variables."""
     e2e_deployment.ensure_deployed()
@@ -30,6 +32,7 @@ def test_config_help_show_variables(e2e_deployment: EndToEndDeployment) -> None:
         assert var in result.stdout, f"Expected variable '{var}' in config help output"
 
 
+@pytest.mark.cli
 def test_config_set_string_variable(e2e_deployment: EndToEndDeployment) -> None:
     """Test that config can set a simple variable of type str."""
     e2e_deployment.ensure_deployed()
@@ -65,6 +68,7 @@ def test_config_set_string_variable(e2e_deployment: EndToEndDeployment) -> None:
     )
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_SAFE_USER"])
 def test_config_set_list_string_variable(e2e_deployment: EndToEndDeployment, logged_user: str, safe_user: str) -> None:
     """Test that config can set a variable of type list[str]."""
@@ -130,6 +134,7 @@ def test_config_set_list_string_variable(e2e_deployment: EndToEndDeployment, log
     # Step 6: Leave as is (no revert)
 
 
+@pytest.mark.cli
 def test_config_set_list_of_dict_variable(e2e_deployment: EndToEndDeployment) -> None:
     """Test that config can set variable of type list of dict[str, str]."""
     e2e_deployment.ensure_deployed()
@@ -201,6 +206,7 @@ def test_config_set_list_of_dict_variable(e2e_deployment: EndToEndDeployment) ->
     )
 
 
+@pytest.mark.cli
 def test_config_set_string_variable_with_verbose(e2e_deployment: EndToEndDeployment) -> None:
     """Test that config --verbose shows full terraform output without progress bar artifacts."""
     e2e_deployment.ensure_deployed()

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_configuration.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_configuration.py
@@ -3,12 +3,14 @@
 import re
 import subprocess
 
+import pytest
 import yaml
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 from pytest_jupyter_deploy.undeployed_project import undeployed_project
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",
@@ -50,6 +52,7 @@ def test_project_is_configurable(e2e_deployment: EndToEndDeployment) -> None:
         assert engine_dir.exists(), f"Engine directory should exist after config: {engine_dir}"
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",
@@ -92,6 +95,7 @@ def test_gitignore_generated_after_init(e2e_deployment: EndToEndDeployment) -> N
         )
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",
@@ -118,6 +122,7 @@ def test_troubleshoot_md_exists_after_init(e2e_deployment: EndToEndDeployment) -
         assert "# Troubleshooting Guide" in troubleshoot_content, "Should have main heading"
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",
@@ -174,6 +179,7 @@ def test_agent_md_generated_after_init(e2e_deployment: EndToEndDeployment) -> No
         assert "}}" not in agent_content, "Should not contain template placeholders"
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",
@@ -210,6 +216,7 @@ def test_store_config_written_after_config(e2e_deployment: EndToEndDeployment) -
         assert store_config["store-id"], "store-id should not be empty"
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",
@@ -239,6 +246,7 @@ def test_show_store_type_after_config(e2e_deployment: EndToEndDeployment) -> Non
         assert actual_store_type == "s3-only", f"Expected store type 's3-only', got '{actual_store_type}'"
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",
@@ -269,6 +277,7 @@ def test_show_store_id_after_config(e2e_deployment: EndToEndDeployment) -> None:
         assert actual_store_id != "N/A", "Store ID should not be 'N/A' after config"
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",
@@ -305,6 +314,7 @@ def test_show_project_id_fails_on_unconfigured_project(e2e_deployment: EndToEndD
         assert "Traceback" not in result.stderr, "Should not show a stack trace in stderr"
 
 
+@pytest.mark.cli
 @skip_if_testvars_not_set(
     [
         "JD_E2E_VAR_DOMAIN",

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_history.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_history.py
@@ -1,8 +1,10 @@
 """E2E tests for jd history commands."""
 
+import pytest
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 
 
+@pytest.mark.cli
 def test_history_list_config_shows_existing_logs(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd history list config shows existing logs with expected format.
 
@@ -39,6 +41,7 @@ def test_history_list_config_shows_existing_logs(e2e_deployment: EndToEndDeploym
     assert ".log" in result_text.stdout, "Expected .log file paths in plain text output"
 
 
+@pytest.mark.cli
 def test_history_list_up_shows_existing_logs(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd history list up shows existing logs with expected format.
 
@@ -75,6 +78,7 @@ def test_history_list_up_shows_existing_logs(e2e_deployment: EndToEndDeployment)
     assert ".log" in result_text.stdout, "Expected .log file paths in plain text output"
 
 
+@pytest.mark.cli
 def test_history_show_latest_without_command(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd history show displays most recent log across all commands.
 
@@ -100,6 +104,7 @@ def test_history_show_latest_without_command(e2e_deployment: EndToEndDeployment)
     assert len(result.stdout) > 100, "Expected substantial log content (>100 chars)"
 
 
+@pytest.mark.cli
 def test_history_show_config_command(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd history show config displays latest config log.
 
@@ -126,6 +131,7 @@ def test_history_show_config_command(e2e_deployment: EndToEndDeployment) -> None
     assert "terraform" in stdout_lower, "Expected 'terraform' keyword in config log"
 
 
+@pytest.mark.cli
 def test_history_show_up_command(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd history show up displays latest up log.
 
@@ -154,6 +160,7 @@ def test_history_show_up_command(e2e_deployment: EndToEndDeployment) -> None:
     )
 
 
+@pytest.mark.cli
 def test_history_show_up_command_slice(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd history show up with -l and -s flags correctly slices log output.
 
@@ -184,6 +191,7 @@ def test_history_show_up_command_slice(e2e_deployment: EndToEndDeployment) -> No
     assert len(lines) > 0, "Expected at least some lines in sliced output"
 
 
+@pytest.mark.cli
 def test_history_clear_with_high_keep_value(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd history clear -k 100 succeeds without errors.
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_open.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_open.py
@@ -5,6 +5,7 @@ import re
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 
 
+# Not marked @pytest.mark.cli — requires a running host and browser, not available in headless CLI containers
 def test_open_show_correct_url(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd open displays the correct URL and the URL is accessible.
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_projects.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_projects.py
@@ -4,6 +4,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import pytest
 import yaml
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 
@@ -22,6 +23,7 @@ def _get_store_type(e2e_deployment: EndToEndDeployment) -> str:
     return store_type
 
 
+@pytest.mark.cli
 def test_projects_list_contains_deployed_project(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd projects list includes the currently deployed project.
 
@@ -44,6 +46,7 @@ def test_projects_list_contains_deployed_project(e2e_deployment: EndToEndDeploym
     assert project_id in project_ids, f"Expected project '{project_id}' in list output. Got: {project_ids}"
 
 
+@pytest.mark.cli
 def test_projects_show_returns_deployed_project_details(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd projects show returns details for the deployed project.
 
@@ -98,6 +101,7 @@ def _restore_project_to_tmpdir(e2e_deployment: EndToEndDeployment, tmpdir: str) 
     return restore_dir
 
 
+@pytest.mark.cli
 def test_restore_project_and_config(e2e_deployment: EndToEndDeployment) -> None:
     """Test that a project can be restored and reconfigured with --restore-secrets.
 
@@ -147,6 +151,7 @@ def test_restore_project_and_config(e2e_deployment: EndToEndDeployment) -> None:
         assert secret_value == "****", f"Secret should remain masked in variables.yaml, got '{secret_value}'"
 
 
+@pytest.mark.cli
 def test_restore_project_with_named_secret(e2e_deployment: EndToEndDeployment) -> None:
     """Test that a project can be restored with a specific named secret.
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_show.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_show.py
@@ -1,9 +1,11 @@
 """E2E tests for jd show command."""
 
+import pytest
 from jupyter_deploy.enum import ValueSource
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 
 
+@pytest.mark.cli
 def test_show_variables_list_matches_config(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --variables --list matches variables.yaml content.
 
@@ -44,6 +46,7 @@ def test_show_variables_list_matches_config(e2e_deployment: EndToEndDeployment) 
     )
 
 
+@pytest.mark.cli
 def test_show_outputs_list_returns_expected_outputs(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --outputs --list returns expected terraform outputs.
 
@@ -77,6 +80,7 @@ def test_show_outputs_list_returns_expected_outputs(e2e_deployment: EndToEndDepl
     )
 
 
+@pytest.mark.cli
 def test_show_variable_domain_matches_config(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --variable domain returns value from variables.yaml.
 
@@ -101,6 +105,7 @@ def test_show_variable_domain_matches_config(e2e_deployment: EndToEndDeployment)
     assert actual_domain == expected_domain, f"Expected domain '{expected_domain}', got '{actual_domain}'"
 
 
+@pytest.mark.cli
 def test_show_output_jupyter_url_matches_variables(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --output jupyter_url returns URL matching variables.
 
@@ -128,6 +133,7 @@ def test_show_output_jupyter_url_matches_variables(e2e_deployment: EndToEndDeplo
     assert actual_url == expected_url, f"Expected URL '{expected_url}', got '{actual_url}'"
 
 
+@pytest.mark.cli
 def test_show_default_does_not_error(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show (no flags) executes successfully.
 
@@ -151,6 +157,7 @@ def test_show_default_does_not_error(e2e_deployment: EndToEndDeployment) -> None
     assert "Project Outputs" in result.stdout, "Expected outputs section"
 
 
+@pytest.mark.cli
 def test_show_template_name_matches_manifest(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --template-name returns value from manifest.yaml.
 
@@ -174,6 +181,7 @@ def test_show_template_name_matches_manifest(e2e_deployment: EndToEndDeployment)
     assert actual_name == expected_name, f"Expected template name '{expected_name}', got '{actual_name}'"
 
 
+@pytest.mark.cli
 def test_show_template_version_matches_manifest(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --template-version returns value from manifest.yaml.
 
@@ -197,6 +205,7 @@ def test_show_template_version_matches_manifest(e2e_deployment: EndToEndDeployme
     assert actual_version == expected_version, f"Expected template version '{expected_version}', got '{actual_version}'"
 
 
+@pytest.mark.cli
 def test_show_project_id_returns_nonempty_value(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --project-id returns a non-empty project ID on a deployed project.
 
@@ -219,6 +228,7 @@ def test_show_project_id_returns_nonempty_value(e2e_deployment: EndToEndDeployme
     )
 
 
+@pytest.mark.cli
 def test_show_store_type_matches_manifest(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --store-type returns the store type from manifest.
 
@@ -242,6 +252,7 @@ def test_show_store_type_matches_manifest(e2e_deployment: EndToEndDeployment) ->
     )
 
 
+@pytest.mark.cli
 def test_show_store_id_returns_nonempty_value(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --store-id returns a non-empty store ID on a deployed project.
 
@@ -259,6 +270,7 @@ def test_show_store_id_returns_nonempty_value(e2e_deployment: EndToEndDeployment
     assert actual_store_id != "N/A", "Store ID should not be 'N/A' on a deployed project"
 
 
+@pytest.mark.cli
 def test_show_info_includes_store_and_project_id(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --info displays Store Type, Store ID, and Project ID rows.
 
@@ -279,6 +291,7 @@ def test_show_info_includes_store_and_project_id(e2e_deployment: EndToEndDeploym
     assert "N/A" not in result.stdout, "Store Type, Store ID, and Project ID should not be N/A on a deployed project"
 
 
+@pytest.mark.cli
 def test_show_sensitive_variable_is_masked(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show -v <sensitive_var> --text returns masked value.
 
@@ -297,6 +310,7 @@ def test_show_sensitive_variable_is_masked(e2e_deployment: EndToEndDeployment) -
     assert value == "****", f"Expected masked value '****', got '{value}'"
 
 
+@pytest.mark.cli
 def test_show_reveal_sensitive_variable(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show -v <sensitive_var> --reveal --text returns the real secret.
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_undeployed_project.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_undeployed_project.py
@@ -1,9 +1,11 @@
 """E2E tests for CLI behavior with undeployed projects."""
 
+import pytest
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.undeployed_project import undeployed_project
 
 
+@pytest.mark.cli
 def test_open_does_not_error(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd open does not error when project is not deployed.
 
@@ -24,6 +26,7 @@ def test_open_does_not_error(e2e_deployment: EndToEndDeployment) -> None:
         assert "jd up" in result.stdout, "Expected suggestion to run 'jd up'"
 
 
+@pytest.mark.cli
 def test_show_does_not_error(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show does not error when project is not deployed.
 
@@ -42,6 +45,7 @@ def test_show_does_not_error(e2e_deployment: EndToEndDeployment) -> None:
         assert "No outputs available." in result.stdout, "Expected 'No outputs available.' message in output"
 
 
+@pytest.mark.cli
 def test_show_info_on_undeployed_project(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --info populates template fields but shows N/A for store/project IDs.
 
@@ -64,6 +68,7 @@ def test_show_info_on_undeployed_project(e2e_deployment: EndToEndDeployment) -> 
         assert result.stdout.strip() == "N/A", f"Expected N/A for --store-id, got '{result.stdout.strip()}'"
 
 
+@pytest.mark.cli
 def test_show_variable_instance_type_does_not_error(e2e_deployment: EndToEndDeployment) -> None:
     """Test that jd show --variable instance_type returns None when project is not deployed.
 

--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -102,6 +102,9 @@ ignore = [
 # Allow lazy imports in provider factory (handles optional dependencies)
 "jupyter_deploy/provider/instruction_runner_factory.py" = ["PLC0415"]
 "jupyter_deploy/provider/store/store_manager_factory.py" = ["PLC0415"]
+# E2E install track tests use inline imports to test optional dependency boundaries
+"tests/e2e/test_bare_installation.py" = ["PLC0415"]
+"tests/e2e/test_aws_installation.py" = ["PLC0415"]
 
 [tool.ruff.format]
 quote-style = "double"
@@ -114,6 +117,10 @@ docstring-code-line-length = 40
 [tool.pytest.ini_options]
 addopts = "--cov=jupyter_deploy --cov-report=term-missing --cov-report=xml --cov-report=html"
 testpaths = ["tests/unit"]
+markers = [
+    "e2e: End-to-end tests using playwright (deselect with '-m \"not e2e\"')",
+    "bare: Tests requiring the bare install track with no AWS deps (select with '-m bare')",
+]
 
 [tool.coverage.run]
 source = ["jupyter_deploy"]

--- a/libs/jupyter-deploy/tests/e2e/conftest.py
+++ b/libs/jupyter-deploy/tests/e2e/conftest.py
@@ -1,0 +1,14 @@
+"""E2E test configuration for jupyter-deploy CLI smoke tests."""
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list) -> None:
+    """Automatically mark all tests in this directory as e2e tests."""
+    for item in items:
+        if "e2e" in str(item.fspath):
+            item.add_marker(pytest.mark.e2e)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line("markers", "bare: tests that require the bare install track (no AWS deps)")

--- a/libs/jupyter-deploy/tests/e2e/test_aws_installation.py
+++ b/libs/jupyter-deploy/tests/e2e/test_aws_installation.py
@@ -1,0 +1,18 @@
+"""AWS install track tests — validate the CLI works with the [aws] extra.
+
+These tests run in the ``aws`` install track where ``jupyter-deploy[aws]``
+is installed alongside the base template.
+"""
+
+import unittest
+
+
+class TestAwsInstallation(unittest.TestCase):
+    def test_boto3_importable(self) -> None:
+        import boto3  # noqa: F401
+
+    def test_botocore_importable(self) -> None:
+        import botocore  # noqa: F401
+
+    def test_provider_factory_resolves(self) -> None:
+        from jupyter_deploy.provider.aws import aws_runner  # noqa: F401

--- a/libs/jupyter-deploy/tests/e2e/test_bare_installation.py
+++ b/libs/jupyter-deploy/tests/e2e/test_bare_installation.py
@@ -1,0 +1,26 @@
+"""Bare install track tests — validate the CLI works without AWS deps.
+
+These tests MUST be run with ``pytest -m bare`` in an environment where
+``jupyter-deploy`` was installed WITHOUT the ``[aws]`` extra. They will
+fail (not skip) if boto3 is present — that's intentional: a bare track
+that accidentally includes cloud deps is a real bug.
+"""
+
+import unittest
+
+import pytest
+
+
+@pytest.mark.bare
+class TestBareInstallation(unittest.TestCase):
+    def test_no_boto3(self) -> None:
+        with self.assertRaises(ImportError):
+            import boto3  # noqa: F401
+
+    def test_no_botocore(self) -> None:
+        with self.assertRaises(ImportError):
+            import botocore  # noqa: F401
+
+    def test_provider_import_fails(self) -> None:
+        with self.assertRaises(ImportError):
+            from jupyter_deploy.provider.aws import aws_runner  # noqa: F401

--- a/libs/jupyter-deploy/tests/e2e/test_help_commands.py
+++ b/libs/jupyter-deploy/tests/e2e/test_help_commands.py
@@ -1,0 +1,29 @@
+"""CLI help smoke tests — validate every subcommand responds to --help."""
+
+import subprocess
+
+import pytest
+
+_HELP_COMMANDS: list[list[str]] = [
+    ["jd", "--help"],
+    ["jd", "init", "--help"],
+    ["jd", "config", "--help"],
+    ["jd", "up", "--help"],
+    ["jd", "down", "--help"],
+    ["jd", "open", "--help"],
+    ["jd", "show", "--help"],
+    ["jd", "server", "--help"],
+    ["jd", "users", "--help"],
+    ["jd", "teams", "--help"],
+    ["jd", "organization", "--help"],
+    ["jd", "host", "--help"],
+    ["jd", "history", "--help"],
+    ["jd", "projects", "--help"],
+]
+
+
+@pytest.mark.parametrize("cmd", _HELP_COMMANDS, ids=[" ".join(c) for c in _HELP_COMMANDS])
+def test_help_commands(cmd: list[str]) -> None:
+    """Every subcommand responds to --help with exit code 0."""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    assert result.returncode == 0, f"{' '.join(cmd)} failed: {result.stderr}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,8 @@ pythonpath = [
   "libs/pytest-jupyter-deploy"
 ]
 markers = [
-  "e2e: marks tests as end-to-end tests (deselect with '-m \"not e2e\"')"
+  "e2e: marks tests as end-to-end tests (deselect with '-m \"not e2e\"')",
+  "cli: Non-mutating CLI tests for release validation (select with '-m cli')",
+  "bare: Tests requiring the bare install track with no AWS deps (select with '-m bare')",
 ]
 addopts = "-m 'not e2e' --import-mode=importlib"


### PR DESCRIPTION
This PR a/ adds e2e test to the `cli` release worklow, b/ breakdown each package release to its own `.github/release-<>.yaml` workflow.

### Maintainer experience
- release plugin to PyPI w/ GH UI > `Action` > `release-plugin`
- release cli to PyPI w/ GH UI > `Action` > `release-cli`
- release base template to PyPI w/ GH UI > `Action` > `release-base`

### Implementation
1. add a CI image for `cli` tests in `.github/e2e-cli`
2. add `pyproject.aws.toml` and `pyproject.bare.toml` for the `pip install jupyter-deploy` and `pip install jupyter-deploy[aws]` optional install
3. add `just` methods for `cli` tests image (build, push, pull)
4. add `just` methods for smoke tests
6. add `just` methods for e2e cli tests that reuse the `test-e2e` method
7. add `cli` pytest marker for base template tests that should run the `cli` release workflow
8. update `cli` release to run both smoke tests (ie bare and aws installs pull the right packages) and then run E2E tests flagged `cli` of the base template

### Testing
Created a branch in the repo, and triggered CI:
- mimick of `cli` release [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/24471202604)
- mimick of `base` template release [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/24472594147)
- ran e2e tests locally for the `base` template (non-mutating)