### PR TITLE
fix: cli path attributes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -106,6 +106,14 @@ Always run from the root of the repository:
 2. you MUST NOT write docstrings that merely repeat a method name
 3. you MUST NOT use `TYPE_CHECKING` imports anywhere
 
+## CLI docstring style
+In CLI command docstrings and help strings (`libs/jupyter-deploy/jupyter_deploy/cli/`):
+1. Avoid mentioning "jupyter", "jupyterlab", or "jupyter-deploy project" — use "project" or "app".
+2. Reference commands with angle brackets: `<jd init>`, `<jd up>`.
+3. Reference optional flags bare (no backticks): --overwrite or -o.
+4. Reference flag values in lowercase angle brackets: --path <project-dir>, --variable <variable-name>.
+**Note:** Rules 2-4 DO NOT apply to `console.print()` statements, only to cli docstrings.
+
 ## Writing unit tests
 Unit tests are located in `libs/<package-name>/tests/unit`
 

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_open.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_open.py
@@ -23,11 +23,11 @@ def test_open_show_correct_url(e2e_deployment: EndToEndDeployment) -> None:
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "open"])
 
     # Verify the output contains expected text
-    assert "Opening Jupyter app at:" in result.stdout, "Expected 'Opening Jupyter app at:' in jd open output"
+    assert "Opening app at:" in result.stdout, "Expected 'Opening app at:' in jd open output"
 
     # Extract the URL from the output using regex
-    # Expected format: "Opening Jupyter app at: https://subdomain.domain.com"
-    url_pattern = r"Opening Jupyter app at:\s+(https://[^\s]+)"
+    # Expected format: "Opening app at: https://subdomain.domain.com"
+    url_pattern = r"Opening app at:\s+(https://[^\s]+)"
     match = re.search(url_pattern, result.stdout)
     assert match is not None, "Could not extract URL from jd open output"
 

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -47,7 +47,7 @@ class JupyterDeployCliRunner:
     def __init__(self) -> None:
         """Setup the CLI shell, add sub-commands."""
         self.app = typer.Typer(
-            help=("Jupyter-deploy CLI helps you deploy notebooks application to your favorite Cloud provider."),
+            help="Deploy interactive applications to the cloud.",
             no_args_is_help=True,
         )
         self._setup_basic_commands()
@@ -84,7 +84,7 @@ def init(
     path: Annotated[
         Path | None,
         typer.Argument(
-            help="Path to the directory where jupyter-deploy will create your project files. "
+            help="Path to the directory where the project files will be created. "
             "Pass '.' to use your current working directory."
         ),
     ] = None,
@@ -130,13 +130,13 @@ def init(
         typer.Option("--store-id", help="ID of a specific store to restore from."),
     ] = None,
 ) -> None:
-    """Initialize a project directory containing the specified infrastructure-as-code template.
+    """Initialize a project from a template in the target directory.
 
     Template will be selected based on the provided parameters - the matching
     template package must have already been installed.
 
     You must specify a project path which must be a directory. If such a directory is not empty,
-    the command will fail unless you passed the `--overwrite` or `-o` flag. `--overwrite` will prompt
+    the command will fail unless you passed --overwrite or -o. --overwrite will prompt
     for confirmation before deleting existing content.
 
     Alternatively, use --restore-project to restore a project from a remote store.
@@ -296,14 +296,14 @@ def config(
 ) -> None:
     """Verify the system configuration, prompt inputs and prepare for deployment.
 
-    You must run this command from a jupyter-deploy project directory created with `jd init`.
+    Run from a project directory created with <jd init>.
 
-    The `config` command will remember your variable values so that you do not need to
-    specify them again next time you run `config`.
+    The config command will remember your variable values so that you do not need to
+    specify them again next time you run <jd config>.
 
-    You can reset these recorded values with `--reset` or `-r`.
+    You can reset these recorded values with --reset or -r.
 
-    You can specify where to save the planned change with `--output-file` or `-f`.
+    You can specify where to save the planned change with --output-file or -f.
     """
     console = Console()
     with handle_cli_errors(console):
