### PR TITLE
feat: add username to ci template

### DIFF
--- a/justfile
+++ b/justfile
@@ -716,9 +716,9 @@ auth-bot-2fa ci_dir="sandbox-ci":
 auth-bot-email ci_dir="sandbox-ci":
     @uv run jd show -v github_bot_account_email --text --path {{ci_dir}}
 
-# Print the GitHub bot account username (email prefix before @)
+# Print the GitHub bot account username
 auth-bot-username ci_dir="sandbox-ci":
-    @just auth-bot-email {{ci_dir}} | cut -d'@' -f1
+    @uv run jd show -v github_bot_account_username --text --path {{ci_dir}}
 
 # Get the ECR repository URL for a given OAuth app number
 ci-e2e-base-ecr-url oauth_app_num ci_dir="sandbox-ci":

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/iam.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/iam.tf
@@ -36,6 +36,7 @@ locals {
   # SSM parameter ARNs — GitHub roles get read-only
   ssm_parameter_ro_arns = [
     module.github_bot_account_email.parameter_arn,
+    module.github_bot_account_username.parameter_arn,
     module.github_oauth_app_client_id_1.parameter_arn,
     module.github_oauth_app_client_id_2.parameter_arn,
     module.github_oauth_app_client_id_3.parameter_arn,

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/outputs.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/outputs.tf
@@ -48,6 +48,11 @@ output "github_bot_account_email_arn" {
   value       = module.github_bot_account_email.parameter_arn
 }
 
+output "github_bot_account_username_arn" {
+  description = "ARN of the SSM parameter for GitHub bot account username."
+  value       = module.github_bot_account_username.parameter_arn
+}
+
 # OAuth app client IDs (x5) — SSM parameters
 output "github_oauth_app_client_id_1_arn" {
   description = "ARN of the SSM parameter for GitHub OAuth app #1 client ID."

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/secrets.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/secrets.tf
@@ -40,6 +40,14 @@ module "github_bot_account_email" {
   tags        = local.default_tags
 }
 
+module "github_bot_account_username" {
+  source      = "./modules/ssm_parameter"
+  name        = "/${var.secret_name_prefix}-${local.doc_postfix}/github-bot-account-username"
+  description = "GitHub bot account username"
+  value       = var.github_bot_account_username
+  tags        = local.default_tags
+}
+
 # OAuth app client IDs (x5) — stored in SSM Parameter Store (not secret)
 # App metadata (app_id, app_url, callback_url) stored as tags for reference.
 module "github_oauth_app_client_id_1" {

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/variables.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/variables.tf
@@ -150,6 +150,16 @@ variable "github_bot_account_email" {
   type        = string
 }
 
+variable "github_bot_account_username" {
+  description = <<-EOT
+    GitHub username of the bot account used by E2E CI.
+
+    This is the actual GitHub login (e.g. "MyBotUser"), which may differ
+    from the email prefix. Stored in SSM Parameter Store.
+  EOT
+  type        = string
+}
+
 variable "github_bot_account_password" {
   description = <<-EOT
     Password for the GitHub bot account used by E2E CI.

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/variables.yaml
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/variables.yaml
@@ -5,6 +5,7 @@ required:
   github_org: null
   github_repo: null
   github_bot_account_email: null
+  github_bot_account_username: null
   github_oauth_app_1: {}
   github_oauth_app_2: {}
   github_oauth_app_3: {}

--- a/libs/jupyter-infra-tf-aws-iam-ci/tests/e2e/configurations/base.yaml
+++ b/libs/jupyter-infra-tf-aws-iam-ci/tests/e2e/configurations/base.yaml
@@ -3,6 +3,7 @@ required:
   github_org: "fake-test-org"
   github_repo: "fake-test-repo"
   github_bot_account_email: "fake-bot@example.com"
+  github_bot_account_username: "fake-bot"
   github_oauth_app_1:
     client_id: "Aa00000000000000test"
     app_id: "100001"

--- a/scripts/config_base_from_ci.py
+++ b/scripts/config_base_from_ci.py
@@ -96,8 +96,13 @@ def main() -> None:
     if allowed_usernames_arg:
         allowed_usernames = allowed_usernames_arg
     else:
-        # Default: allow the bot account (extract username from email)
-        bot_username = bot_email.split("@")[0] if "@" in bot_email else bot_email
+        result = subprocess.run(
+            ["uv", "run", "jd", "show", "-v", "github_bot_account_username", "--text", "-p", ci_dir],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        bot_username = result.stdout.strip()
         allowed_usernames = f'["{bot_username}"]'
 
     print(f"  allowed_usernames: {allowed_usernames}")

--- a/scripts/env_setup_base.py
+++ b/scripts/env_setup_base.py
@@ -147,7 +147,7 @@ def infer_deployment_vars(ci_dir: str, oauth_app_num: str) -> dict[str, str]:
     subdomain = parts[0]
     domain = parts[1]
 
-    # Read bot email
+    # Read bot email and username
     result = subprocess.run(
         ["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "-p", ci_dir],
         capture_output=True,
@@ -155,7 +155,13 @@ def infer_deployment_vars(ci_dir: str, oauth_app_num: str) -> dict[str, str]:
         check=True,
     )
     bot_email = result.stdout.strip()
-    bot_username = bot_email.split("@")[0] if "@" in bot_email else bot_email
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "-v", "github_bot_account_username", "--text", "-p", ci_dir],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    bot_username = result.stdout.strip()
 
     return {
         "JD_E2E_VAR_DOMAIN": domain,
@@ -244,15 +250,14 @@ def main() -> None:
             set_env_var(env_var, value)
             print(f"  {env_var}={value}")
 
-    # 1b. Derive bot username from CI and set JD_E2E_USER + allowed usernames
+    # 1b. Read bot username from CI and set JD_E2E_USER + allowed usernames
     result = subprocess.run(
-        ["uv", "run", "jd", "show", "-v", "github_bot_account_email", "--text", "-p", ci_dir],
+        ["uv", "run", "jd", "show", "-v", "github_bot_account_username", "--text", "-p", ci_dir],
         capture_output=True,
         text=True,
         check=True,
     )
-    bot_email = result.stdout.strip()
-    bot_username = bot_email.split("@")[0] if "@" in bot_email else bot_email
+    bot_username = result.stdout.strip()
 
     if "JD_E2E_USER" not in option_env_vars:
         set_env_var("JD_E2E_USER", bot_username)


### PR DESCRIPTION
This PR adds a `username` variable to the CI template. That's needed for testing on personal GitHub account where the email prefix may diverge from the GitHub username. Also update the `just` method `just auth-bot-username` to read that ssm-parameter instead of inferring from the email

### Testing
- updated the CI template in my personal account
- verified the `just` method manually