### PR TITLE
fix: variables description

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_set.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_set.py
@@ -31,6 +31,10 @@ def test_config_help_show_variables(e2e_deployment: EndToEndDeployment) -> None:
     for var in expected_variables:
         assert var in result.stdout, f"Expected variable '{var}' in config help output"
 
+    # Verify descriptions are expanded (not raw heredoc markers)
+    assert "<<-EOT" not in result.stdout, "Config help contains unexpanded heredoc marker <<-EOT"
+    assert "<<EOT" not in result.stdout, "Config help contains unexpanded heredoc marker <<EOT"
+
 
 @pytest.mark.cli
 def test_config_set_string_variable(e2e_deployment: EndToEndDeployment) -> None:

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_show.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_show.py
@@ -3,6 +3,12 @@
 import pytest
 from jupyter_deploy.enum import ValueSource
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.terraform.utils import (
+    get_outputs_dot_tf_path,
+    get_variables_dot_tf_path,
+    parse_output_descriptions,
+    parse_variable_descriptions,
+)
 
 
 @pytest.mark.cli
@@ -289,6 +295,73 @@ def test_show_info_includes_store_and_project_id(e2e_deployment: EndToEndDeploym
     assert "Project ID" in result.stdout, "Info table should contain Project ID row"
     # On a deployed project, all store fields should have values
     assert "N/A" not in result.stdout, "Store Type, Store ID, and Project ID should not be N/A on a deployed project"
+
+
+@pytest.mark.cli
+def test_show_variable_description_single_line(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that a short heredoc description is correctly expanded.
+
+    Uses 'volume_size_gb' whose first description line is a single sentence.
+    Compares CLI output against the first line parsed independently from variables.tf.
+    """
+    e2e_deployment.ensure_deployed()
+
+    variables_tf = get_variables_dot_tf_path(e2e_deployment.suite_config.project_dir)
+    expected = parse_variable_descriptions(variables_tf)
+    expected_first_line = expected["volume_size_gb"].split("\n")[0]
+
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "show", "--variable", "volume_size_gb", "--description", "--text"]
+    )
+    desc = result.stdout.strip()
+
+    assert desc.startswith(expected_first_line), (
+        f"Expected description to start with {expected_first_line!r}, got {desc!r}"
+    )
+
+
+@pytest.mark.cli
+def test_show_variable_description_multiline(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that a long multi-line heredoc description is correctly expanded.
+
+    Uses 'domain' whose description spans many lines with URLs.
+    Compares CLI output against the first line parsed independently from variables.tf.
+    """
+    e2e_deployment.ensure_deployed()
+
+    variables_tf = get_variables_dot_tf_path(e2e_deployment.suite_config.project_dir)
+    expected = parse_variable_descriptions(variables_tf)
+    expected_first_line = expected["domain"].split("\n")[0]
+
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "show", "--variable", "domain", "--description", "--text"]
+    )
+    desc = result.stdout.strip()
+
+    assert desc.startswith(expected_first_line), (
+        f"Expected description to start with {expected_first_line!r}, got {desc!r}"
+    )
+
+
+@pytest.mark.cli
+def test_show_output_description_matches_template(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that jd show -o <output> --description returns the correct description.
+
+    Uses 'jupyter_url' whose description is an inline string in outputs.tf.
+    Compares CLI output against the description parsed independently from outputs.tf.
+    """
+    e2e_deployment.ensure_deployed()
+
+    outputs_tf = get_outputs_dot_tf_path(e2e_deployment.suite_config.project_dir)
+    expected = parse_output_descriptions(outputs_tf)
+    expected_desc = expected["jupyter_url"]
+
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "show", "--output", "jupyter_url", "--description", "--text"]
+    )
+    desc = result.stdout.strip()
+
+    assert desc == expected_desc, f"Expected output description {expected_desc!r}, got {desc!r}"
 
 
 @pytest.mark.cli

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_varfiles.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_varfiles.py
@@ -1,3 +1,5 @@
+import re
+import textwrap
 from typing import Any
 
 import hcl2  # type: ignore[import-untyped]
@@ -6,6 +8,27 @@ from pydantic import ValidationError
 from jupyter_deploy.engine.terraform import tf_plan, tf_vardefs
 
 _HCL2_LITERAL_MAP: dict[str, Any] = {"null": None, "true": True, "false": False}
+_HEREDOC_RE = re.compile(r"^<<(-?)([A-Za-z_][A-Za-z0-9_]*)\n")
+
+
+def _expand_heredoc(s: str) -> str:
+    """Expand an HCL heredoc string to its content.
+
+    Handles both ``<<MARKER`` (literal) and ``<<-MARKER`` (indent-stripped)
+    forms. Returns *s* unchanged if it does not start with a heredoc prefix.
+    """
+    m = _HEREDOC_RE.match(s)
+    if not m:
+        return s
+    strip_indent = m.group(1) == "-"
+    marker = m.group(2)
+    lines = s[m.end() :].split("\n")
+    if lines and lines[-1].strip() == marker:
+        lines = lines[:-1]
+    body = "\n".join(lines)
+    if strip_indent:
+        body = textwrap.dedent(body)
+    return body.strip("\n")
 
 
 def strip_hcl2_quotes(obj: Any) -> Any:
@@ -15,13 +38,14 @@ def strip_hcl2_quotes(obj: Any) -> Any:
     - Quoted HCL strings keep their quotes: "region" → '"region"' (v7 returned 'region')
     - HCL literals returned as strings: null → 'null', true → 'true' (v7 returned None/True)
     - Comments collected in '__comments__' key (v7 discarded them)
+    - Heredoc blocks returned as literal strings with markers instead of expanded content
 
-    This recursively strips outer quotes, converts literal strings back to Python types,
-    and removes the '__comments__' key.
+    This recursively strips outer quotes, expands heredocs, converts literal strings back
+    to Python types, and removes the '__comments__' key.
     """
     if isinstance(obj, str):
         if len(obj) >= 2 and obj[0] == '"' and obj[-1] == '"':
-            return obj[1:-1]
+            return _expand_heredoc(obj[1:-1])
         if obj in _HCL2_LITERAL_MAP:
             return _HCL2_LITERAL_MAP[obj]
         return obj

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/mock_outputs.tf
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/mock_outputs.tf
@@ -9,3 +9,13 @@ output "aws_region" {
   description = "Name of the AWS region."
   value       = data.aws_region.current.id
 }
+
+# Public URL (heredoc description)
+output "public_url" {
+  description = <<-EOT
+    The public URL for accessing the server.
+
+    Includes the subdomain and domain.
+  EOT
+  value       = "https://example.com"
+}

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_outfiles.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_outfiles.py
@@ -24,7 +24,11 @@ class TestExtractDescriptionFromDotTfFile(unittest.TestCase):
         content = self.outputs_tf_content
         result = tf_outfiles.extract_description_from_dot_tf_content(content)
 
-        expected = {"instance_id": "ID of the jupyter notebook.", "aws_region": "Name of the AWS region."}
+        expected = {
+            "instance_id": "ID of the jupyter notebook.",
+            "aws_region": "Name of the AWS region.",
+            "public_url": "The public URL for accessing the server.\n\nIncludes the subdomain and domain.",
+        }
         self.assertEqual(expected, result)
 
 

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_varfiles.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_varfiles.py
@@ -83,14 +83,86 @@ class TestParseVariablesDotTfContent(unittest.TestCase):
         self.assertIsInstance(result["some_list_of_string"], tf_vardefs.TerraformListOfStrVariableDefinition)
         self.assertIsInstance(result["some_map_of_sring"], tf_vardefs.TerraformMapOfStrVariableDefinition)
 
-        # Verify descriptions are correctly parsed
-        self.assertIn("Recommended: t3.medium", result["some_string_value"].description)
-        self.assertIn("For example the size of the disk in GB.", result["some_int_value"].description)
-        self.assertIn("Recommended: 0.9", result["some_float_value"].description)
+        # Verify descriptions are correctly parsed (exact match to catch heredoc expansion regressions)
+        self.assertEqual(
+            "For example the instance type.\n\nRecommended: t3.medium",
+            result["some_string_value"].description,
+        )
+        self.assertEqual(
+            "For example the size of the disk in GB.\n\nRecommended: 30",
+            result["some_int_value"].description,
+        )
+        self.assertEqual(
+            "For example the max GPU utilization.\n\nRecommended: 0.9",
+            result["some_float_value"].description,
+        )
 
         # Verify sensitive flag is set correctly
         self.assertTrue(result["some_secret"].sensitive)
         self.assertFalse(result["some_string_value"].sensitive)
+
+
+class TestStripHcl2QuotesHeredocExpansion(unittest.TestCase):
+    def test_expands_indented_heredoc(self) -> None:
+        raw = '"<<-EOT\n    Line one.\n\n    Line two.\n  EOT"'
+        result = tf_varfiles.strip_hcl2_quotes(raw)
+        self.assertEqual("Line one.\n\nLine two.", result)
+
+    def test_expands_non_indented_heredoc(self) -> None:
+        raw = '"<<EOT\nLine one.\nLine two.\nEOT"'
+        result = tf_varfiles.strip_hcl2_quotes(raw)
+        self.assertEqual("Line one.\nLine two.", result)
+
+    def test_expands_heredoc_with_custom_marker(self) -> None:
+        raw = '"<<-DESC\n    Custom marker.\n  DESC"'
+        result = tf_varfiles.strip_hcl2_quotes(raw)
+        self.assertEqual("Custom marker.", result)
+
+    def test_passes_through_plain_quoted_string(self) -> None:
+        raw = '"Inline description"'
+        result = tf_varfiles.strip_hcl2_quotes(raw)
+        self.assertEqual("Inline description", result)
+
+    def test_expands_heredoc_in_nested_dict(self) -> None:
+        raw = {
+            '"var_name"': {
+                "description": '"<<-EOT\n    A description.\n  EOT"',
+                "type": "string",
+            }
+        }
+        result = tf_varfiles.strip_hcl2_quotes(raw)
+        self.assertEqual("A description.", result["var_name"]["description"])
+
+
+class TestParseVariablesDotTfHeredocDescriptions(unittest.TestCase):
+    variables_tf_content: str
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        mock_variables_path = Path(__file__).parent / "mock_variables.tf"
+        with open(mock_variables_path) as f:
+            cls.variables_tf_content = f.read()
+
+    def test_descriptions_do_not_contain_heredoc_markers(self) -> None:
+        result = tf_varfiles.parse_variables_dot_tf_content(self.variables_tf_content)
+        for var_name, var_def in result.items():
+            self.assertNotIn("<<-EOT", var_def.description, f"Variable '{var_name}' has unexpanded heredoc")
+            self.assertNotIn("EOT", var_def.description.split("\n")[-1] if var_def.description else "")
+
+    def test_heredoc_descriptions_are_fully_expanded(self) -> None:
+        result = tf_varfiles.parse_variables_dot_tf_content(self.variables_tf_content)
+        self.assertEqual(
+            "For example the instance type.\n\nRecommended: t3.medium",
+            result["some_string_value"].description,
+        )
+        self.assertEqual(
+            "For example the size of the disk in GB.\n\nRecommended: 30",
+            result["some_int_value"].description,
+        )
+        self.assertEqual(
+            "For example a resource prefix",
+            result["some_string_value_with_condition"].description,
+        )
 
 
 class TestParseDotTfvarsContentAndAddDefaults(unittest.TestCase):

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/terraform/utils.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/terraform/utils.py
@@ -1,0 +1,53 @@
+"""Utilities for parsing Terraform files in E2E tests.
+
+These helpers parse .tf files independently of python-hcl2, providing a
+reference implementation that E2E tests can compare CLI output against.
+"""
+
+import re
+import textwrap
+from pathlib import Path
+
+_VARIABLE_HEREDOC_RE = re.compile(
+    r'variable\s+"(?P<name>[^"]+)"\s*\{[^}]*?'
+    r"description\s*=\s*<<-(?P<marker>[A-Za-z_]\w*)\n(?P<body>.*?)^\s*(?P=marker)",
+    re.MULTILINE | re.DOTALL,
+)
+
+_OUTPUT_INLINE_DESC_RE = re.compile(
+    r'output\s+"(?P<name>[^"]+)"\s*\{[^}]*?description\s*=\s*"(?P<desc>[^"]*)"',
+)
+
+
+def get_variables_dot_tf_path(project_dir: Path) -> Path:
+    """Return the default path to variables.tf within a Terraform-based jupyter-deploy project."""
+    return project_dir / "engine" / "variables.tf"
+
+
+def get_outputs_dot_tf_path(project_dir: Path) -> Path:
+    """Return the default path to outputs.tf within a Terraform-based jupyter-deploy project."""
+    return project_dir / "engine" / "outputs.tf"
+
+
+def parse_variable_descriptions(variables_tf: Path) -> dict[str, str]:
+    """Read variables.tf file, parse using regex, return the dict varname->cleaned-content.
+
+    Only handles ``<<-MARKER`` (indented) heredoc descriptions.
+    Returns a dict mapping variable name to the expanded description body.
+    """
+    content = variables_tf.read_text()
+    result: dict[str, str] = {}
+    for m in _VARIABLE_HEREDOC_RE.finditer(content):
+        body = textwrap.dedent(m.group("body")).strip("\n")
+        result[m.group("name")] = body
+    return result
+
+
+def parse_output_descriptions(outputs_tf: Path) -> dict[str, str]:
+    """Read outputs.tf file, parse using regex, return the dict outputname->cleaned-content.
+
+    Only handles inline quoted descriptions (``description = "..."``).
+    Returns a dict mapping output name to its description string.
+    """
+    content = outputs_tf.read_text()
+    return {m.group("name"): m.group("desc") for m in _OUTPUT_INLINE_DESC_RE.finditer(content)}


### PR DESCRIPTION
This PR fixes a regression introduced by #198 where `hcl2` upgrade to `9.*` broke the parsing of `variables.tf` description, so that `jd config --help` no longer showed a usable variable description. Also affected `jd show -v VARNAME --description`.

### Implementation
- fix `<jd>/engine/terraform/tf_varfiles` to correctly parse the content
- expand unit tests to catch future regressions (both for `variables.tf` and `outputs.tf`)
- add e2e test coverage for variables and outputs description in `jd config --help` and `jd show`