@@ -455,12 +455,14 @@ def config(
 @runner.app.command()
 def up(
     project_dir: Annotated[
-        Path | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to bring up.")
+        Path | None, typer.Option("--path", "-p", help="Directory of the project to bring up.")
     ] = None,
     config_filename: Annotated[
         str | None,
         typer.Option(
-            "--config-filename", "-f", help="Name of a file in the project_dir containing the execution configuration."
+            "--config-filename",
+            "-f",
+            help="Name of a file in the project directory containing the execution configuration.",
         ),
     ] = None,
     auto_approve: Annotated[
@@ -468,13 +470,13 @@ def up(
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Show full output without progress bar.")] = False,
 ) -> None:
-    """Apply the changes defined in the infrastructure-as-code template.
+    """Apply the project configuration to the cloud resources.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory. Optionally, you can also pass a --config-file
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>. Optionally, you can also pass a --config-file
     argument.
 
-    Call `jd config` first to set the input variables and
+    Call <jd config> first to set the input variables and
     verify the configuration.
     """
     console = Console()
@@ -526,20 +528,20 @@ def up(
 @runner.app.command()
 def down(
     project_dir: Annotated[
-        Path | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to bring down.")
+        Path | None, typer.Option("--path", "-p", help="Directory of the project to bring down.")
     ] = None,
     auto_approve: Annotated[
         bool, typer.Option("--answer-yes", "-y", help="Destroy resources without confirmation prompt.")
     ] = False,
     verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Show full output without progress bar.")] = False,
 ) -> None:
-    """Destroy the resources defined in the infrastructure-as-code template.
+    """Destroy the cloud resources defined in the project configuration.
 
-    Run either from a jupyter-deploy project directed that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
 
-    No-op if you have not already created the infrastructure with `jd up`, or if you
-    already ran `jd down`.
+    No-op if you have not already created the infrastructure with <jd up>, or if you
+    already ran <jd down>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -587,16 +589,14 @@ def down(
 
 @runner.app.command()
 def open(
-    project_dir: Annotated[
-        Path | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to open.")
-    ] = None,
+    project_dir: Annotated[Path | None, typer.Option("--path", "-p", help="Directory of the project to open.")] = None,
 ) -> None:
-    """Open the Jupyter app in your webbrowser.
+    """Open the app in your web browser.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
 
-    Call `jd config` and `jd up` first.
+    Call <jd config> and <jd up> first.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -607,7 +607,7 @@ def open(
 
         try:
             url = handler.open()
-            console.print(f"\nOpening Jupyter app at: {url}", style="green")
+            console.print(f"\nOpening app at: {url}", style="green")
         except UrlNotAvailableError as e:
             # URL not available - show helpful message but don't fail (project not deployed)
             console.print(f":x: {e}", style="bold red")
@@ -663,7 +663,7 @@ def open(
 @runner.app.command()
 def show(
     project_dir: Annotated[
-        Path | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to show information.")
+        Path | None, typer.Option("--path", "-p", help="Directory of the project to show information.")
     ] = None,
     info: Annotated[bool, typer.Option("--info", help="Display core project and template information.")] = False,
     outputs: Annotated[bool, typer.Option("--outputs", help="Display outputs information.")] = False,
@@ -706,13 +706,13 @@ def show(
         typer.Option("--text", help="Output plain text without Rich markup."),
     ] = False,
 ) -> None:
-    """Display information about the jupyter-deploy project.
+    """Display information about the project.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
 
     If the project is up, shows the values of the output as defined in
-    the infrastructure as code project.
+    the infrastructure-as-code project.
 
     Pass --variable <variable-name> to display the value of a single variable, or
     -v <variable-name> --description to display its description.

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -82,7 +82,7 @@ runner = JupyterDeployCliRunner()
 @runner.app.command()
 def init(
     path: Annotated[
-        str | None,
+        Path | None,
         typer.Argument(
             help="Path to the directory where jupyter-deploy will create your project files. "
             "Pass '.' to use your current working directory."
@@ -156,7 +156,7 @@ def init(
 
 def _init_from_template(
     console: Console,
-    path: str,
+    path: Path,
     engine: EngineType,
     provider: ProviderType,
     infrastructure: InfrastructureType,
@@ -215,7 +215,7 @@ def _init_from_template(
 
 def _init_from_store(
     console: Console,
-    path: str,
+    path: Path,
     project_id: str,
     store_type: StoreType | None,
     store_id: str | None,
@@ -455,7 +455,7 @@ def config(
 @runner.app.command()
 def up(
     project_dir: Annotated[
-        str | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to bring up.")
+        Path | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to bring up.")
     ] = None,
     config_filename: Annotated[
         str | None,
@@ -526,7 +526,7 @@ def up(
 @runner.app.command()
 def down(
     project_dir: Annotated[
-        str | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to bring down.")
+        Path | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to bring down.")
     ] = None,
     auto_approve: Annotated[
         bool, typer.Option("--answer-yes", "-y", help="Destroy resources without confirmation prompt.")
@@ -588,7 +588,7 @@ def down(
 @runner.app.command()
 def open(
     project_dir: Annotated[
-        str | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to open.")
+        Path | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to open.")
     ] = None,
 ) -> None:
     """Open the Jupyter app in your webbrowser.
@@ -663,7 +663,7 @@ def open(
 @runner.app.command()
 def show(
     project_dir: Annotated[
-        str | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to show information.")
+        Path | None, typer.Option("--path", "-p", help="Directory of the jupyter-deploy project to show information.")
     ] = None,
     info: Annotated[bool, typer.Option("--info", help="Display core project and template information.")] = False,
     outputs: Annotated[bool, typer.Option("--outputs", help="Display outputs information.")] = False,

--- a/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
@@ -76,8 +76,7 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         console.print(f":x: {e}", style="bold red")
         console.line()
         console.print(
-            ":bulb: Change your working directory to a jupyter-deploy project "
-            "or create one with [bold cyan]jd init PATH[/]"
+            ":bulb: Change your working directory to a project directory or create one with [bold cyan]jd init PATH[/]"
         )
         raise typer.Exit(code=1) from None
 

--- a/libs/jupyter-deploy/jupyter_deploy/cli/history_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/history_app.py
@@ -25,7 +25,7 @@ def list(
         typer.Argument(help="Jupyter-deploy command that generated the logs."),
     ],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
     n: Annotated[
@@ -81,7 +81,7 @@ def show(
         ),
     ] = None,
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
     n: Annotated[
@@ -165,7 +165,7 @@ def clear(
         ),
     ],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
     keep: Annotated[

--- a/libs/jupyter-deploy/jupyter_deploy/cli/history_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/history_app.py
@@ -13,7 +13,7 @@ from jupyter_deploy.enum import HistoryEnabledCommandType
 from jupyter_deploy.handlers.command_history_handler import CommandHistoryHandler
 
 history_app = typer.Typer(
-    help=("View and manage logs emitted by the infrastructure-as-code engine within jupyter-deploy commands."),
+    help="View and manage logs emitted by the infrastructure-as-code engine.",
     no_args_is_help=True,
 )
 
@@ -22,11 +22,11 @@ history_app = typer.Typer(
 def list(
     command: Annotated[
         HistoryEnabledCommandType,
-        typer.Argument(help="Jupyter-deploy command that generated the logs."),
+        typer.Argument(help="Command that generated the logs."),
     ],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
     n: Annotated[
         int,
@@ -39,8 +39,8 @@ def list(
 ) -> None:
     """Show the list of execution logs available in the project for a specific command.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -77,12 +77,12 @@ def show(
     command: Annotated[
         HistoryEnabledCommandType | None,
         typer.Argument(
-            help="Jupyter-deploy command that generated the log. If omitted, show latest log from any command.",
+            help="Command that generated the log. If omitted, show latest log from any command.",
         ),
     ] = None,
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
     n: Annotated[
         int,
@@ -99,8 +99,8 @@ def show(
 ) -> None:
     """Display the content of a specific command execution log.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
 
     By default, displays the content of the entire log.
 
@@ -166,7 +166,7 @@ def clear(
     ],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
     keep: Annotated[
         int,
@@ -175,8 +175,8 @@ def clear(
 ) -> None:
     """Delete execution logs for a specific command, keeping only the most recent N logs.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -18,7 +19,7 @@ host_app = typer.Typer(
 @host_app.command()
 def status(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to check status."),
     ] = None,
     status_for: Annotated[
@@ -50,7 +51,7 @@ def status(
 @host_app.command()
 def stop(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to stop."),
     ] = None,
 ) -> None:
@@ -71,7 +72,7 @@ def stop(
 @host_app.command()
 def start(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to start."),
     ] = None,
 ) -> None:
@@ -92,7 +93,7 @@ def start(
 @host_app.command()
 def restart(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to restart."),
     ] = None,
 ) -> None:
@@ -113,7 +114,7 @@ def restart(
 @host_app.command()
 def connect(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to restart."),
     ] = None,
 ) -> None:
@@ -135,7 +136,7 @@ def connect(
 def exec(
     ctx: typer.Context,
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -11,7 +11,7 @@ from jupyter_deploy.enum import HostStatusType
 from jupyter_deploy.handlers.resource import host_handler
 
 host_app = typer.Typer(
-    help=("""Interact with the host running your Jupyter server."""),
+    help="Interact with the host machine running your app.",
     no_args_is_help=True,
 )
 
@@ -20,7 +20,7 @@ host_app = typer.Typer(
 def status(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to check status."),
+        typer.Option("--path", "-p", help="Directory of the project whose host to check status."),
     ] = None,
     status_for: Annotated[
         HostStatusType | None,
@@ -29,8 +29,8 @@ def status(
 ) -> None:
     """Check the status of the host machine.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -52,13 +52,13 @@ def status(
 def stop(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to stop."),
+        typer.Option("--path", "-p", help="Directory of the project whose host to stop."),
     ] = None,
 ) -> None:
     """Stop the host machine.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -73,13 +73,13 @@ def stop(
 def start(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to start."),
+        typer.Option("--path", "-p", help="Directory of the project whose host to start."),
     ] = None,
 ) -> None:
     """Start the host machine.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -94,13 +94,13 @@ def start(
 def restart(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to restart."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
     """Restart the host machine.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -115,13 +115,13 @@ def restart(
 def connect(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose host to restart."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
     """Start an SSH-style connection to the host machine.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -137,19 +137,19 @@ def exec(
     ctx: typer.Context,
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
     """Execute a non-interactive command on the host machine.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
 
     Pass the command after '--', for example:
 
-    jd host exec -- df -h
+    <jd host exec -- df -h>
 
-    jd host exec -- "docker container list | grep jupyter"
+    <jd host exec -- "docker container list | grep jupyter">
     """
     # Arguments after -- are in ctx.args
     command_args = ctx.args

--- a/libs/jupyter-deploy/jupyter_deploy/cli/organization_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/organization_app.py
@@ -10,7 +10,7 @@ from jupyter_deploy.cli.simple_display import SimpleDisplayManager
 from jupyter_deploy.handlers.access import organization_handler
 
 organization_app = typer.Typer(
-    help=("""Control access to your jupyter app at the organization level."""),
+    help="Control access to your app at the organization level.",
     no_args_is_help=True,
 )
 
@@ -20,13 +20,13 @@ def set(
     organization: Annotated[str, typer.Argument(help="Name of the organization to allowlist.")],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Allowlist an organization to access the Jupyter app.
+    """Allowlist an organization to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -41,13 +41,13 @@ def set(
 def unset(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Remove organization-based access to the Jupyter app.
+    """Remove organization-based access from the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -62,13 +62,13 @@ def unset(
 def get(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Show the name of the organization authorized to access the Jupyter app.
+    """Show the name of the organization authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):

--- a/libs/jupyter-deploy/jupyter_deploy/cli/organization_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/organization_app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -18,7 +19,7 @@ organization_app = typer.Typer(
 def set(
     organization: Annotated[str, typer.Argument(help="Name of the organization to allowlist.")],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:
@@ -39,7 +40,7 @@ def set(
 @organization_app.command()
 def unset(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:
@@ -60,7 +61,7 @@ def unset(
 @organization_app.command()
 def get(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -17,7 +18,7 @@ servers_app = typer.Typer(
 @servers_app.command()
 def status(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option(
             "--path", "-p", help="Directory of the jupyter-deploy project whose server to send an health check."
         ),
@@ -42,7 +43,7 @@ def status(
 @servers_app.command()
 def start(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose server to start."),
     ] = None,
     service: Annotated[
@@ -73,7 +74,7 @@ def start(
 @servers_app.command()
 def stop(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose server to stop."),
     ] = None,
     service: Annotated[
@@ -104,7 +105,7 @@ def stop(
 @servers_app.command()
 def restart(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose server to restart."),
     ] = None,
     service: Annotated[
@@ -136,7 +137,7 @@ def restart(
 def logs(
     ctx: typer.Context,
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose server to restart."),
     ] = None,
     service: Annotated[
@@ -195,7 +196,7 @@ def logs(
 def exec(
     ctx: typer.Context,
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
     service: Annotated[
@@ -257,7 +258,7 @@ def exec(
 @servers_app.command()
 def connect(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
     service: Annotated[str, typer.Option("--service", "-s", help="Name of the service to connect to.")] = "default",

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -10,7 +10,7 @@ from jupyter_deploy.cli.simple_display import SimpleDisplayManager
 from jupyter_deploy.handlers.resource import server_handler
 
 servers_app = typer.Typer(
-    help=("""Interact with the services running your Jupyter app."""),
+    help="Interact with the services running your app.",
     no_args_is_help=True,
 )
 
@@ -19,15 +19,13 @@ servers_app = typer.Typer(
 def status(
     project_dir: Annotated[
         Path | None,
-        typer.Option(
-            "--path", "-p", help="Directory of the jupyter-deploy project whose server to send an health check."
-        ),
+        typer.Option("--path", "-p", help="Directory of the project whose server to send a health check."),
     ] = None,
 ) -> None:
     """Sends a health check to the services.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -37,14 +35,14 @@ def status(
         with simple_display_manager.spinner("Checking server status..."):
             server_status = handler.get_server_status()
 
-        console.print(f"Jupyter server status: [bold cyan]{server_status}[/]")
+        console.print(f"Server status: [bold cyan]{server_status}[/]")
 
 
 @servers_app.command()
 def start(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose server to start."),
+        typer.Option("--path", "-p", help="Directory of the project whose server to start."),
     ] = None,
     service: Annotated[
         str, typer.Option("--service", "-s", help="Service to start ('all', 'jupyter', or other available services).")
@@ -54,8 +52,8 @@ def start(
 
     By default, starts all services. Specify --service to target a specific service.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -66,7 +64,7 @@ def start(
             handler.start_server(service)
 
         if service == "all":
-            simple_display_manager.success("Started the Jupyter server and all the sidecars.")
+            simple_display_manager.success("Started all services.")
         else:
             simple_display_manager.success(f"Started the '{service}' service.")
 
@@ -75,7 +73,7 @@ def start(
 def stop(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose server to stop."),
+        typer.Option("--path", "-p", help="Directory of the project whose server to stop."),
     ] = None,
     service: Annotated[
         str, typer.Option("--service", "-s", help="Service to stop ('all', 'jupyter', or other available services).")
@@ -85,8 +83,8 @@ def stop(
 
     By default, stops all services. Specify --service to target a specific service.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -97,7 +95,7 @@ def stop(
             handler.stop_server(service)
 
         if service == "all":
-            simple_display_manager.success("Stopped the Jupyter server and all the sidecars.")
+            simple_display_manager.success("Stopped all services.")
         else:
             simple_display_manager.success(f"Stopped the '{service}' service.")
 
@@ -106,7 +104,7 @@ def stop(
 def restart(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose server to restart."),
+        typer.Option("--path", "-p", help="Directory of the project whose server to restart."),
     ] = None,
     service: Annotated[
         str, typer.Option("--service", "-s", help="Service to restart ('all', 'jupyter', or other available services).")
@@ -116,8 +114,8 @@ def restart(
 
     By default, restarts all services. Specify --service to target a specific service.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -128,7 +126,7 @@ def restart(
             handler.restart_server(service)
 
         if service == "all":
-            simple_display_manager.success("Restarted the Jupyter server and all the sidecars.")
+            simple_display_manager.success("Restarted all services.")
         else:
             simple_display_manager.success(f"Restarted the '{service}' service.")
 
@@ -138,7 +136,7 @@ def logs(
     ctx: typer.Context,
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project whose server to restart."),
+        typer.Option("--path", "-p", help="Directory of the project whose server to restart."),
     ] = None,
     service: Annotated[
         str, typer.Option("--service", "-s", help="Name of the service whose logs to display.")
@@ -148,8 +146,8 @@ def logs(
 
     By default, logs your main application service. Specify --service to target a specific service.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path <PATH> to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
 
     You can pass additional arguments after '--'
 
@@ -197,7 +195,7 @@ def exec(
     ctx: typer.Context,
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
     service: Annotated[
         str, typer.Option("--service", "-s", help="Name of the service in which to execute the command.")
@@ -207,14 +205,14 @@ def exec(
 
     By default, executes in your main application service. Specify --service to target a specific service.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
 
     Pass the command after '--', for example:
 
-    jd server exec -s SERVICE -- pwd
+    <jd server exec -s SERVICE -- pwd>
 
-    jd server exec -s SERVICE -- "df -h"
+    <jd server exec -s SERVICE -- "df -h">
 
     Note: the commands you can execute depend on the service;
     distroless images in particular expose very limited commands.
@@ -259,7 +257,7 @@ def exec(
 def connect(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
     service: Annotated[str, typer.Option("--service", "-s", help="Name of the service to connect to.")] = "default",
 ) -> None:
@@ -267,14 +265,14 @@ def connect(
 
     By default, connects to your main application service. Specify --service to target a specific service.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
 
     Example:
 
-    jd server connect
+    <jd server connect>
 
-    jd server connect -s SERVICE
+    <jd server connect -s SERVICE>
 
     Note: you may not be able to connect to all services;
     some containers do not have any shell installed.

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -136,7 +136,7 @@ def logs(
     ctx: typer.Context,
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the project whose server to restart."),
+        typer.Option("--path", "-p", help="Directory of the project whose server logs to display."),
     ] = None,
     service: Annotated[
         str, typer.Option("--service", "-s", help="Name of the service whose logs to display.")

--- a/libs/jupyter-deploy/jupyter_deploy/cli/teams_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/teams_app.py
@@ -10,7 +10,7 @@ from jupyter_deploy.cli.simple_display import SimpleDisplayManager
 from jupyter_deploy.handlers.access import team_handler
 
 teams_app = typer.Typer(
-    help=("""Control access to your jupyter app at team level."""),
+    help="Control access to your app at team level.",
     no_args_is_help=True,
 )
 
@@ -20,13 +20,13 @@ def add(
     teams: Annotated[list[str], typer.Argument(help="Names of the teams to add to the allowlist.")],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Add team(s) to the list authorized to access the Jupyter app.
+    """Add team(s) to the list authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -42,13 +42,13 @@ def remove(
     teams: Annotated[list[str], typer.Argument(help="Names of the teams to remove from the allowlist.")],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Remove team(s) from the list authorized to access the Jupyter app.
+    """Remove team(s) from the list authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -64,13 +64,13 @@ def set(
     teams: Annotated[list[str], typer.Argument(help="Names of the teams to allowlist.")],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Set the list of team(s) authorized to access the Jupyter app.
+    """Set the list of team(s) authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -86,13 +86,13 @@ def set(
 def list_teams(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Show the name(s) of the team(s) authorized to access the Jupyter app.
+    """Show the name(s) of the team(s) authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):

--- a/libs/jupyter-deploy/jupyter_deploy/cli/teams_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/teams_app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -18,7 +19,7 @@ teams_app = typer.Typer(
 def add(
     teams: Annotated[list[str], typer.Argument(help="Names of the teams to add to the allowlist.")],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:
@@ -40,7 +41,7 @@ def add(
 def remove(
     teams: Annotated[list[str], typer.Argument(help="Names of the teams to remove from the allowlist.")],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:
@@ -62,7 +63,7 @@ def remove(
 def set(
     teams: Annotated[list[str], typer.Argument(help="Names of the teams to allowlist.")],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:
@@ -84,7 +85,7 @@ def set(
 @teams_app.command("list")
 def list_teams(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:

--- a/libs/jupyter-deploy/jupyter_deploy/cli/users_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/users_app.py
@@ -10,7 +10,7 @@ from jupyter_deploy.cli.simple_display import SimpleDisplayManager
 from jupyter_deploy.handlers.access import user_handler
 
 users_app = typer.Typer(
-    help=("""Control access to your jupyter app at user level."""),
+    help="Control access to your app at user level.",
     no_args_is_help=True,
 )
 
@@ -20,13 +20,13 @@ def add(
     users: Annotated[list[str], typer.Argument(help="Name of the users to add to the allowlist.")],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Add user(s) to the list authorized to access the Jupyter app.
+    """Add user(s) to the list authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -42,13 +42,13 @@ def remove(
     users: Annotated[list[str], typer.Argument(help="Name of the users to remove from the allowlist.")],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Remove user(s) from the list authorized to access the Jupyter app.
+    """Remove user(s) from the list authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -64,13 +64,13 @@ def set(
     users: Annotated[list[str], typer.Argument(help="Names of the users to allowlist.")],
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Set the list of username(s) authorized to access the Jupyter app.
+    """Set the list of username(s) authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -86,13 +86,13 @@ def set(
 def list_users(
     project_dir: Annotated[
         Path | None,
-        typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
+        typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
 ) -> None:
-    """Show the name(s) of user(s) authorized to access the Jupyter app.
+    """Show the name(s) of user(s) authorized to access the app.
 
-    Run either from a jupyter-deploy project directory that you created with `jd init`;
-    or pass a --path PATH to such a directory.
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):

--- a/libs/jupyter-deploy/jupyter_deploy/cli/users_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/users_app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -18,7 +19,7 @@ users_app = typer.Typer(
 def add(
     users: Annotated[list[str], typer.Argument(help="Name of the users to add to the allowlist.")],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:
@@ -40,7 +41,7 @@ def add(
 def remove(
     users: Annotated[list[str], typer.Argument(help="Name of the users to remove from the allowlist.")],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:
@@ -62,7 +63,7 @@ def remove(
 def set(
     users: Annotated[list[str], typer.Argument(help="Names of the users to allowlist.")],
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:
@@ -84,7 +85,7 @@ def set(
 @users_app.command("list")
 def list_users(
     project_dir: Annotated[
-        str | None,
+        Path | None,
         typer.Option("--path", "-p", help="Directory of the jupyter-deploy project."),
     ] = None,
 ) -> None:

--- a/libs/jupyter-deploy/jupyter_deploy/cli/variables_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/variables_decorator.py
@@ -19,7 +19,7 @@ def with_project_variables() -> Callable:
     typer sees a new method defined by the decorator with all the template variables.
 
     The variable definition discovery relies on retrieving the current working directory,
-    so the user must have changed dir to a jupyter-deploy project dir.
+    so the user must have changed dir to a project directory.
 
     Usage:
         @cli_app.app.command()

--- a/libs/jupyter-deploy/jupyter_deploy/cmd_utils.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cmd_utils.py
@@ -185,7 +185,7 @@ def run_cmd_and_pipe_to_terminal(
 
 
 @contextmanager
-def project_dir(dir: str | None) -> Generator:
+def project_dir(dir: Path | None) -> Generator:
     """Execute the inner function within a `cd` to the dir_path argument.
 
     If target_path is None, just execute the inner function.
@@ -202,7 +202,7 @@ def project_dir(dir: str | None) -> Generator:
         return
 
     original_dir = Path(os.getcwd())
-    target_path = Path(dir)
+    target_path = dir
 
     if not target_path.exists():
         raise InvalidProjectPathError(f"Target path not found: {target_path}")

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_handler.py
@@ -17,7 +17,7 @@ class InitHandler:
 
     def __init__(
         self,
-        project_dir: str | None,
+        project_dir: Path | None,
         engine: EngineType = EngineType.TERRAFORM,
         provider: ProviderType = ProviderType.AWS,
         infrastructure: InfrastructureType = AWSInfrastructureType.EC2,
@@ -27,7 +27,7 @@ class InitHandler:
         if not project_dir:
             self.project_path = fs_utils.get_default_project_path()
         else:
-            self.project_path = Path(project_dir)
+            self.project_path = project_dir
 
         self.abs_project_path = Path.resolve(self.project_path)
         self.engine = engine
@@ -94,7 +94,7 @@ class InitHandler:
 
     @staticmethod
     def restore(
-        project_dir: str,
+        project_dir: Path,
         project_id: str,
         store_type: StoreType,
         display_manager: DisplayManager,
@@ -105,7 +105,7 @@ class InitHandler:
         Returns:
             The absolute path to the restored project.
         """
-        dest_path = Path(project_dir)
+        dest_path = project_dir
         store_manager = StoreManagerFactory.get_manager(store_type=store_type, store_id=store_id)
         store_manager.pull(project_id, dest_path, display_manager)
 

--- a/libs/jupyter-deploy/tests/unit/cli/test_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app.py
@@ -2,6 +2,7 @@ import sys
 import unittest
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import typer
@@ -183,7 +184,7 @@ class TestDownCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["down", "--path", "/custom/path"])
 
         self.assertEqual(result.exit_code, 0)
-        mock_project_ctx_manager.assert_called_once_with("/custom/path")
+        mock_project_ctx_manager.assert_called_once_with(Path("/custom/path"))
         mock_down_fns["destroy"].assert_called_once()
 
     @patch("jupyter_deploy.cli.app.DownHandler")

--- a/libs/jupyter-deploy/tests/unit/cli/test_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app.py
@@ -84,7 +84,7 @@ class TestJupyterDeployCliRunner(unittest.TestCase):
 
         # Check that the command ran successfully
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(result.stdout.index("Jupyter-deploy") >= 0)
+        self.assertTrue(result.stdout.index("Deploy interactive") >= 0)
         self.assertTrue(result.stdout.index("server") >= 0)
         self.assertTrue(result.stdout.index("host") >= 0)
         self.assertTrue(result.stdout.index("users") >= 0)
@@ -97,7 +97,7 @@ class TestJupyterDeployCliRunner(unittest.TestCase):
 
         # Check that the command ran successfully
         self.assertEqual(result.exit_code, 0)
-        self.assertTrue(result.stdout.index("Jupyter-deploy") >= 0)
+        self.assertTrue(result.stdout.index("Deploy interactive") >= 0)
 
 
 class TestJupyterDeployApp(unittest.TestCase):

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_init.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_init.py
@@ -37,7 +37,7 @@ class TestInitCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, "init command should work")
 
         mock_handler_cls.assert_called_once_with(
-            project_dir=".",
+            project_dir=Path("."),
             engine=EngineType.TERRAFORM,
             provider="aws",
             infrastructure="ec2",
@@ -68,7 +68,7 @@ class TestInitCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, "init command should work")
 
         mock_handler_cls.assert_called_once_with(
-            project_dir="custom-dir",
+            project_dir=Path("custom-dir"),
             engine=EngineType.TERRAFORM,
             provider="aws",
             infrastructure="ec2",
@@ -88,7 +88,7 @@ class TestInitCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, "init command should work")
 
         mock_handler_cls.assert_called_once_with(
-            project_dir="custom-dir",
+            project_dir=Path("custom-dir"),
             engine=EngineType.TERRAFORM,
             provider="aws",
             infrastructure="ec2",
@@ -188,7 +188,7 @@ class TestInitRestoreCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         mock_handler_cls.restore.assert_called_once()
         call_kwargs = mock_handler_cls.restore.call_args.kwargs
-        self.assertEqual(call_kwargs["project_dir"], "/tmp/restored")
+        self.assertEqual(call_kwargs["project_dir"], Path("/tmp/restored"))
         self.assertEqual(call_kwargs["project_id"], "tpl-abc123")
         self.assertIsNone(call_kwargs["store_id"])
         self.assertIn("restored", result.output)

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
@@ -89,7 +89,7 @@ class TestOpenCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         # Check that success message is displayed
-        self.assertIn("Opening Jupyter app at:", result.output)
+        self.assertIn("Opening app at:", result.output)
         self.assertIn("https://example.com/jupyter", result.output)
         # Check that hint is displayed
         self.assertIn("Having trouble?", result.output)
@@ -249,7 +249,7 @@ class TestOpenCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["open"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("Opening Jupyter app at:", result.output)
+        self.assertIn("Opening app at:", result.output)
         # Check that hint is NOT displayed
         self.assertNotIn("Having trouble?", result.output)
 

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -52,7 +53,7 @@ class TestOpenCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["open", "--path", "/custom/path"])
 
         self.assertEqual(result.exit_code, 0)
-        mock_project_ctx_manager.assert_called_once_with("/custom/path")
+        mock_project_ctx_manager.assert_called_once_with(Path("/custom/path"))
         mock_open_fns["open"].assert_called_once()
 
     @patch("jupyter_deploy.cli.app.OpenHandler")

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_show.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_show.py
@@ -1,6 +1,7 @@
 import unittest
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -156,7 +157,7 @@ class TestShowCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["show", "--path", "/custom/path"])
 
         self.assertEqual(result.exit_code, 0)
-        mock_project_ctx_manager.assert_called_once_with("/custom/path")
+        mock_project_ctx_manager.assert_called_once_with(Path("/custom/path"))
 
     @patch("jupyter_deploy.cli.app.ShowHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_up.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_up.py
@@ -1,6 +1,7 @@
 import unittest
 from collections.abc import Generator
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -74,7 +75,7 @@ class TestUpCommand(unittest.TestCase):
 
         # Should exit with code 1 when config file doesn't exist
         self.assertEqual(result.exit_code, 1)
-        mock_project_ctx_manager.assert_called_once_with("/custom/path")
+        mock_project_ctx_manager.assert_called_once_with(Path("/custom/path"))
 
     @patch("jupyter_deploy.cli.app.UpHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -139,7 +140,7 @@ class TestUpCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["up", "--path", "/custom/path", "--answer-yes"])
 
         self.assertEqual(result.exit_code, 0)
-        mock_project_ctx_manager.assert_called_once_with("/custom/path")
+        mock_project_ctx_manager.assert_called_once_with(Path("/custom/path"))
         mock_up_fns["get_config_file_path"].assert_called_once_with(None)
         mock_up_fns["apply"].assert_called_once_with("/path/to/config", True)
 

--- a/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -111,7 +112,7 @@ class TestHostStatusCommand(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -176,7 +177,7 @@ class TestHostStartCommand(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -241,7 +242,7 @@ class TestHostStopCommand(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -306,7 +307,7 @@ class TestHostRestartCommand(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -396,7 +397,7 @@ class TestHostStatusForFlag(unittest.TestCase):
         result = runner.invoke(host_app, ["status", "--for", "connection", "--path", "/test/project/path"])
 
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -486,7 +487,7 @@ class TestHostConnectCommand(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.cli.host_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.host_app.Console")
@@ -651,7 +652,7 @@ class TestHostExecCommand(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.cli.host_app.Console")
     def test_fails_when_no_command_provided(self, mock_console_class: Mock) -> None:

--- a/libs/jupyter-deploy/tests/unit/cli/test_organization_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_organization_app.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -84,7 +85,7 @@ class TestOrganizationSetCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.organization_handler.OrganizationHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -160,7 +161,7 @@ class TestOrganizationUnsetCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.organization_handler.OrganizationHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -312,7 +313,7 @@ class TestOrganizationGetCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.organization_handler.OrganizationHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")

--- a/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -116,7 +117,7 @@ class TestServerStatusCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -232,7 +233,7 @@ class TestServerStartCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.cli.servers_app.Console")
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
@@ -367,7 +368,7 @@ class TestServerStopCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.cli.servers_app.Console")
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
@@ -502,7 +503,7 @@ class TestServerRestartCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.cli.servers_app.Console")
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")

--- a/libs/jupyter-deploy/tests/unit/cli/test_teams_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_teams_app.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -81,7 +82,7 @@ class TestTeamAddCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.team_handler.TeamsHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -154,7 +155,7 @@ class TestTeamRemoveCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.team_handler.TeamsHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -228,7 +229,7 @@ class TestTeamSetCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.team_handler.TeamsHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -378,7 +379,7 @@ class TestTeamListCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.team_handler.TeamsHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")

--- a/libs/jupyter-deploy/tests/unit/cli/test_users_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_users_app.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
@@ -80,7 +81,7 @@ class TestUserAddCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.user_handler.UsersHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -152,7 +153,7 @@ class TestUserRemoveCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.user_handler.UsersHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -225,7 +226,7 @@ class TestUserSetCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.user_handler.UsersHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -375,7 +376,7 @@ class TestUserListCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_project_dir.assert_called_once_with("/test/project/path")
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
 
     @patch("jupyter_deploy.handlers.access.user_handler.UsersHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")

--- a/libs/jupyter-deploy/tests/unit/handlers/test_init_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_init_handler.py
@@ -20,7 +20,7 @@ class TestInitHandler(unittest.TestCase):
     ) -> None:
         """Test initialization with project_dir provided."""
         # Setup
-        project_dir = "/test/project/dir"
+        project_dir = Path("/test/project/dir")
         mock_template_path = Path("/mock/template/path")
         mock_find_template_path.return_value = mock_template_path
 
@@ -58,7 +58,7 @@ class TestInitHandler(unittest.TestCase):
     def test_init_with_enum_parameters(self, mock_find_template_path: MagicMock) -> None:
         """Test initialization with enum types for provider and infrastructure."""
         # Setup
-        project_dir = "/test/project/dir"
+        project_dir = Path("/test/project/dir")
         mock_template_path = Path("/mock/template/path")
         mock_find_template_path.return_value = mock_template_path
 
@@ -83,7 +83,7 @@ class TestInitHandler(unittest.TestCase):
         # Setup
         mock_find_template_path.return_value = Path("/mock/template/path")
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
 
         # Execute
         mock_find_template_path.return_value = Path("/mock/template/path")
@@ -101,7 +101,7 @@ class TestInitHandler(unittest.TestCase):
             ValueError("Template name cannot be empty"),  # For the actual test
         ]
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
 
         # Execute and Assert
         with self.assertRaisesRegex(ValueError, "Template name cannot be empty"):
@@ -119,7 +119,7 @@ class TestInitHandler(unittest.TestCase):
             ValueError("Engine 'terraform' is not supported. Available engines: none available"),  # For the actual test
         ]
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
 
         # Execute and Assert
         with self.assertRaisesRegex(ValueError, "Engine 'terraform' is not supported"):
@@ -138,7 +138,7 @@ class TestInitHandler(unittest.TestCase):
             ),  # For the actual test
         ]
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
 
         # Execute and Assert
         with self.assertRaisesRegex(ValueError, "Template 'aws:ec2:base' not found"):
@@ -157,7 +157,7 @@ class TestInitHandler(unittest.TestCase):
         mock_path.exists = mock_exists
         mock_find_template_path.return_value = Path("/mock/template/path")
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
         handler.project_path = mock_path
 
         # Execute
@@ -181,7 +181,7 @@ class TestInitHandler(unittest.TestCase):
         mock_is_empty_dir.return_value = True
         mock_find_template_path.return_value = Path("/mock/template/path")
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
         handler.project_path = mock_path
 
         # Execute
@@ -205,7 +205,7 @@ class TestInitHandler(unittest.TestCase):
         mock_is_empty_dir.return_value = False
         mock_find_template_path.return_value = Path("/mock/template/path")
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
         handler.project_path = mock_path
 
         # Execute
@@ -224,7 +224,7 @@ class TestInitHandler(unittest.TestCase):
         mock_path = Path("/test/project/dir")
         mock_find_template_path.return_value = Path("/mock/template/path")
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
         handler.project_path = mock_path
 
         # Execute
@@ -251,7 +251,7 @@ class TestInitHandler(unittest.TestCase):
         mock_docs_generator = MagicMock()
         mock_docs_generator_class.return_value = mock_docs_generator
 
-        handler = InitHandler(project_dir="/test/project/dir")
+        handler = InitHandler(project_dir=Path("/test/project/dir"))
         handler.project_path = mock_project_path
 
         # Execute
@@ -276,7 +276,7 @@ class TestInitHandlerRestore(unittest.TestCase):
         mock_factory.get_manager.return_value = mock_store_manager
 
         result = InitHandler.restore(
-            project_dir="/tmp/restored",
+            project_dir=Path("/tmp/restored"),
             project_id="tpl-abc123",
             store_type=StoreType.S3_ONLY,
             display_manager=NullDisplay(),
@@ -294,7 +294,7 @@ class TestInitHandlerRestore(unittest.TestCase):
         mock_factory.get_manager.return_value = mock_store_manager
 
         InitHandler.restore(
-            project_dir="/tmp/restored",
+            project_dir=Path("/tmp/restored"),
             project_id="tpl-abc123",
             store_type=StoreType.S3_ONLY,
             display_manager=NullDisplay(),
@@ -311,7 +311,7 @@ class TestInitHandlerRestore(unittest.TestCase):
         mock_factory.get_manager.return_value = mock_store_manager
 
         InitHandler.restore(
-            project_dir="/tmp/restored",
+            project_dir=Path("/tmp/restored"),
             project_id="tpl-abc123",
             store_type=StoreType.S3_ONLY,
             display_manager=NullDisplay(),
@@ -334,7 +334,7 @@ class TestInitHandlerRestore(unittest.TestCase):
         mock_factory.get_manager.return_value = mock_store_manager
 
         InitHandler.restore(
-            project_dir="/tmp/restored",
+            project_dir=Path("/tmp/restored"),
             project_id="tpl-abc123",
             store_type=StoreType.S3_ONLY,
             display_manager=NullDisplay(),

--- a/libs/jupyter-deploy/tests/unit/test_cmd_utils.py
+++ b/libs/jupyter-deploy/tests/unit/test_cmd_utils.py
@@ -595,7 +595,7 @@ class TestProjectManagerDirContextManager(unittest.TestCase):
         mock_is_dir.return_value = True
 
         # Call the context manager with a valid directory
-        with project_dir("/target/dir"):
+        with project_dir(Path("/target/dir")):
             # Verify directory was changed to target
             pass
 
@@ -618,7 +618,7 @@ class TestProjectManagerDirContextManager(unittest.TestCase):
 
         # Call the context manager with a valid directory and raise an exception inside
         with self.assertRaises(ValueError):  # noqa: SIM117
-            with project_dir("/target/dir"):
+            with project_dir(Path("/target/dir")):
                 raise ValueError("Test exception")
 
         # Verify directory was changed back to original despite the exception
@@ -636,7 +636,7 @@ class TestProjectManagerDirContextManager(unittest.TestCase):
 
         # Call the context manager with a non-existent directory
         with self.assertRaises(InvalidProjectPathError) as context:  # noqa: SIM117
-            with project_dir("/nonexistent/dir"):
+            with project_dir(Path("/nonexistent/dir")):
                 pass
 
         # Verify the correct error message
@@ -656,7 +656,7 @@ class TestProjectManagerDirContextManager(unittest.TestCase):
 
         # Call the context manager with a path that's not a directory
         with self.assertRaises(InvalidProjectPathError) as context:  # noqa: SIM117
-            with project_dir("/path/to/file.txt"):
+            with project_dir(Path("/path/to/file.txt")):
                 pass
 
         # Verify the correct error message

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
@@ -124,9 +124,9 @@ class JDCli:
         """
         result = self.run_command(["jupyter-deploy", "server", "status"])
 
-        # Parse output for line "Jupyter server status: <status>"
+        # Parse output for line "Server status: <status>"
         for line in result.stdout.splitlines():
-            if line.startswith("Jupyter server status:"):
+            if line.startswith("Server status:"):
                 # Extract status after the colon and color codes
                 status = line.split(":", 1)[1].strip()
                 # Remove ANSI color codes if present

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
@@ -134,7 +134,7 @@ class GitHubOAuth2ProxyApplication:
         logger.debug("Clicked authorize button on reauthorization page")
 
         # Wait for redirect after clicking (back to app domain, not GitHub)
-        self.page.wait_for_url(lambda url: "github.com" not in url, timeout=30000)
+        self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=30000)
 
         # Add 60-second delay post-authorization to allow GitHub processing
         logger.debug("Waiting 60 seconds for GitHub to process reauthorization...")
@@ -159,7 +159,7 @@ class GitHubOAuth2ProxyApplication:
                 authorize_button.click()
                 logger.debug("Clicked authorize button")
                 # Wait for redirect after clicking (back to app domain, not GitHub)
-                self.page.wait_for_url(lambda url: "github.com" not in url, timeout=10000)
+                self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=10000)
             else:
                 # No authorize button visible, might need manual auth
                 error_msg = (
@@ -202,6 +202,7 @@ class GitHubOAuth2ProxyApplication:
                 # Normal case: no 2FA interstitial, proceed with standard authorize flow
                 return False
         except Exception as e:
+            # Log a warning and continue here, the assertions will likely fail afterwards
             logger.warning(f"Error finding skip 2FA verification: {e}")
             return False
 
@@ -209,7 +210,7 @@ class GitHubOAuth2ProxyApplication:
         skip_button.click()
         # After skipping, GitHub shows a meta-refresh redirect page that is still on github.com.
         # Wait for the redirect to actually complete (leave github.com).
-        self.page.wait_for_url(lambda url: "github.com" not in url, timeout=30000)
+        self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=30000)
         logger.debug(f"2FA verification dismissed, now at: {self.page.url}")
         return True
 
@@ -295,7 +296,7 @@ class GitHubOAuth2ProxyApplication:
             # 3. Show a reauthorization page with a disabled button that becomes enabled
             try:
                 # Check if we're redirected automatically (back to app domain, not GitHub)
-                self.page.wait_for_url(lambda url: "github.com" not in url, timeout=5000)
+                self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=5000)
             except Exception:
                 # Still on authorize page - handle both normal and reauthorization flows
                 self._handle_oauth_authorize_page()
@@ -393,13 +394,13 @@ class GitHubOAuth2ProxyApplication:
         current_url = self.page.url
         if "github.com/login/oauth/authorize" in current_url:
             try:
-                self.page.wait_for_url(lambda url: "github.com" not in url, timeout=5000)
+                self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=5000)
             except Exception:
                 self._handle_oauth_authorize_page()
         elif "github.com" in current_url:
             # Wait a bit for any redirects to complete
             with contextlib.suppress(Exception):
-                self.page.wait_for_url(lambda url: "github.com" not in url, timeout=10000)
+                self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=10000)
 
         self.save_storage_state()
         logger.info("2FA login complete, storage state saved")

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
@@ -187,16 +187,51 @@ class GitHubOAuth2ProxyApplication:
             )
             raise RuntimeError(error_msg) from e
 
+    def _handle_2fa_verification_interstitial(self) -> bool:
+        """Dismiss GitHub's one-time 2FA verification interstitial if present.
+
+        GitHub periodically shows a "Verify your two-factor authentication (2FA) settings"
+        page during OAuth flows. Clicks "skip 2FA verification" to dismiss it.
+
+        Returns:
+            True if the interstitial was detected and dismissed, False otherwise.
+        """
+        try:
+            skip_button = self.page.get_by_role("button", name="skip 2FA verification")
+            if not skip_button.is_visible(timeout=2000):
+                # Normal case: no 2FA interstitial, proceed with standard authorize flow
+                return False
+        except Exception as e:
+            logger.warning(f"Error finding skip 2FA verification: {e}")
+            return False
+
+        logger.info("GitHub 2FA verification interstitial detected, skipping...")
+        skip_button.click()
+        # After skipping, GitHub shows a meta-refresh redirect page that is still on github.com.
+        # Wait for the redirect to actually complete (leave github.com).
+        self.page.wait_for_url(lambda url: "github.com" not in url, timeout=30000)
+        logger.debug(f"2FA verification dismissed, now at: {self.page.url}")
+        return True
+
     def _handle_oauth_authorize_page(self) -> None:
         """Handle GitHub OAuth authorize page, dispatching to appropriate handler.
 
-        Detects whether this is a standard authorization page or a reauthorization page
-        (shown when GitHub detects unusually high authorization request volume) and
-        dispatches to the appropriate handler.
+        Detects whether this is a standard authorization page, a reauthorization page
+        (shown when GitHub detects unusually high authorization request volume), or
+        a 2FA verification interstitial, and dispatches to the appropriate handler.
 
         Raises:
             RuntimeError: If authorization fails
         """
+        if self._handle_2fa_verification_interstitial():
+            # After dismissing, GitHub may redirect back to authorize page or to the app
+            current_url = self.page.url
+            if "github.com" not in current_url:
+                return
+            if "github.com/login/oauth/authorize" not in current_url:
+                return
+            # Still on authorize page — fall through to handle normal/reauth flow
+
         # Check if this is a reauthorization page by looking for the heading
         try:
             reauth_heading = self.page.get_by_role("heading", name="Reauthorization required")


### PR DESCRIPTION
This PR makes two minor improvements to the CLI:
1. change all path type CLI attributes from `str` to `Path` --> improves devX by supporting fs-based autocompletion
2. make CLI docstring more generic (e.g. `jupyter app` > `app`), and consistent

Also in this PR:
- plugin: handle 2fa verify prompt on GitHub (skip it)

### Testing
- run smoke tests
- run cli tests