### PR TITLE
fix: skip canary on forks

### DIFF
--- a/.github/workflows/e2e-base-canary.yml
+++ b/.github/workflows/e2e-base-canary.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   canary:
+    if: github.repository == 'jupyter-infra/jupyter-deploy'
     uses: ./.github/workflows/e2e-base-fresh.yml
     with:
       oauth-app-num: "3"


### PR DESCRIPTION
This PR adds a guard to prevent the weekly canary to run on forks, where the OIDC assume role would fail.
- passed canary [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/24618822504) on the main repo
- failed canary [run](https://github.com/JGuinegagne/jupyter-deploy/actions/runs/24620006506) on fork
