### PR TITLE
feat: eks OIDC template

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -77,3 +77,4 @@ ignore: |
   dist/
   build/
   *.egg-info/
+  **/charts/*/templates/

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_manifest_yaml.py
@@ -167,6 +167,16 @@ class TestManifest(unittest.TestCase):
         for expected_cmd in self.EXPECTED_SECRET_COMMANDS:
             self.assertIn(expected_cmd, command_names, f"Expected secret command {expected_cmd} missing from manifest")
 
+    def test_project_store_declared(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None, test setup failed")
+            return
+
+        project_store = self.MANIFEST.get("project-store")
+        self.assertIsNotNone(project_store, "project-store section missing from manifest")
+        assert project_store is not None
+        self.assertEqual(project_store.get("store-type"), "s3-only")
+
     def test_output_sourced_values_have_matching_terraform_outputs(self) -> None:
         if self.MANIFEST is None:
             self.fail("MANIFEST is None, test setup failed")

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/LICENSE
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Amazon Web Services
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -1,0 +1,27 @@
+# Jupyter Deploy AWS EKS OIDC template
+
+The **AWS EKS OIDC Template** deploys **JupyterLab** workspaces on an Amazon EKS cluster,
+with HTTPS, GitHub OAuth via Dex, and the [jupyter-k8s](https://github.com/jupyter-infra/jupyter-k8s)
+operator for workspace lifecycle management.
+
+**Documentation:** [jupyter-deploy.readthedocs.io](https://jupyter-deploy.readthedocs.io)
+
+## Prerequisites
+
+- An AWS account with CLI credentials configured
+- A domain registered in Amazon Route 53
+- A GitHub OAuth app for authentication
+
+## Usage
+
+```bash
+pip install jupyter-deploy jupyter-deploy-tf-aws-eks-oidc
+jd init aws:eks:oidc my-cluster
+cd my-cluster
+jd config
+jd up
+```
+
+## License
+
+MIT License — see [LICENSE](LICENSE).

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/__init__.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/__init__.py
@@ -1,0 +1,3 @@
+"""AWS EKS OIDC Terraform template for deploying JupyterLab workspaces on Kubernetes."""
+
+__version__ = "0.1.0"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template.py
@@ -1,0 +1,5 @@
+"""Template path provider for the AWS EKS OIDC template."""
+
+from pathlib import Path
+
+TEMPLATE_PATH = Path(__file__).resolve().parent / "template"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/AGENT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/AGENT.md.template
@@ -1,0 +1,125 @@
+# Jupyter-deploy: Terraform AWS EKS OIDC template
+
+## Project organization
+
+This project manages the AWS resources to deploy JupyterLab workspaces on an Amazon EKS cluster.
+It uses Terraform as the infrastructure-as-code engine, provisions an EKS cluster with the
+jupyter-k8s operator for workspace lifecycle management, and controls access with GitHub identities via Dex.
+
+**IMPORTANT:** An Amazon Route53 hosted zone for the domain MUST exist in the AWS account.
+
+The template deploys:
+- A VPC with public and private subnets across 2 AZs
+- An EKS cluster with managed node groups
+- EKS add-ons: vpc-cni, kube-proxy, coredns, pod-identity-agent, ebs-csi-driver, cert-manager, external-dns
+- Helm releases: traefik-crds, jupyter-k8s operator, aws-traefik-dex (OIDC routing)
+- Dex as an OIDC identity provider on the cluster for kubectl authentication
+
+## Usage
+{{ jupyter-deploy-cli-general-instructions }}
+
+## General project information
+{{ show-info-instructions }}
+
+### Configure and create the infrastructure
+{{ config-up-instructions }}
+
+{{ set-variables-with-cmd-instructions }}
+
+{{ set-variables-with-file-instructions }}
+
+{{ read-variables-with-cmd-instructions }}
+
+### View the full terraform logs
+
+{{ history-logs-instructions }}
+
+### Delete all the resources
+
+{{ down-instructions }}
+
+## The terraform project
+
+### Engine directory
+
+The core terraform files are located in `./engine`, including `main.tf`, `variables.tf` and `outputs.tf`.
+Reusable modules are defined in `./engine/modules`:
+- `iam_role` — creates an IAM role with trust policy and attached managed/inline policies
+- `iam_policy` — creates an IAM policy from a list of {actions, resources} statements
+- `vpc` — VPC with public/private subnets, IGW, NAT gateways, route tables
+- `eks_cluster` — EKS cluster (control plane, security groups, OIDC provider)
+- `node_group` — EKS managed node group with role-based labeling
+- `s3_bucket` — S3 bucket with versioning, KMS encryption, public access block
+- `secret` — AWS Secrets Manager secret
+- `ecr` — ECR repository with lifecycle policy
+- `codebuild_job` — CodeBuild project for container image builds
+- `application` — workspace application image build and ECR push
+
+From the `engine` directory, this is a classic terraform project.
+It is possible to use the `terraform` CLI directly, but the recommended way is to use the jupyter-deploy commands.
+
+#### Presets
+`./engine/presets` correspond to optional set of default variables. Users SHOULD NOT modify these files.
+
+### Applications directory
+
+`./applications/` contains Dockerfiles for workspace images (e.g. `jupyterlab/`).
+Each workspace application is wired via the `application` module in `applications.tf`, which creates:
+- An ECR repository for the image that the template will reference
+- A CodeBuild project that builds and pushes the image
+- An S3 source artifact upload
+
+Applications are gated by a `_use` boolean variable (e.g. `workspace_app_jupyterlab_use`).
+
+### Charts directory
+
+`./charts/` contains local Helm charts:
+- `workspace-defaults/` — deploys the default access strategy and template into the shared namespace. It makes it easy for workspace users to create workspace later
+- `console/` — nginx pod serving the `/get-started/` onboarding page with kubeconfig setup instructions.
+
+To modify chart values, edit the `yamlencode({...})` block in the corresponding `.tf` file (`workspaces.tf` or `console.tf`).
+Charts are deployed via `helm_release` with a local path, so changes take effect on the next `jd up`.
+
+### Console page
+
+The console serves two files at `/get-started/`:
+Workspace users should bookmark this URL, then use it to setup their kubectl and manage their workspaces.
+- `setup-config.html.tftpl` — static HTML onboarding page
+- `set-kubeconfig.sh.tftpl` — shell script that configures kubectl with OIDC authentication via kubelogin
+
+
+
+### Router waiter script
+
+`waiter.tf` runs `local-await-router.sh.tftpl` as a `local-exec` provisioner after Helm releases are deployed.
+
+It handles the DNS race condition on fresh deploys because:
+1. domain must resolve from the cluster pods (often fails when existing)
+2. ExternalDNS must create the Route53 record (up to 5 min)
+3. CoreDNS must restart to flush cached NXDOMAIN responses
+4. As a result, routing deployments may be CrashLoopBackOff
+
+The script waits for all routing deployments (traefik, dex, oauth2-proxy, authmiddleware) to become ready,
+and triggers on domain, cluster name, or router chart version/revision changes.
+
+## The deployed EKS cluster
+
+### Accessing the cluster
+
+After deployment, configure kubectl:
+```
+aws eks update-kubeconfig --name CLUSTER_NAME --region REGION
+```
+
+### Key namespaces
+- `jupyter-k8s-system` — jupyter-k8s operator
+- `jupyter-k8s-router` — traefik + dex + oauth2-proxy + authmiddleware (OIDC routing)
+- `jupyter-k8s-shared` - access strategy and default template
+
+### Useful kubectl commands
+- `kubectl get nodes` — list cluster nodes
+- `kubectl get pods -n jupyter-k8s-system` — operator pods
+- `kubectl get pods -n jupyter-k8s-router` — routing pods
+- `kubectl get workspaces -A` — list all workspaces
+
+{{ generated-by-footer }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/Dockerfile
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/Dockerfile
@@ -1,0 +1,26 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+USER root
+
+RUN useradd -m -s /bin/bash jovyan
+
+RUN mkdir -p /etc/jupyter
+COPY jupyter_server_config.py /etc/jupyter/
+
+RUN mkdir -p /opt/uv/jupyter
+COPY pyproject.toml /opt/uv/jupyter/pyproject.toml
+RUN uv sync --directory /opt/uv/jupyter
+
+COPY jupyter-start.sh /usr/local/bin/
+COPY jupyter-reset.sh /usr/local/bin/
+
+RUN chmod -R a+r /opt/uv
+RUN chmod -R a+r /etc/jupyter
+RUN chmod +x /usr/local/bin/jupyter-start.sh
+RUN chmod +x /usr/local/bin/jupyter-reset.sh
+RUN chown -R jovyan:jovyan /home/jovyan
+
+WORKDIR /home/jovyan
+USER jovyan
+
+ENTRYPOINT ["/usr/local/bin/jupyter-start.sh"]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/jupyter-reset.sh
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/jupyter-reset.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+echo "Resetting Jupyter environment (uv)..."
+
+if [ -d "/home/jovyan/.venv" ]; then
+    rm -rf /home/jovyan/.venv
+fi
+
+if [ -f "/home/jovyan/pyproject.toml" ]; then
+    rm -f /home/jovyan/pyproject.toml
+fi
+
+if [ -f "/home/jovyan/uv.lock" ]; then
+    rm -f /home/jovyan/uv.lock
+fi
+
+if [ -d "/home/jovyan/.jupyter" ]; then
+    rm -rf /home/jovyan/.jupyter
+fi
+
+cp /opt/uv/jupyter/pyproject.toml /home/jovyan/
+cp /opt/uv/jupyter/uv.lock /home/jovyan/
+
+echo "Recreating uv environment..."
+uv sync --locked
+
+uv run jupyter lab \
+    --no-browser \
+    --ip=0.0.0.0 \
+    --IdentityProvider.token=

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/jupyter-start.sh
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/jupyter-start.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+BASE_URL="${JUPYTER_BASE_URL:-/}"
+
+echo "Setting up uv environment..."
+cp /opt/uv/jupyter/pyproject.toml /home/jovyan/
+cp /opt/uv/jupyter/uv.lock /home/jovyan/
+
+if [ ! -f "/home/jovyan/pyproject.toml" ] || [ ! -f "/home/jovyan/uv.lock" ]; then
+    echo "Did not find uv environment files in /home/jovyan."
+    cp /opt/uv/jupyter/pyproject.toml /home/jovyan/
+    cp /opt/uv/jupyter/uv.lock /home/jovyan/
+else
+    echo "Found existing uv environment files, syncing..."
+fi
+
+uv sync --locked
+
+set +e
+uv run jupyter lab \
+    --no-browser \
+    --ip=0.0.0.0 \
+    --IdentityProvider.token= \
+    --ServerApp.base_url="$BASE_URL"
+
+jupyter_exit_code=$?
+set -e
+
+if [ $jupyter_exit_code -ne 0 ]; then
+    echo "Jupyter lab failed to start, calling reset script..."
+    /usr/local/bin/jupyter-reset.sh
+fi

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/jupyter_server_config.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/jupyter_server_config.py
@@ -1,0 +1,5 @@
+# mypy: disable-error-code=name-defined
+c = get_config()  # noqa
+
+c.Application.log_level = "INFO"
+c.ServerApp.root_dir = "/home/jovyan"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "jupyter"
+version = "0.1.0"
+description = "JupyterLab workspace image for jupyter-deploy EKS template"
+requires-python = ">=3.12"
+dependencies = [
+    "jupyterlab>=4.4.2",
+]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/Chart.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: console
+version: 0.1.0
+description: Get-started console page with kubectl OIDC setup instructions
+type: application

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/templates/configmap.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/managed-by: jupyter-deploy
+data:
+  index.html: {{ .Values.html | quote }}
+  set-kubeconfig.sh: {{ .Values.script | quote }}
+  nginx.conf: {{ .Values.nginxConf | quote }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/templates/deployment.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/managed-by: jupyter-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Values.name }}
+      app.kubernetes.io/managed-by: jupyter-deploy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Values.name }}
+        app.kubernetes.io/managed-by: jupyter-deploy
+    spec:
+      nodeSelector:
+        jupyter-deploy/role: components
+      containers:
+        - name: nginx
+          image: nginx:1-alpine
+          ports:
+            - containerPort: {{ .Values.port }}
+          volumeMounts:
+            - name: content
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+      volumes:
+        - name: content
+          configMap:
+            name: {{ .Values.name }}
+            items:
+              - key: index.html
+                path: index.html
+              - key: set-kubeconfig.sh
+                path: set-kubeconfig.sh
+        - name: nginx-conf
+          configMap:
+            name: {{ .Values.name }}
+            items:
+              - key: nginx.conf
+                path: default.conf

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/templates/ingressroute.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/templates/ingressroute.yaml
@@ -1,0 +1,20 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: "Host(`{{ .Values.domain }}`) && PathPrefix(`{{ .Values.path }}`)"
+      kind: Rule
+      middlewares:
+        - name: auth-headers
+          namespace: {{ .Values.namespace }}
+        - name: oauth-auth-redirect
+          namespace: {{ .Values.namespace }}
+      services:
+        - name: {{ .Values.name }}
+          namespace: {{ .Values.namespace }}
+          port: {{ .Values.port }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/templates/service.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/managed-by: jupyter-deploy
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Values.name }}
+    app.kubernetes.io/managed-by: jupyter-deploy
+  ports:
+    - port: {{ .Values.port }}
+      targetPort: {{ .Values.port }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/values.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/values.yaml
@@ -1,0 +1,9 @@
+domain: ""
+namespace: jupyter-k8s-router
+name: console
+port: 8080
+path: /get-started/
+
+html: ""
+script: ""
+nginxConf: ""

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/Chart.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: workspace-defaults
+version: 0.1.0
+description: Default workspace resources (access strategy, workspace template, console)
+type: application

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/access-strategy.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/access-strategy.yaml
@@ -1,0 +1,95 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceAccessStrategy
+metadata:
+  name: {{ .Values.accessStrategy.name }}
+  namespace: {{ .Values.sharedNamespace }}
+spec:
+  displayName: OIDC Routing Strategy with GitHub authentication
+  accessResourceTemplates:
+    - kind: NetworkPolicy
+      apiVersion: networking.k8s.io/v1
+      namePrefix: workspace-network-policy
+      template: |
+        spec:
+          podSelector:
+            matchLabels:
+              workspace.jupyter.org/workspaceName: "{{"{{"}} .Workspace.Name {{"}}"}}"
+          policyTypes:
+          - Ingress
+          ingress:
+          - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: {{ .Values.routerNamespace }}
+              podSelector:
+                matchLabels:
+                  app: traefik
+                  component: router
+            ports:
+            - port: 8888
+              protocol: TCP
+          - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: {{ .Values.operatorNamespace }}
+            ports:
+            - port: 8888
+              protocol: TCP
+    - kind: IngressRoute
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: authorized-route
+      template: |
+        spec:
+          entryPoints:
+            - websecure
+          routes:
+            - match: "Host(`{{ .Values.domain }}`) && PathPrefix(`/workspaces/{{"{{"}} .Workspace.Namespace {{"}}"}}/{{"{{"}} .Workspace.Name {{"}}"}}/`)"
+              kind: Rule
+              priority: 100
+              middlewares:
+                - name: auth-headers
+                  namespace: {{ .Values.routerNamespace }}
+                - name: authmiddleware-verify
+                  namespace: {{ .Values.routerNamespace }}
+              services:
+                - name: "{{"{{"}} .Service.Name {{"}}"}}"
+                  namespace: "{{"{{"}} .Service.Namespace {{"}}"}}"
+                  port: 8888
+    - kind: IngressRoute
+      apiVersion: traefik.io/v1alpha1
+      namePrefix: unauthorized-route
+      template: |
+        spec:
+          entryPoints:
+            - websecure
+          routes:
+            - match: "Host(`{{ .Values.domain }}`) && PathPrefix(`/workspaces/{{"{{"}} .Workspace.Namespace {{"}}"}}/{{"{{"}} .Workspace.Name {{"}}"}}/auth`)"
+              kind: Rule
+              priority: 110
+              middlewares:
+                - name: auth-headers
+                  namespace: {{ .Values.routerNamespace }}
+                - name: oauth-auth-redirect
+                  namespace: {{ .Values.routerNamespace }}
+                - name: authmiddleware-auth
+                  namespace: {{ .Values.routerNamespace }}
+                - name: strip-auth-suffix
+                  namespace: {{ .Values.routerNamespace }}
+              services:
+                - name: "{{"{{"}} .Service.Name {{"}}"}}"
+                  namespace: "{{"{{"}} .Service.Namespace {{"}}"}}"
+                  port: 8888
+  deploymentModifications:
+    podModifications:
+      primaryContainerModifications:
+        mergeEnv:
+          - name: JUPYTER_BASE_URL
+            valueTemplate: "/workspaces/{{"{{"}} .Workspace.Namespace {{"}}"}}/{{"{{"}} .Workspace.Name {{"}}"}}/"
+  accessURLTemplate: "https://{{ .Values.domain }}/workspaces/{{"{{"}} .Workspace.Namespace {{"}}"}}/{{"{{"}} .Workspace.Name {{"}}"}}/auth"
+  accessStartupProbe:
+    httpGet:
+      urlTemplate: "https://{{ .Values.domain }}/workspaces/{{"{{"}} .Workspace.Namespace {{"}}"}}/{{"{{"}} .Workspace.Name {{"}}"}}/"
+      additionalSuccessStatusCodes: [401]
+    initialDelaySeconds: 1
+    periodSeconds: 2
+    failureThreshold: 20

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
@@ -1,0 +1,53 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: {{ .Values.workspaceTemplate.name }}
+  namespace: {{ .Values.sharedNamespace }}
+  labels:
+    workspace.jupyter.org/default-template: {{ .Values.workspaceTemplate.isDefault | quote }}
+spec:
+  displayName: {{ .Values.workspaceTemplate.displayName }}
+  description: {{ .Values.workspaceTemplate.description }}
+  defaultImage: {{ .Values.workspaceTemplate.imageUri }}
+  appType: {{ .Values.workspaceTemplate.appType }}
+  defaultAccessType: {{ .Values.workspaceTemplate.accessType }}
+  defaultOwnershipType: {{ .Values.workspaceTemplate.ownershipType }}
+  defaultAccessStrategy:
+    name: {{ .Values.accessStrategy.name }}
+    namespace: {{ .Values.sharedNamespace }}
+  defaultResources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+  resourceBounds:
+    resources:
+      cpu:
+        min: "100m"
+        max: "8"
+      memory:
+        min: "256Mi"
+        max: "32Gi"
+  primaryStorage:
+    defaultSize: "10Gi"
+    minSize: "1Gi"
+    maxSize: "100Gi"
+    defaultStorageClassName: {{ .Values.workspaceTemplate.storageClassName }}
+    defaultMountPath: "/home/jovyan"
+  defaultPodSecurityContext:
+    fsGroup: 1000
+  defaultNodeSelector:
+    jupyter-deploy/role: workspaces
+  defaultIdleShutdown:
+    enabled: {{ .Values.workspaceTemplate.idleShutdown.enabled }}
+    idleTimeoutInMinutes: {{ .Values.workspaceTemplate.idleShutdown.timeoutMinutes }}
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+  idleShutdownOverrides:
+    allow: true
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: {{ .Values.workspaceTemplate.idleShutdown.maxTimeoutMinutes }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/values.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/values.yaml
@@ -1,0 +1,22 @@
+domain: ""
+sharedNamespace: jupyter-k8s-shared
+routerNamespace: jupyter-k8s-router
+operatorNamespace: jupyter-k8s-system
+
+accessStrategy:
+  name: oauth-access-strategy
+
+workspaceTemplate:
+  name: jupyterlab
+  isDefault: "true"
+  displayName: JupyterLab
+  description: "JupyterLab workspace with persistent EBS storage"
+  imageUri: ""
+  appType: jupyterlab
+  accessType: OwnerOnly
+  ownershipType: OwnerOnly
+  storageClassName: ebs-sc
+  idleShutdown:
+    enabled: true
+    timeoutMinutes: 60
+    maxTimeoutMinutes: 480

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/console/set-kubeconfig.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/console/set-kubeconfig.sh.tftpl
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+CLUSTER_NAME="${cluster_name}"
+API_ENDPOINT="${cluster_endpoint}"
+DEX_URL="${dex_url}"
+CLIENT_SECRET="${client_secret}"
+LISTEN_PORT="${listen_port}"
+CA_DATA="${cluster_ca}"
+
+echo "Configuring kubectl for cluster: $CLUSTER_NAME"
+
+# Write CA certificate
+mkdir -p /tmp/eks-certs
+echo "$CA_DATA" | base64 --decode > "/tmp/eks-certs/$CLUSTER_NAME-ca.crt"
+
+# Set cluster
+kubectl config set-cluster "$CLUSTER_NAME" \
+    --embed-certs \
+    --certificate-authority="/tmp/eks-certs/$CLUSTER_NAME-ca.crt" \
+    --server "$API_ENDPOINT"
+
+# Set credentials with kubelogin exec plugin
+kubectl config set-credentials "$CLUSTER_NAME-github" \
+    --exec-api-version=client.authentication.k8s.io/v1 \
+    --exec-interactive-mode=IfAvailable \
+    --exec-command=kubectl \
+    --exec-arg=oidc-login \
+    --exec-arg=get-token \
+    --exec-arg="--oidc-issuer-url=$DEX_URL" \
+    --exec-arg="--oidc-client-id=kubectl-oidc" \
+    --exec-arg="--oidc-client-secret=$CLIENT_SECRET" \
+    --exec-arg="--listen-address=localhost:$LISTEN_PORT" \
+    --exec-arg="--oidc-extra-scope=openid" \
+    --exec-arg="--oidc-extra-scope=profile" \
+    --exec-arg="--oidc-extra-scope=email" \
+    --exec-arg="--oidc-extra-scope=groups"
+
+# Set context
+kubectl config set-context "$CLUSTER_NAME" \
+    --cluster="$CLUSTER_NAME" \
+    --user="$CLUSTER_NAME-github" \
+    --namespace=default
+
+# Switch to context
+kubectl config use-context "$CLUSTER_NAME"
+
+echo ""
+echo "Done! Run 'kubectl auth whoami' to verify (a browser window will open for GitHub login)."
+echo "If you get a 'port already in use' error, run: lsof -i :$LISTEN_PORT | awk 'NR>1 {print \$2}' | xargs kill -9"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/console/setup-config.html.tftpl
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/console/setup-config.html.tftpl
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Get Started</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 680px; margin: 40px auto; padding: 0 20px; line-height: 1.6; color: #1a1a1a; }
+    h1 { font-size: 1.5rem; border-bottom: 1px solid #e0e0e0; padding-bottom: 0.5rem; }
+    h2 { font-size: 1.1rem; margin-top: 2rem; }
+    code { background: #f4f4f4; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+    pre { background: #f4f4f4; padding: 16px; border-radius: 6px; overflow-x: auto; font-size: 0.85em; }
+    .btn { display: inline-block; padding: 10px 20px; background: #2563eb; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 500; margin-top: 1rem; }
+    .btn:hover { background: #1d4ed8; }
+    .step { margin-bottom: 1.5rem; }
+  </style>
+</head>
+<body>
+  <h1>Get Started</h1>
+  <p>Configure <code>kubectl</code> to access this cluster using your GitHub identity.</p>
+
+  <h2>Prerequisites</h2>
+  <div class="step">
+    <p>Install the following tools:</p>
+    <ul>
+      <li><a href="https://kubernetes.io/docs/tasks/tools/">kubectl</a></li>
+      <li><a href="https://github.com/int128/kubelogin#setup">kubelogin</a> (kubectl oidc-login plugin)</li>
+    </ul>
+  </div>
+
+  <h2>Setup</h2>
+  <div class="step">
+    <p>Download and run the setup script:</p>
+    <a class="btn" href="/get-started/set-kubeconfig.sh" download>Download set-kubeconfig.sh</a>
+    <pre>./set-kubeconfig.sh</pre>
+    <p>This configures your kubeconfig to authenticate via GitHub OAuth. On first <code>kubectl</code> command, a browser window opens for login.</p>
+  </div>
+
+  <h2>Verify</h2>
+  <div class="step">
+    <pre>kubectl auth whoami</pre>
+    <p>You should see your GitHub email as the username.</p>
+  </div>
+
+  <h2>Find your Workspaces</h2>
+  <div class="step">
+    <pre>kubectl get Workspaces</pre>
+    <p>To view a workspace's details and access URL:</p>
+    <pre>kubectl get Workspace my-workspace -o yaml</pre>
+    <p>Once the workspace is <code>Available</code>, open the access URL shown in the status.</p>
+  </div>
+
+  <h2>Create a Workspace</h2>
+  <div class="step">
+    <p>Create a file called <code>my-workspace.yaml</code>:</p>
+    <pre>apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: my-workspace
+  namespace: default
+spec:
+  displayName: "My Notebook"</pre>
+    <p>Apply it:</p>
+    <pre>kubectl apply -f my-workspace.yaml</pre>
+  </div>
+
+  <h2>Troubleshooting</h2>
+  <div class="step">
+    <p>If you get a "port already in use" error, kill the stale process:</p>
+    <pre>lsof -i :9800 | awk 'NR>1 {print $2}' | xargs kill -9</pre>
+  </div>
+</body>
+</html>

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/applications.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/applications.tf
@@ -1,0 +1,21 @@
+module "build_artifacts_bucket" {
+  source = "./modules/s3_bucket"
+
+  bucket_name_prefix = "${local.resource_name_prefix}-build-"
+  combined_tags      = local.combined_tags
+}
+
+module "app_jupyterlab" {
+  count  = var.workspace_app_jupyterlab_use ? 1 : 0
+  source = "./modules/application"
+
+  name                 = "jupyterlab"
+  resource_name_prefix = local.resource_name_prefix
+  source_dir           = "${path.module}/../applications/jupyterlab"
+  image_name           = var.workspace_app_jupyterlab_image_name
+  image_build          = var.workspace_app_jupyterlab_image_build
+  build_bucket_name    = module.build_artifacts_bucket.bucket_name
+  build_bucket_arn     = module.build_artifacts_bucket.bucket_arn
+  region               = var.region
+  combined_tags        = local.combined_tags
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/console.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/console.tf
@@ -1,0 +1,47 @@
+locals {
+  console_name      = "console"
+  console_namespace = var.workspace_router_namespace
+  console_port      = 8080
+  console_path      = "/get-started/"
+
+  console_html = templatefile("${path.module}/../console/setup-config.html.tftpl", {})
+
+  console_script = templatefile("${path.module}/../console/set-kubeconfig.sh.tftpl", {
+    cluster_name     = module.eks_cluster.cluster_name
+    cluster_endpoint = module.eks_cluster.cluster_endpoint
+    cluster_ca       = module.eks_cluster.cluster_ca_certificate
+    dex_url          = "https://${local.full_domain}/dex"
+    client_secret    = random_password.dex_client_secret.result
+    listen_port      = "9800"
+  })
+
+  console_nginx_conf = <<-NGINX
+    server {
+      listen ${local.console_port};
+      root /usr/share/nginx/html;
+      location /get-started/ {
+        alias /usr/share/nginx/html/;
+        default_type text/html;
+      }
+    }
+  NGINX
+}
+
+resource "helm_release" "console" {
+  name      = "console"
+  chart     = "${path.module}/../charts/console"
+  namespace = local.console_namespace
+
+  values = [yamlencode({
+    domain    = local.full_domain
+    namespace = local.console_namespace
+    name      = local.console_name
+    port      = local.console_port
+    path      = local.console_path
+    html      = local.console_html
+    script    = local.console_script
+    nginxConf = local.console_nginx_conf
+  })]
+
+  depends_on = [helm_release.workspace_router]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/eks_addons.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/eks_addons.tf
@@ -1,0 +1,73 @@
+resource "time_sleep" "wait_for_nodes" {
+  create_duration = "30s"
+  depends_on      = [module.eks_cluster]
+}
+
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "vpc-cni"
+  tags         = local.combined_tags
+}
+
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "kube-proxy"
+  tags         = local.combined_tags
+}
+
+resource "aws_eks_addon" "coredns" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "coredns"
+  tags         = local.combined_tags
+
+  depends_on = [time_sleep.wait_for_nodes]
+}
+
+resource "aws_eks_addon" "pod_identity_agent" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "eks-pod-identity-agent"
+  tags         = local.combined_tags
+}
+
+resource "aws_eks_addon" "ebs_csi_driver" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "aws-ebs-csi-driver"
+  tags         = local.combined_tags
+
+  pod_identity_association {
+    role_arn        = module.ebs_csi_role.role_arn
+    service_account = "ebs-csi-controller-sa"
+  }
+
+  depends_on = [aws_eks_addon.pod_identity_agent]
+}
+
+resource "aws_eks_addon" "cert_manager" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "cert-manager"
+  tags         = local.combined_tags
+
+  depends_on = [aws_eks_addon.pod_identity_agent, time_sleep.wait_for_nodes]
+}
+
+# cert-manager addon doesn't support inline pod_identity_association; use a standalone resource.
+resource "aws_eks_pod_identity_association" "cert_manager" {
+  cluster_name    = module.eks_cluster.cluster_name
+  namespace       = "cert-manager"
+  service_account = "cert-manager"
+  role_arn        = module.cert_manager_role.role_arn
+}
+
+resource "aws_eks_addon" "external_dns" {
+  count        = local.enable_external_dns ? 1 : 0
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "external-dns"
+  tags         = local.combined_tags
+
+  pod_identity_association {
+    role_arn        = module.external_dns_role[0].role_arn
+    service_account = "external-dns"
+  }
+
+  depends_on = [aws_eks_addon.pod_identity_agent, time_sleep.wait_for_nodes]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/helm.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/helm.tf
@@ -1,0 +1,157 @@
+resource "random_password" "oauth2_proxy_cookie_secret" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "dex_client_secret" {
+  length  = 32
+  special = false
+}
+
+locals {
+  traefik_crds_repo   = "https://traefik.github.io/charts"
+  enable_external_dns = true
+  letsencrypt_staging = false
+
+  oauth_teams_parsed = [
+    for entry in var.oauth_allowed_teams : {
+      org  = split(":", entry)[0]
+      team = split(":", entry)[1]
+    }
+  ]
+  github_orgs_unique = distinct([for t in local.oauth_teams_parsed : t.org])
+}
+
+resource "helm_release" "traefik_crds" {
+  name             = "traefik-crds"
+  repository       = local.traefik_crds_repo
+  chart            = "traefik-crds"
+  version          = var.traefik_crd_chart_version
+  namespace        = var.workspace_router_namespace
+  create_namespace = true
+
+  depends_on = [aws_eks_addon.cert_manager]
+}
+
+resource "helm_release" "jupyter_k8s" {
+  name             = "jupyter-k8s"
+  chart            = var.workspace_operator_chart_oci
+  version          = var.workspace_operator_chart_version
+  namespace        = var.workspace_operator_namespace
+  create_namespace = true
+
+  set = [
+    {
+      name  = "certManager.enable"
+      value = "true"
+    },
+    {
+      name  = "crd.enable"
+      value = "true"
+    },
+    {
+      name  = "workspaceTemplates.defaultNamespace"
+      value = var.workspace_shared_namespace
+    },
+    {
+      name  = "manager.nodeSelector.jupyter-deploy/role"
+      value = "components"
+    },
+  ]
+
+  depends_on = [aws_eks_addon.cert_manager, helm_release.traefik_crds]
+}
+
+resource "helm_release" "workspace_router" {
+  name             = "jupyter-k8s-aws-oidc"
+  chart            = var.workspace_router_chart_oci
+  version          = var.workspace_router_chart_version
+  namespace        = var.workspace_router_namespace
+  create_namespace = true
+  wait             = false
+  timeout          = 600
+
+  set = concat(
+    [
+      {
+        name  = "domain"
+        value = local.full_domain
+      },
+      {
+        name  = "certManager.email"
+        value = var.letsencrypt_email
+      },
+      {
+        name  = "certManager.useStaging"
+        value = tostring(local.letsencrypt_staging)
+      },
+      {
+        name  = "github.clientId"
+        value = var.oauth_app_client_id
+      },
+      {
+        name  = "externalDns.enabled"
+        value = tostring(local.enable_external_dns)
+      },
+      {
+        name  = "storageClass.ebs.create"
+        value = "true"
+      },
+      {
+        name  = "storageClass.efs.create"
+        value = "false"
+      },
+      {
+        name  = "nodeSelector.jupyter-deploy/role"
+        value = "components"
+      },
+    ],
+    [
+      for idx, org in local.github_orgs_unique : {
+        name  = "github.orgs[${idx}].name"
+        value = org
+      }
+    ],
+    flatten([
+      for org_index, org in local.github_orgs_unique : [
+        for team_index, t in [for t in local.oauth_teams_parsed : t.team if t.org == org] : {
+          name  = "github.orgs[${org_index}].teams[${team_index}]"
+          value = t
+        }
+      ]
+    ]),
+    [
+      for idx, org in local.github_orgs_unique : {
+        name  = "githubRbac.orgs[${idx}].name"
+        value = org
+      }
+    ],
+    flatten([
+      for org_index, org in local.github_orgs_unique : [
+        for team_index, t in [for t in local.oauth_teams_parsed : t.team if t.org == org] : {
+          name  = "githubRbac.orgs[${org_index}].teams[${team_index}]"
+          value = t
+        }
+      ]
+    ]),
+  )
+
+  set_sensitive = [
+    {
+      name  = "github.clientSecret"
+      value = var.oauth_app_client_secret
+    },
+    {
+      name  = "oauth2Proxy.cookieSecret"
+      value = base64encode(random_password.oauth2_proxy_cookie_secret.result)
+    },
+    {
+      name  = "dex.oauth2ProxyClientSecret"
+      value = random_password.dex_client_secret.result
+    },
+  ]
+
+  depends_on = [helm_release.jupyter_k8s, aws_eks_addon.cert_manager, helm_release.traefik_crds]
+}
+
+

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/iam.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/iam.tf
@@ -1,0 +1,118 @@
+# --- Trust policies ---
+
+data "aws_iam_policy_document" "eks_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["eks.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "ec2_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "pod_identity_trust" {
+  statement {
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+  }
+}
+
+# --- Custom policies ---
+
+module "cert_manager_policy" {
+  source      = "./modules/iam_policy"
+  policy_name = "${local.resource_name_prefix}-cert-manager-route53"
+  statements = [
+    {
+      actions   = ["route53:GetChange"]
+      resources = ["arn:${data.aws_partition.current.partition}:route53:::change/*"]
+    },
+    {
+      actions   = ["route53:ChangeResourceRecordSets", "route53:ListResourceRecordSets"]
+      resources = [data.aws_route53_zone.domain.arn]
+    },
+    {
+      actions   = ["route53:ListHostedZonesByName"]
+      resources = ["*"]
+    },
+  ]
+  combined_tags = local.combined_tags
+}
+
+module "external_dns_policy" {
+  count       = local.enable_external_dns ? 1 : 0
+  source      = "./modules/iam_policy"
+  policy_name = "${local.resource_name_prefix}-external-dns-route53"
+  statements = [
+    {
+      actions   = ["route53:ChangeResourceRecordSets", "route53:ListResourceRecordSets"]
+      resources = [data.aws_route53_zone.domain.arn]
+    },
+    {
+      actions   = ["route53:ListHostedZones", "route53:ListTagsForResource"]
+      resources = ["*"]
+    },
+  ]
+  combined_tags = local.combined_tags
+}
+
+# --- Roles ---
+
+module "cluster_role" {
+  source             = "./modules/iam_role"
+  role_name          = "${local.resource_name_prefix}-cluster"
+  assume_role_policy = data.aws_iam_policy_document.eks_trust.json
+  policy_arns        = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSClusterPolicy"]
+  combined_tags      = local.combined_tags
+}
+
+module "node_role" {
+  source             = "./modules/iam_role"
+  role_name          = "${local.resource_name_prefix}-node"
+  assume_role_policy = data.aws_iam_policy_document.ec2_trust.json
+  policy_arns = [
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy",
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEKS_CNI_Policy",
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+    "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore",
+  ]
+  combined_tags = local.combined_tags
+}
+
+module "ebs_csi_role" {
+  source             = "./modules/iam_role"
+  role_name          = "${local.resource_name_prefix}-ebs-csi"
+  assume_role_policy = data.aws_iam_policy_document.pod_identity_trust.json
+  policy_arns        = ["arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"]
+  combined_tags      = local.combined_tags
+}
+
+module "cert_manager_role" {
+  source             = "./modules/iam_role"
+  role_name          = "${local.resource_name_prefix}-cert-manager"
+  assume_role_policy = data.aws_iam_policy_document.pod_identity_trust.json
+  policy_arns        = [module.cert_manager_policy.policy_arn]
+  combined_tags      = local.combined_tags
+}
+
+module "external_dns_role" {
+  count              = local.enable_external_dns ? 1 : 0
+  source             = "./modules/iam_role"
+  role_name          = "${local.resource_name_prefix}-external-dns"
+  assume_role_policy = data.aws_iam_policy_document.pod_identity_trust.json
+  policy_arns        = [module.external_dns_policy[0].policy_arn]
+  combined_tags      = local.combined_tags
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/local-await-router.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/local-await-router.sh.tftpl
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+
+DOMAIN="${domain}"
+HOSTED_ZONE_ID="${hosted_zone_id}"
+ROUTER_NAMESPACE="${router_namespace}"
+CLUSTER_NAME="${cluster_name}"
+REGION="${region}"
+
+DEPLOYMENTS="traefik dex oauth2-proxy authmiddleware"
+
+setup_kubeconfig() {
+    echo "Configuring kubectl for cluster $CLUSTER_NAME..."
+    if ! aws eks update-kubeconfig \
+        --name "$CLUSTER_NAME" \
+        --region "$REGION" 2>&1; then
+        echo "ERROR: Failed to configure kubeconfig"
+        return 1
+    fi
+
+    # Verify kubectl is targeting the correct cluster and region
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null)
+    if [[ "$current_context" != *"$CLUSTER_NAME"* ]] || [[ "$current_context" != *"$REGION"* ]]; then
+        echo "ERROR: kubectl context '$current_context' does not match expected cluster '$CLUSTER_NAME' in region '$REGION'."
+        echo "Aborting to avoid modifying the wrong cluster."
+        return 1
+    fi
+    echo "kubectl configured (context: $current_context)."
+}
+
+dns_already_resolves() {
+    # Quick check: if the domain already resolves, this is not a fresh deploy.
+    # Use a short timeout to avoid blocking on slow DNS.
+    local result
+    result=$(dig +short "$DOMAIN" +time=3 +tries=1 2>/dev/null)
+    if [ -n "$result" ]; then
+        echo "Domain $DOMAIN already resolves ($result), skipping DNS wait."
+        return 0
+    fi
+    return 1
+}
+
+wait_for_route53_record() {
+    local MAX_WAIT_SECONDS=300
+    local SLEEP_INTERVAL=10
+    local waited=0
+
+    echo "Waiting for Route53 record for $DOMAIN (ExternalDNS)..."
+
+    while true; do
+        # Query Route53 directly (bypasses DNS cache) for A or ALIAS records
+        local record_count
+        record_count=$(aws route53 list-resource-record-sets \
+            --hosted-zone-id "$HOSTED_ZONE_ID" \
+            --region "$REGION" \
+            --query "ResourceRecordSets[?Name=='$${DOMAIN}.' && (Type=='A' || Type=='AAAA')] | length(@)" \
+            --output text 2>/dev/null)
+
+        if [ -n "$record_count" ] && [ "$record_count" -gt 0 ] 2>/dev/null; then
+            echo "Route53 record found for $DOMAIN."
+            return 0
+        fi
+
+        if [ $waited -ge $MAX_WAIT_SECONDS ]; then
+            echo "WARNING: Timed out waiting for Route53 record after $${MAX_WAIT_SECONDS}s."
+            echo "ExternalDNS may not have created the record yet."
+            echo "The deployment may still succeed once DNS propagates."
+            return 1
+        fi
+
+        echo "No Route53 record yet, waiting... ($${waited}s / $${MAX_WAIT_SECONDS}s)"
+        sleep $SLEEP_INTERVAL
+        waited=$((waited + SLEEP_INTERVAL))
+    done
+}
+
+flush_coredns_cache() {
+    echo "Restarting CoreDNS to flush negative DNS cache..."
+
+    if ! kubectl rollout restart deployment/coredns -n kube-system 2>&1; then
+        echo "WARNING: Failed to restart CoreDNS. Pods may take longer to recover."
+        return 1
+    fi
+
+    if ! kubectl rollout status deployment/coredns -n kube-system --timeout=60s 2>&1; then
+        echo "WARNING: CoreDNS rollout did not complete within 60s."
+        return 1
+    fi
+
+    echo "CoreDNS restarted successfully."
+    return 0
+}
+
+restart_crashed_pods() {
+    # After CoreDNS flush, pods in CrashLoopBackOff still have exponential backoff.
+    # Restarting the deployments forces immediate pod recreation.
+    echo "Restarting routing deployments to recover from CrashLoopBackOff..."
+
+    local failed=0
+    for deploy in $DEPLOYMENTS; do
+        if ! kubectl get deployment "$deploy" -n "$ROUTER_NAMESPACE" > /dev/null 2>&1; then
+            echo "WARNING: Deployment $deploy not found in $ROUTER_NAMESPACE, skipping."
+            continue
+        fi
+
+        # Check if any pods are in a crash state
+        local not_ready
+        not_ready=$(kubectl get deployment "$deploy" -n "$ROUTER_NAMESPACE" \
+            -o jsonpath='{.status.unavailableReplicas}' 2>/dev/null)
+
+        if [ -n "$not_ready" ] && [ "$not_ready" != "0" ] && [ "$not_ready" != "<none>" ]; then
+            echo "Restarting $deploy ($not_ready unavailable replicas)..."
+            if ! kubectl rollout restart deployment/"$deploy" -n "$ROUTER_NAMESPACE" 2>&1; then
+                echo "WARNING: Failed to restart $deploy."
+                failed=$((failed + 1))
+            fi
+        else
+            echo "Deployment $deploy is healthy, skipping restart."
+        fi
+    done
+
+    if [ $failed -gt 0 ]; then
+        echo "WARNING: $failed deployment(s) failed to restart."
+        return 1
+    fi
+    return 0
+}
+
+wait_for_deployments_ready() {
+    local MAX_WAIT_SECONDS=300
+    local SLEEP_INTERVAL=15
+    local waited=0
+
+    echo "Waiting for routing deployments to become ready..."
+
+    while true; do
+        local all_ready=true
+
+        for deploy in $DEPLOYMENTS; do
+            if ! kubectl get deployment "$deploy" -n "$ROUTER_NAMESPACE" > /dev/null 2>&1; then
+                echo "WARNING: Deployment $deploy not found, skipping."
+                continue
+            fi
+
+            local available
+            local desired
+            available=$(kubectl get deployment "$deploy" -n "$ROUTER_NAMESPACE" \
+                -o jsonpath='{.status.availableReplicas}' 2>/dev/null)
+            desired=$(kubectl get deployment "$deploy" -n "$ROUTER_NAMESPACE" \
+                -o jsonpath='{.spec.replicas}' 2>/dev/null)
+
+            # Default to 0 if empty
+            available=$${available:-0}
+            desired=$${desired:-1}
+
+            if [ "$available" -lt "$desired" ] 2>/dev/null; then
+                all_ready=false
+
+                # On early attempts, check for CrashLoopBackOff and report
+                if [ $waited -gt 0 ]; then
+                    local crash_pods
+                    crash_pods=$(kubectl get pods -n "$ROUTER_NAMESPACE" -l app="$deploy" \
+                        --field-selector=status.phase!=Running \
+                        -o jsonpath='{range .items[*]}{.metadata.name}: {.status.containerStatuses[0].state.waiting.reason}{"\n"}{end}' 2>/dev/null)
+                    if [ -n "$crash_pods" ]; then
+                        echo "  $deploy: not ready ($available/$desired) — $crash_pods"
+                    else
+                        echo "  $deploy: not ready ($available/$desired)"
+                    fi
+                fi
+            fi
+        done
+
+        if [ "$all_ready" = "true" ]; then
+            echo "All routing deployments are ready."
+            return 0
+        fi
+
+        if [ $waited -ge $MAX_WAIT_SECONDS ]; then
+            echo "ERROR: Timed out waiting for routing deployments after $${MAX_WAIT_SECONDS}s."
+            echo ""
+            echo "Your deployment may still succeed once DNS fully propagates."
+            echo "Check pod status with: kubectl get pods -n $ROUTER_NAMESPACE"
+            echo "If pods are in CrashLoopBackOff, try:"
+            echo "  kubectl rollout restart deployment/coredns -n kube-system"
+            echo "  kubectl rollout restart deployment -n $ROUTER_NAMESPACE"
+            exit 1
+        fi
+
+        echo "Waiting for deployments... ($${waited}s / $${MAX_WAIT_SECONDS}s)"
+        sleep $SLEEP_INTERVAL
+        waited=$((waited + SLEEP_INTERVAL))
+    done
+}
+
+main() {
+    setup_kubeconfig || exit 1
+
+    if dns_already_resolves; then
+        # Domain resolves — skip DNS wait and CoreDNS flush, just verify health
+        wait_for_deployments_ready
+        return $?
+    fi
+
+    # Fresh deploy path: wait for DNS, flush cache, restart crashed pods
+    if wait_for_route53_record; then
+        flush_coredns_cache
+        # Give CoreDNS a moment to serve the new record
+        sleep 5
+        restart_crashed_pods
+    else
+        # Route53 record not found within timeout — still try to help recovery
+        echo "Attempting recovery without confirmed Route53 record..."
+        flush_coredns_cache
+        sleep 5
+        restart_crashed_pods
+    fi
+
+    wait_for_deployments_ready
+}
+
+main

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/main.tf
@@ -1,0 +1,173 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.30"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.14"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+provider "kubernetes" {
+  host                   = module.eks_cluster.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks_cluster.cluster_ca_certificate)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", module.eks_cluster.cluster_name, "--region", var.region]
+  }
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = module.eks_cluster.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks_cluster.cluster_ca_certificate)
+    exec = {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks_cluster.cluster_name, "--region", var.region]
+    }
+  }
+}
+
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "random_id" "postfix" {
+  byte_length = 4
+}
+
+locals {
+  template_name    = "tf-aws-eks-oidc"
+  template_version = "0.1.0"
+
+  default_tags = {
+    Source       = "jupyter-deploy"
+    Template     = local.template_name
+    Version      = local.template_version
+    DeploymentId = random_id.postfix.hex
+  }
+  combined_tags        = merge(local.default_tags, var.custom_tags)
+  cluster_name         = "${var.cluster_name_prefix}-${random_id.postfix.hex}"
+  resource_name_prefix = local.cluster_name
+}
+
+data "aws_route53_zone" "domain" {
+  name = var.domain
+}
+
+locals {
+  full_domain         = var.subdomain != "" ? "${var.subdomain}.${var.domain}" : var.domain
+  workspaces_base_url = "https://${local.full_domain}/workspaces"
+}
+
+module "vpc" {
+  source               = "./modules/vpc"
+  resource_name_prefix = local.resource_name_prefix
+  combined_tags        = local.combined_tags
+}
+
+module "eks_cluster" {
+  source                     = "./modules/eks_cluster"
+  cluster_name               = local.cluster_name
+  kubernetes_version         = var.kubernetes_version
+  cluster_role_arn           = module.cluster_role.role_arn
+  cluster_log_retention_days = var.cluster_log_retention_days
+  vpc_id                     = module.vpc.vpc_id
+  private_subnet_ids         = module.vpc.private_subnet_ids
+  public_subnet_ids          = module.vpc.public_subnet_ids
+  combined_tags              = local.combined_tags
+}
+
+locals {
+  admin_role_arns = {
+    for name in var.admin_role_names :
+    name => "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${name}"
+  }
+}
+
+resource "aws_eks_access_entry" "admin" {
+  for_each          = local.admin_role_arns
+  cluster_name      = module.eks_cluster.cluster_name
+  principal_arn     = each.value
+  kubernetes_groups = ["cluster-workspace-admin"]
+}
+
+resource "aws_eks_access_policy_association" "admin" {
+  for_each      = local.admin_role_arns
+  cluster_name  = module.eks_cluster.cluster_name
+  principal_arn = each.value
+  policy_arn    = "arn:${data.aws_partition.current.partition}:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.admin]
+}
+
+module "node_group" {
+  source   = "./modules/node_group"
+  for_each = { for ng in var.node_groups : ng.name => ng }
+
+  cluster_name    = module.eks_cluster.cluster_name
+  node_group_name = "${local.cluster_name}-${each.key}"
+  node_role_arn   = module.node_role.role_arn
+  subnet_ids      = module.vpc.private_subnet_ids
+  instance_type   = each.value.instance_type
+  ami_type        = lookup(each.value, "ami_type", "default")
+  role_label      = each.value.role
+  disk_size_gb    = tonumber(each.value.disk_size_gb)
+  min_size        = tonumber(each.value.min_size)
+  max_size        = tonumber(each.value.max_size)
+  desired_size    = tonumber(each.value.desired_size)
+  combined_tags   = local.combined_tags
+}
+
+module "oauth_secret" {
+  source        = "./modules/secret"
+  secret_prefix = "${local.resource_name_prefix}-oauth"
+  secret_value  = var.oauth_app_client_secret
+  region        = data.aws_region.current.id
+  combined_tags = local.combined_tags
+}
+
+resource "aws_eks_identity_provider_config" "dex" {
+  cluster_name = module.eks_cluster.cluster_name
+
+  oidc {
+    identity_provider_config_name = "dex"
+    issuer_url                    = "https://${local.full_domain}/dex"
+    client_id                     = "kubectl-oidc"
+    username_claim                = "preferred_username"
+    username_prefix               = "github:"
+    groups_claim                  = "groups"
+    groups_prefix                 = "github:"
+  }
+
+  depends_on = [helm_release.workspace_router]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/application/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/application/main.tf
@@ -1,0 +1,111 @@
+locals {
+  project_name = "${var.resource_name_prefix}-${var.name}"
+  source_zip   = "${path.root}/.terraform/tmp/${var.name}-source.zip"
+  image_uri    = "${module.ecr.repository_url}:${var.image_build}"
+
+  buildspec = <<-YAML
+    version: 0.2
+    phases:
+      pre_build:
+        commands:
+          - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_REPO_URL
+      build:
+        commands:
+          - docker build -t $ECR_REPO_URL:$IMAGE_TAG .
+          - docker tag $ECR_REPO_URL:$IMAGE_TAG $ECR_REPO_URL:latest
+      post_build:
+        commands:
+          - docker push $ECR_REPO_URL:$IMAGE_TAG
+          - docker push $ECR_REPO_URL:latest
+  YAML
+}
+
+data "archive_file" "source" {
+  type        = "zip"
+  source_dir  = var.source_dir
+  output_path = local.source_zip
+}
+
+resource "aws_s3_object" "source" {
+  bucket = var.build_bucket_name
+  key    = "${var.image_name}/${var.image_build}/source.zip"
+  source = data.archive_file.source.output_path
+  etag   = data.archive_file.source.output_md5
+}
+
+module "ecr" {
+  source = "../ecr"
+
+  repository_name = "${var.resource_name_prefix}/${var.image_name}"
+  combined_tags   = var.combined_tags
+}
+
+module "build" {
+  source = "../codebuild_job"
+
+  project_name         = local.project_name
+  ecr_repository_url   = module.ecr.repository_url
+  ecr_repository_arn   = module.ecr.repository_arn
+  image_tag            = var.image_build
+  buildspec            = local.buildspec
+  source_s3_location   = "${var.build_bucket_name}/${var.image_name}/${var.image_build}/source.zip"
+  source_s3_bucket_arn = var.build_bucket_arn
+  combined_tags        = var.combined_tags
+}
+
+resource "null_resource" "build_trigger" {
+  triggers = {
+    image_tag    = var.image_build
+    project_name = module.build.project_name
+    source_hash  = data.archive_file.source.output_md5
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -euo pipefail
+      echo "Starting CodeBuild for ${var.image_name}:${var.image_build}..."
+
+      BUILD_ID=$(aws codebuild start-build \
+        --project-name ${module.build.project_name} \
+        --region ${var.region} \
+        --query 'build.id' \
+        --output text)
+
+      echo "Build started: $BUILD_ID"
+      echo "Waiting for build to complete (timeout: 30m)..."
+
+      SECONDS=0
+      TIMEOUT=1800
+
+      while true; do
+        if [ $SECONDS -ge $TIMEOUT ]; then
+          echo "ERROR: Build timed out after 30 minutes."
+          exit 1
+        fi
+
+        STATUS=$(aws codebuild batch-get-builds \
+          --ids "$BUILD_ID" \
+          --region ${var.region} \
+          --query 'builds[0].buildStatus' \
+          --output text)
+
+        case "$STATUS" in
+          SUCCEEDED)
+            echo "${var.image_name}:${var.image_build} build succeeded in $(($SECONDS / 60))m $(($SECONDS % 60))s."
+            break
+            ;;
+          FAILED|FAULT|STOPPED|TIMED_OUT)
+            echo "${var.image_name}:${var.image_build} build failed with status: $STATUS"
+            exit 1
+            ;;
+          *)
+            echo "${var.image_name}:${var.image_build} build in progress... ($((SECONDS / 60))m $((SECONDS % 60))s elapsed)"
+            sleep 15
+            ;;
+        esac
+      done
+    EOT
+  }
+
+  depends_on = [aws_s3_object.source]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/application/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/application/outputs.tf
@@ -1,0 +1,7 @@
+output "image_uri" {
+  value = local.image_uri
+}
+
+output "repository_url" {
+  value = module.ecr.repository_url
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/application/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/application/variables.tf
@@ -1,0 +1,35 @@
+variable "name" {
+  type = string
+}
+
+variable "resource_name_prefix" {
+  type = string
+}
+
+variable "source_dir" {
+  type = string
+}
+
+variable "image_name" {
+  type = string
+}
+
+variable "image_build" {
+  type = string
+}
+
+variable "build_bucket_name" {
+  type = string
+}
+
+variable "build_bucket_arn" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/codebuild_job/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/codebuild_job/main.tf
@@ -1,0 +1,102 @@
+data "aws_iam_policy_document" "codebuild_trust" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["codebuild.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "codebuild" {
+  name               = "${var.project_name}-codebuild"
+  assume_role_policy = data.aws_iam_policy_document.codebuild_trust.json
+  tags               = var.combined_tags
+}
+
+data "aws_iam_policy_document" "codebuild_permissions" {
+  statement {
+    sid = "ECRPush"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = [var.ecr_repository_arn]
+  }
+
+  statement {
+    sid       = "ECRAuth"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "S3Source"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+    ]
+    resources = ["${var.source_s3_bucket_arn}/*"]
+  }
+
+  statement {
+    sid       = "S3BucketList"
+    actions   = ["s3:ListBucket"]
+    resources = [var.source_s3_bucket_arn]
+  }
+
+  statement {
+    sid = "CloudWatchLogs"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "codebuild" {
+  name   = "${var.project_name}-permissions"
+  role   = aws_iam_role.codebuild.id
+  policy = data.aws_iam_policy_document.codebuild_permissions.json
+}
+
+resource "aws_codebuild_project" "this" {
+  name         = var.project_name
+  service_role = aws_iam_role.codebuild.arn
+
+  source {
+    type      = "S3"
+    location  = var.source_s3_location
+    buildspec = var.buildspec
+  }
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type    = "BUILD_GENERAL1_SMALL"
+    image           = "aws/codebuild/standard:7.0"
+    type            = "LINUX_CONTAINER"
+    privileged_mode = true
+
+    environment_variable {
+      name  = "ECR_REPO_URL"
+      value = var.ecr_repository_url
+    }
+
+    environment_variable {
+      name  = "IMAGE_TAG"
+      value = var.image_tag
+    }
+  }
+
+  tags = var.combined_tags
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/codebuild_job/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/codebuild_job/outputs.tf
@@ -1,0 +1,3 @@
+output "project_name" {
+  value = aws_codebuild_project.this.name
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/codebuild_job/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/codebuild_job/variables.tf
@@ -1,0 +1,31 @@
+variable "project_name" {
+  type = string
+}
+
+variable "ecr_repository_url" {
+  type = string
+}
+
+variable "ecr_repository_arn" {
+  type = string
+}
+
+variable "image_tag" {
+  type = string
+}
+
+variable "buildspec" {
+  type = string
+}
+
+variable "source_s3_location" {
+  type = string
+}
+
+variable "source_s3_bucket_arn" {
+  type = string
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/ecr/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/ecr/main.tf
@@ -1,0 +1,46 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.repository_name
+  image_tag_mutability = "MUTABLE"
+  force_delete         = true
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = var.combined_tags
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Keep last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 2
+        description  = "Remove untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/ecr/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/ecr/outputs.tf
@@ -1,0 +1,11 @@
+output "repository_url" {
+  value = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  value = aws_ecr_repository.this.arn
+}
+
+output "repository_name" {
+  value = aws_ecr_repository.this.name
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/ecr/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/ecr/variables.tf
@@ -1,0 +1,7 @@
+variable "repository_name" {
+  type = string
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/eks_cluster/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/eks_cluster/main.tf
@@ -1,0 +1,35 @@
+resource "aws_cloudwatch_log_group" "cluster" {
+  name              = "/aws/eks/${var.cluster_name}/cluster"
+  retention_in_days = var.cluster_log_retention_days
+  tags              = var.combined_tags
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = var.cluster_name
+  version  = var.kubernetes_version
+  role_arn = var.cluster_role_arn
+
+  vpc_config {
+    subnet_ids              = concat(var.private_subnet_ids, var.public_subnet_ids)
+    endpoint_private_access = true
+    endpoint_public_access  = true
+  }
+
+  access_config {
+    authentication_mode                         = "API_AND_CONFIG_MAP"
+    bootstrap_cluster_creator_admin_permissions = true
+  }
+
+  enabled_cluster_log_types = [
+    "api",
+    "audit",
+    "authenticator",
+    "controllerManager",
+    "scheduler",
+  ]
+
+  tags = var.combined_tags
+
+  depends_on = [aws_cloudwatch_log_group.cluster]
+}
+

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/eks_cluster/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/eks_cluster/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_name" {
+  value = aws_eks_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_ca_certificate" {
+  value = aws_eks_cluster.this.certificate_authority[0].data
+}
+
+output "cluster_arn" {
+  value = aws_eks_cluster.this.arn
+}
+
+output "cluster_security_group_id" {
+  value = aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/eks_cluster/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/eks_cluster/variables.tf
@@ -1,0 +1,31 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "kubernetes_version" {
+  type = string
+}
+
+variable "cluster_role_arn" {
+  type = string
+}
+
+variable "cluster_log_retention_days" {
+  type = number
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "public_subnet_ids" {
+  type = list(string)
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_policy/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_policy/main.tf
@@ -1,0 +1,15 @@
+data "aws_iam_policy_document" "this" {
+  dynamic "statement" {
+    for_each = var.statements
+    content {
+      actions   = statement.value.actions
+      resources = statement.value.resources
+    }
+  }
+}
+
+resource "aws_iam_policy" "this" {
+  name   = var.policy_name
+  policy = data.aws_iam_policy_document.this.json
+  tags   = var.combined_tags
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_policy/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_policy/outputs.tf
@@ -1,0 +1,3 @@
+output "policy_arn" {
+  value = aws_iam_policy.this.arn
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_policy/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_policy/variables.tf
@@ -1,0 +1,14 @@
+variable "policy_name" {
+  type = string
+}
+
+variable "statements" {
+  type = list(object({
+    actions   = list(string)
+    resources = list(string)
+  }))
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/main.tf
@@ -1,0 +1,11 @@
+resource "aws_iam_role" "this" {
+  name               = var.role_name
+  assume_role_policy = var.assume_role_policy
+  tags               = var.combined_tags
+}
+
+resource "aws_iam_role_policy_attachment" "policies" {
+  for_each   = { for idx, arn in var.policy_arns : tostring(idx) => arn }
+  role       = aws_iam_role.this.name
+  policy_arn = each.value
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/outputs.tf
@@ -1,0 +1,7 @@
+output "role_arn" {
+  value = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  value = aws_iam_role.this.name
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/variables.tf
@@ -1,0 +1,16 @@
+variable "role_name" {
+  type = string
+}
+
+variable "assume_role_policy" {
+  type = string
+}
+
+variable "policy_arns" {
+  type    = list(string)
+  default = []
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/node_group/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/node_group/main.tf
@@ -1,0 +1,44 @@
+data "aws_ec2_instance_type" "this" {
+  instance_type = var.instance_type
+}
+
+locals {
+  has_gpu    = try(length(data.aws_ec2_instance_type.this.gpus) > 0, false)
+  has_neuron = try(length(data.aws_ec2_instance_type.this.neuron_devices) > 0, false)
+
+  supported_architectures = try(data.aws_ec2_instance_type.this.supported_architectures, ["x86_64"])
+  architecture            = contains(local.supported_architectures, "x86_64") ? "x86_64" : "arm64"
+
+  # Map instance capabilities to EKS AL2023 ami_type values
+  resolved_ami_type = (
+    local.has_gpu && local.architecture == "x86_64" ? "AL2023_x86_64_NVIDIA" :
+    local.has_neuron ? "AL2023_x86_64_NEURON" :
+    local.architecture == "arm64" ? "AL2023_ARM_64_STANDARD" :
+    "AL2023_x86_64_STANDARD"
+  )
+
+  ami_type = var.ami_type == "default" ? local.resolved_ami_type : var.ami_type
+}
+
+resource "aws_eks_node_group" "this" {
+  cluster_name    = var.cluster_name
+  node_group_name = var.node_group_name
+  node_role_arn   = var.node_role_arn
+  subnet_ids      = var.subnet_ids
+  ami_type        = local.ami_type
+
+  instance_types = [var.instance_type]
+  disk_size      = var.disk_size_gb
+
+  labels = {
+    "jupyter-deploy/role" = var.role_label
+  }
+
+  scaling_config {
+    min_size     = var.min_size
+    max_size     = var.max_size
+    desired_size = var.desired_size
+  }
+
+  tags = var.combined_tags
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/node_group/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/node_group/outputs.tf
@@ -1,0 +1,12 @@
+output "node_group_name" {
+  value = aws_eks_node_group.this.node_group_name
+}
+
+output "ami_type" {
+  value = local.ami_type
+}
+
+output "instance_category" {
+  description = "Instance category: cpu, gpu, or neuron"
+  value       = local.has_neuron ? "neuron" : (local.has_gpu ? "gpu" : "cpu")
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/node_group/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/node_group/variables.tf
@@ -1,0 +1,48 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "node_group_name" {
+  type = string
+}
+
+variable "node_role_arn" {
+  type = string
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "instance_type" {
+  type = string
+}
+
+variable "ami_type" {
+  type        = string
+  description = "EKS AMI type. Set to 'default' to auto-detect from instance capabilities."
+}
+
+variable "role_label" {
+  type = string
+}
+
+variable "disk_size_gb" {
+  type = number
+}
+
+variable "min_size" {
+  type = number
+}
+
+variable "max_size" {
+  type = number
+}
+
+variable "desired_size" {
+  type = number
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/s3_bucket/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/s3_bucket/main.tf
@@ -1,0 +1,38 @@
+resource "aws_s3_bucket" "this" {
+  bucket_prefix = var.bucket_name_prefix
+  force_destroy = true
+
+  tags = merge(
+    var.combined_tags,
+    {
+      Name = var.bucket_name_prefix
+    }
+  )
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/s3_bucket/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/s3_bucket/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = aws_s3_bucket.this.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.this.arn
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/s3_bucket/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/s3_bucket/variables.tf
@@ -1,0 +1,17 @@
+variable "bucket_name_prefix" {
+  type = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*$", var.bucket_name_prefix))
+    error_message = "bucket_name_prefix must be lowercase alphanumeric with hyphens, cannot start with a hyphen."
+  }
+
+  validation {
+    condition     = length(var.bucket_name_prefix) >= 3 && length(var.bucket_name_prefix) <= 36
+    error_message = "bucket_name_prefix must be between 3 and 36 characters."
+  }
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/secret/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/secret/main.tf
@@ -1,0 +1,24 @@
+resource "aws_secretsmanager_secret" "this" {
+  name_prefix = "${var.secret_prefix}-"
+  description = "Managed by jupyter-deploy."
+  tags        = var.combined_tags
+}
+
+resource "null_resource" "store_secret" {
+  triggers = {
+    secret_arn = aws_secretsmanager_secret.this.arn
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws secretsmanager put-secret-value \
+        --secret-id ${aws_secretsmanager_secret.this.arn} \
+        --secret-string "${var.secret_value}" \
+        --region ${var.region}
+    EOT
+  }
+
+  depends_on = [
+    aws_secretsmanager_secret.this
+  ]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/secret/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/secret/outputs.tf
@@ -1,0 +1,3 @@
+output "secret_arn" {
+  value = aws_secretsmanager_secret.this.arn
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/secret/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/secret/variables.tf
@@ -1,0 +1,16 @@
+variable "secret_prefix" {
+  type = string
+}
+
+variable "secret_value" {
+  type      = string
+  sensitive = true
+}
+
+variable "region" {
+  type = string
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/vpc/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/vpc/main.tf
@@ -1,0 +1,125 @@
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  azs           = slice(data.aws_availability_zones.available.names, 0, 2)
+  vpc_cidr      = "10.0.0.0/16"
+  public_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_cidrs = ["10.0.10.0/24", "10.0.11.0/24"]
+}
+
+resource "aws_vpc" "this" {
+  cidr_block           = local.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.combined_tags, {
+    Name = "${var.resource_name_prefix}-vpc"
+  })
+}
+
+# --- Public subnets ---
+
+resource "aws_subnet" "public" {
+  count                   = 2
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = local.public_cidrs[count.index]
+  availability_zone       = local.azs[count.index]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.combined_tags, {
+    Name                     = "${var.resource_name_prefix}-public-${local.azs[count.index]}"
+    "kubernetes.io/role/elb" = "1"
+  })
+}
+
+# --- Private subnets ---
+
+resource "aws_subnet" "private" {
+  count             = 2
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = local.private_cidrs[count.index]
+  availability_zone = local.azs[count.index]
+
+  tags = merge(var.combined_tags, {
+    Name                              = "${var.resource_name_prefix}-private-${local.azs[count.index]}"
+    "kubernetes.io/role/internal-elb" = "1"
+  })
+}
+
+# --- Internet Gateway ---
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.combined_tags, {
+    Name = "${var.resource_name_prefix}-igw"
+  })
+}
+
+# --- NAT Gateways (one per AZ) ---
+
+resource "aws_eip" "nat" {
+  count  = 2
+  domain = "vpc"
+
+  tags = merge(var.combined_tags, {
+    Name = "${var.resource_name_prefix}-nat-eip-${local.azs[count.index]}"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  count         = 2
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
+
+  tags = merge(var.combined_tags, {
+    Name = "${var.resource_name_prefix}-nat-${local.azs[count.index]}"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# --- Public route table ---
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(var.combined_tags, {
+    Name = "${var.resource_name_prefix}-public-rt"
+  })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = 2
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+# --- Private route tables (one per AZ for NAT GW isolation) ---
+
+resource "aws_route_table" "private" {
+  count  = 2
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this[count.index].id
+  }
+
+  tags = merge(var.combined_tags, {
+    Name = "${var.resource_name_prefix}-private-rt-${local.azs[count.index]}"
+  })
+}
+
+resource "aws_route_table_association" "private" {
+  count          = 2
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private[count.index].id
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/vpc/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  value = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/vpc/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/vpc/variables.tf
@@ -1,0 +1,7 @@
+variable "resource_name_prefix" {
+  type = string
+}
+
+variable "combined_tags" {
+  type = map(string)
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/outputs.tf
@@ -1,0 +1,49 @@
+output "cluster_name" {
+  value = module.eks_cluster.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks_cluster.cluster_endpoint
+}
+
+output "cluster_ca_certificate" {
+  value     = module.eks_cluster.cluster_ca_certificate
+  sensitive = true
+}
+
+output "region" {
+  value = data.aws_region.current.id
+}
+
+output "deployment_id" {
+  value = random_id.postfix.hex
+}
+
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "workspace_operator_namespace" {
+  value = var.workspace_operator_namespace
+}
+
+output "workspace_router_namespace" {
+  value = var.workspace_router_namespace
+}
+
+output "workspace_base_url" {
+  value = local.workspaces_base_url
+}
+
+output "get_started_url" {
+  value = "https://${local.full_domain}/get-started/"
+}
+
+output "secret_arn" {
+  description = "ARN of the Secrets Manager secret storing the OAuth app client secret."
+  value       = module.oauth_secret.secret_arn
+}
+
+output "jupyterlab_image_uri" {
+  value = var.workspace_app_jupyterlab_use ? module.app_jupyterlab[0].image_uri : ""
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
@@ -1,0 +1,47 @@
+cluster_name_prefix              = "jupyter-deploy-eks"
+region                           = "us-west-2"
+kubernetes_version               = "1.35"
+admin_role_names                 = ["Admin"]
+cluster_log_retention_days       = 30
+custom_tags                      = {}
+workspace_operator_namespace     = "jupyter-k8s-system"
+workspace_router_namespace       = "jupyter-k8s-router"
+workspace_shared_namespace       = "jupyter-k8s-shared"
+workspace_operator_chart_oci     = "oci://ghcr.io/jupyter-infra/charts/jupyter-k8s"
+workspace_operator_chart_version = "0.1.0-rc.2"
+workspace_router_chart_oci       = "oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc"
+workspace_router_chart_version   = "0.1.0-rc.2"
+traefik_crd_chart_version        = "1.15.0"
+
+workspaces_default_access_type           = "OwnerOnly"
+workspaces_default_ownership_type        = "OwnerOnly"
+workspaces_idle_shutdown_enabled         = true
+workspaces_idle_shutdown_timeout_default = 60
+workspaces_idle_shutdown_timeout_max     = 480
+workspace_app_jupyterlab_use             = true
+workspace_app_jupyterlab_app_type        = "jupyterlab"
+workspace_app_jupyterlab_image_name      = "jupyterlab-v0.1.0"
+workspace_app_jupyterlab_image_build     = "v1"
+
+node_groups = [
+  {
+    name          = "components"
+    role          = "components"
+    instance_type = "t3.medium"
+    ami_type      = "default"
+    disk_size_gb  = "50"
+    min_size      = "1"
+    max_size      = "3"
+    desired_size  = "2"
+  },
+  {
+    name          = "workspaces"
+    role          = "workspaces"
+    instance_type = "c5.2xlarge"
+    ami_type      = "default"
+    disk_size_gb  = "50"
+    min_size      = "1"
+    max_size      = "5"
+    desired_size  = "1"
+  }
+]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-base.tfvars
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-base.tfvars
@@ -1,0 +1,8 @@
+workspace_operator_namespace     = "jupyter-k8s-system"
+workspace_router_namespace       = "jupyter-k8s-router"
+workspace_shared_namespace       = "jupyter-k8s-shared"
+workspace_operator_chart_oci     = "oci://ghcr.io/jupyter-infra/charts/jupyter-k8s"
+workspace_operator_chart_version = "0.1.0-rc.2"
+workspace_router_chart_oci       = "oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc"
+workspace_router_chart_version   = "0.1.0-rc.1"
+traefik_crd_chart_version        = "1.17.0"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/destroy.tfvars
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/destroy.tfvars
@@ -1,0 +1,1 @@
+oauth_app_client_secret = "unused"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -1,0 +1,494 @@
+variable "cluster_name_prefix" {
+  description = <<-EOT
+    The prefix for the EKS cluster name.
+
+    The template appends a unique deployment ID to ensure multiple
+    deployments can coexist in the same AWS account and region.
+
+    Recommended: jupyter-deploy-eks
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z][a-zA-Z0-9-]*$", var.cluster_name_prefix))
+    error_message = "cluster_name_prefix must start with a letter and contain only letters, digits, and hyphens."
+  }
+
+  validation {
+    condition     = length(var.cluster_name_prefix) >= 1 && length(var.cluster_name_prefix) <= 42
+    error_message = "cluster_name_prefix must be between 1 and 42 characters (template appends a 9-character suffix; IAM role names are limited to 64 characters)."
+  }
+}
+
+variable "region" {
+  description = <<-EOT
+    The AWS region where to deploy the resources.
+
+    Refer to: https://docs.aws.amazon.com/global-infrastructure/latest/regions/aws-regions.html
+
+    Example: us-west-2
+  EOT
+  type        = string
+}
+
+variable "kubernetes_version" {
+  description = <<-EOT
+    The Kubernetes version for the EKS cluster.
+
+    Refer to: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+
+    Recommended: 1.35
+  EOT
+  type        = string
+}
+
+variable "domain" {
+  description = <<-EOT
+    The domain name where to add the DNS records for the workspace URLs.
+
+    You must own this domain, and your AWS account must have a Route 53
+    hosted zone for it.
+    Refer to: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-domain-registration.html
+
+    Example: mydomain.com
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$", var.domain))
+    error_message = "domain must be a valid fully qualified domain name (e.g. mydomain.com)."
+  }
+}
+
+variable "subdomain" {
+  description = <<-EOT
+    The subdomain prefix for the workspace URLs.
+
+    For example, if you choose 'workspaces' and your domain is 'mydomain.com',
+    the full URL will be 'workspaces.mydomain.com'.
+
+    Example: workspaces
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$", var.subdomain))
+    error_message = "subdomain must be a valid DNS label (letters, digits, hyphens; max 63 characters; cannot start or end with a hyphen)."
+  }
+}
+
+variable "letsencrypt_email" {
+  description = <<-EOT
+    The email that Let's Encrypt will use to deliver notices about TLS certificates.
+
+    Example: yourname@example.com
+  EOT
+  type        = string
+}
+
+variable "oauth_app_client_id" {
+  description = <<-EOT
+    Client ID of the GitHub OAuth app that controls access to workspaces.
+
+    You must create an OAuth app first in your GitHub account.
+    1. Create a new OAuth app at: https://github.com/settings/applications/new
+    2. 'Homepage URL': https://<subdomain>.<domain>
+    3. 'Authorization callback URL': https://<subdomain>.<domain>/dex/callback
+    4. Retrieve the Client ID
+
+    Example: Ov23liAbCdEfGhIjKlMn
+  EOT
+  type        = string
+}
+
+variable "oauth_app_client_secret" {
+  description = <<-EOT
+    Client secret of the GitHub OAuth app that controls access to workspaces.
+
+    1. Open https://github.com/settings/developers
+    2. Select your OAuth app
+    3. Generate a secret
+    4. Retrieve and save the secret value
+
+    Example: 00000aaaaa11111bbbbb22222ccccc33333ddddd
+  EOT
+  type        = string
+  sensitive   = true
+}
+
+variable "oauth_allowed_teams" {
+  description = <<-EOT
+    List of GitHub teams to allow access, in 'org:team' format.
+
+    Example: ["my-org:my-team", "my-org:another-team"]
+  EOT
+  type        = list(string)
+  validation {
+    condition     = alltrue([for t in var.oauth_allowed_teams : length(split(":", t)) == 2])
+    error_message = "Each entry in oauth_allowed_teams must be in 'org:team' format."
+  }
+}
+
+variable "node_groups" {
+  description = <<-EOT
+    List of EKS managed node groups to create.
+
+    Keys: name, role, instance_type, disk_size_gb, min_size, max_size, desired_size, ami_type (optional).
+
+    Each node group has a role that determines which pods are scheduled on it:
+    - "components": cluster infrastructure pods (operator, router, cert-manager)
+    - "workspaces": user workspace pods
+
+    Nodes are labeled with 'jupyter-deploy/role' matching their role, and
+    pod affinity rules schedule pods to the appropriate node group.
+
+    The ami_type key controls the EKS-optimized AMI. Set to "default" (or omit)
+    to auto-detect from instance capabilities:
+    - CPU x86_64 instances -> AL2023_x86_64_STANDARD
+    - CPU arm64 instances  -> AL2023_ARM_64_STANDARD
+    - GPU x86_64 instances -> AL2023_x86_64_NVIDIA
+    - Neuron instances     -> AL2023_x86_64_NEURON
+
+    Or set an explicit EKS ami_type value (e.g. "BOTTLEROCKET_x86_64").
+
+    Example: [
+      {
+        name          = "components"
+        role          = "components"
+        instance_type = "t3.medium"
+        ami_type      = "default"
+        disk_size_gb  = "50"
+        min_size      = "1"
+        max_size      = "3"
+        desired_size  = "2"
+      },
+      {
+        name          = "workspaces"
+        role          = "workspaces"
+        instance_type = "g5.xlarge"
+        ami_type      = "default"
+        disk_size_gb  = "100"
+        min_size      = "0"
+        max_size      = "5"
+        desired_size  = "0"
+      }
+    ]
+  EOT
+  type        = list(map(string))
+
+  validation {
+    condition     = length(var.node_groups) == length(distinct([for ng in var.node_groups : ng.name]))
+    error_message = "Node group names must be unique."
+  }
+
+  validation {
+    condition = alltrue([
+      for ng in var.node_groups :
+      can(tonumber(ng.min_size)) && tonumber(ng.min_size) >= 0 && tonumber(ng.min_size) <= 450
+    ])
+    error_message = "min_size must be an integer between 0 and 450."
+  }
+
+  validation {
+    condition = alltrue([
+      for ng in var.node_groups :
+      can(tonumber(ng.max_size)) && tonumber(ng.max_size) >= 1 && tonumber(ng.max_size) <= 450
+    ])
+    error_message = "max_size must be an integer between 1 and 450."
+  }
+
+  validation {
+    condition = alltrue([
+      for ng in var.node_groups :
+      can(tonumber(ng.min_size)) && can(tonumber(ng.max_size)) && can(tonumber(ng.desired_size)) &&
+      tonumber(ng.min_size) <= tonumber(ng.desired_size) &&
+      tonumber(ng.desired_size) <= tonumber(ng.max_size)
+    ])
+    error_message = "Each node group must satisfy: min_size <= desired_size <= max_size."
+  }
+
+  validation {
+    condition = alltrue([
+      for ng in var.node_groups :
+      can(tonumber(ng.disk_size_gb)) && tonumber(ng.disk_size_gb) >= 1 && tonumber(ng.disk_size_gb) <= 16384
+    ])
+    error_message = "disk_size_gb must be an integer between 1 and 16384."
+  }
+}
+
+variable "admin_role_names" {
+  description = <<-EOT
+    List of IAM role names to grant EKS cluster admin and workspace admin permissions.
+
+    Values may embed the IAM path prefix (e.g. "ci/DeployRole" for a role at path /ci/).
+    Each role gets the AmazonEKSClusterAdminPolicy and the 'cluster-workspace-admin'
+    Kubernetes group, which allows managing all workspaces regardless of ownership.
+
+    Example: ["Admin", "ci/DeployRole"]
+  EOT
+  type        = list(string)
+
+  validation {
+    condition     = alltrue([for name in var.admin_role_names : can(regex("^[a-zA-Z0-9/_+=,.@-]+$", name))])
+    error_message = "Each entry must be a valid IAM role name or path/name (e.g. 'Admin' or 'path/to/MyRole')."
+  }
+}
+
+variable "cluster_log_retention_days" {
+  description = <<-EOT
+    The number of days to retain EKS cluster CloudWatch logs.
+
+    Recommended: 30
+  EOT
+  type        = number
+
+  validation {
+    condition     = var.cluster_log_retention_days >= 1 && var.cluster_log_retention_days <= 3650
+    error_message = "cluster_log_retention_days must be between 1 and 3650."
+  }
+}
+
+variable "custom_tags" {
+  description = <<-EOT
+    Tags added to all the AWS resources this template creates in your AWS account.
+
+    This template adds default tags in addition to optional tags you specify here.
+
+    Example: { MyKey = "MyValue" }
+
+    Recommended: {}
+  EOT
+  type        = map(string)
+}
+
+variable "workspace_operator_namespace" {
+  description = <<-EOT
+    The Kubernetes namespace for the workspace operator (jupyter-k8s).
+
+    Recommended: jupyter-k8s-system
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$", var.workspace_operator_namespace))
+    error_message = "workspace_operator_namespace must be a valid Kubernetes namespace (lowercase letters, digits, hyphens; 2-63 characters; cannot start or end with a hyphen)."
+  }
+}
+
+variable "workspace_shared_namespace" {
+  description = <<-EOT
+    The Kubernetes namespace for shared workspace resources (templates and access strategies).
+
+    This namespace is separate from the operator and router namespaces.
+    Resources here can be referenced cross-namespace by any workspace.
+
+    Recommended: jupyter-k8s-shared
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$", var.workspace_shared_namespace))
+    error_message = "workspace_shared_namespace must be a valid Kubernetes namespace (lowercase letters, digits, hyphens; 2-63 characters; cannot start or end with a hyphen)."
+  }
+}
+
+variable "workspace_router_namespace" {
+  description = <<-EOT
+    The Kubernetes namespace for the router layer components (traefik, dex, oauth2-proxy, authmiddleware).
+
+    Recommended: jupyter-k8s-router
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$", var.workspace_router_namespace))
+    error_message = "workspace_router_namespace must be a valid Kubernetes namespace (lowercase letters, digits, hyphens; 2-63 characters; cannot start or end with a hyphen)."
+  }
+}
+
+variable "workspace_operator_chart_oci" {
+  description = <<-EOT
+    The full OCI reference for the workspace operator Helm chart.
+
+    Override this to test against a staging registry.
+
+    Recommended: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s
+  EOT
+  type        = string
+}
+
+variable "workspace_operator_chart_version" {
+  description = <<-EOT
+    The version of the jupyter-k8s Helm chart to install.
+
+    Refer to: https://github.com/jupyter-infra/jupyter-k8s/releases
+
+    Example: 0.1.0
+  EOT
+  type        = string
+}
+
+variable "workspace_router_chart_oci" {
+  description = <<-EOT
+    The full OCI reference for the workspace router Helm chart (OIDC authentication).
+
+    Override this to test against a staging registry.
+
+    Recommended: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc
+  EOT
+  type        = string
+}
+
+variable "workspace_router_chart_version" {
+  description = <<-EOT
+    The version of the jupyter-k8s-aws-oidc Helm chart to install.
+
+    Refer to: https://github.com/jupyter-infra/jupyter-k8s-aws/releases
+
+    Example: 0.1.0
+  EOT
+  type        = string
+}
+
+variable "traefik_crd_chart_version" {
+  description = <<-EOT
+    The version of the Traefik CRDs Helm chart to install.
+
+    The CRDs must be compatible with the workspace router chart version.
+    Refer to: https://github.com/traefik/traefik-helm-chart/releases
+
+    Recommended: 1.15.0
+  EOT
+  type        = string
+}
+
+variable "workspaces_default_access_type" {
+  description = <<-EOT
+    The default access type for new workspaces.
+
+    Controls who can access the workspace's URL:
+    - "OwnerOnly": only the workspace creator can access it
+    - "Public": any authenticated user can access it
+
+    Recommended: OwnerOnly
+  EOT
+  type        = string
+
+  validation {
+    condition     = contains(["OwnerOnly", "Public"], var.workspaces_default_access_type)
+    error_message = "workspaces_default_access_type must be 'OwnerOnly' or 'Public'."
+  }
+}
+
+variable "workspaces_default_ownership_type" {
+  description = <<-EOT
+    The default ownership type for new workspaces.
+
+    Controls who can manage (update, delete) the workspace:
+    - "OwnerOnly": only the workspace creator can manage it
+    - "Public": any authorized user can manage it
+
+    Recommended: OwnerOnly
+  EOT
+  type        = string
+
+  validation {
+    condition     = contains(["OwnerOnly", "Public"], var.workspaces_default_ownership_type)
+    error_message = "workspaces_default_ownership_type must be 'OwnerOnly' or 'Public'."
+  }
+}
+
+variable "workspaces_idle_shutdown_enabled" {
+  description = <<-EOT
+    Whether to enable automatic idle shutdown for workspaces.
+
+    When enabled, workspaces that remain idle (no HTTP activity) for
+    the configured timeout are automatically stopped.
+
+    Recommended: true
+  EOT
+  type        = bool
+}
+
+variable "workspaces_idle_shutdown_timeout_default" {
+  description = <<-EOT
+    The default number of minutes a workspace can remain idle before auto-shutdown.
+
+    Users can override this per-workspace up to the max bound.
+    Only applies when workspaces_idle_shutdown_enabled is true.
+
+    Recommended: 60
+  EOT
+  type        = number
+
+  validation {
+    condition     = var.workspaces_idle_shutdown_timeout_default >= 5 && var.workspaces_idle_shutdown_timeout_default <= 1440
+    error_message = "workspaces_idle_shutdown_timeout_default must be between 5 and 1440 minutes (24 hours)."
+  }
+}
+
+variable "workspaces_idle_shutdown_timeout_max" {
+  description = <<-EOT
+    The maximum number of minutes a user can set for idle shutdown on their workspace.
+
+    Acts as an admin guardrail to limit cost exposure.
+    Only applies when workspaces_idle_shutdown_enabled is true.
+
+    Recommended: 480
+  EOT
+  type        = number
+
+  validation {
+    condition     = var.workspaces_idle_shutdown_timeout_max >= 15 && var.workspaces_idle_shutdown_timeout_max <= 1440
+    error_message = "workspaces_idle_shutdown_timeout_max must be between 15 and 1440 minutes (24 hours)."
+  }
+}
+
+variable "workspace_app_jupyterlab_use" {
+  description = <<-EOT
+    Whether to build and deploy the JupyterLab workspace application image.
+
+    When enabled, the template creates an ECR repository and a CodeBuild
+    project that builds the image from applications/jupyterlab/.
+
+    Recommended: true
+  EOT
+  type        = bool
+}
+
+variable "workspace_app_jupyterlab_app_type" {
+  description = <<-EOT
+    The application type identifier for the JupyterLab workspace template.
+
+    Maps to the 'appType' field in the WorkspaceTemplate CRD, used by
+    the operator to identify what kind of application this template provides.
+
+    Recommended: jupyterlab
+  EOT
+  type        = string
+}
+
+variable "workspace_app_jupyterlab_image_name" {
+  description = <<-EOT
+    The ECR repository name for the JupyterLab workspace image.
+
+    Changing this value creates a new ECR repository. Use the convention
+    'jupyterlab-v<version>' so that version upgrades produce a new repo
+    while keeping previous images available for running workspaces.
+
+    Example: jupyterlab-v1.0.0
+  EOT
+  type        = string
+}
+
+variable "workspace_app_jupyterlab_image_build" {
+  description = <<-EOT
+    The build tag for the JupyterLab workspace image.
+
+    Increment this to trigger a rebuild of the same application version
+    (e.g. to pick up dependency updates or Dockerfile changes).
+
+    Example: v1
+  EOT
+  type        = string
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/waiter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/waiter.tf
@@ -1,0 +1,33 @@
+locals {
+  await_router_file = templatefile("${path.module}/local-await-router.sh.tftpl", {
+    domain           = local.full_domain
+    hosted_zone_id   = data.aws_route53_zone.domain.zone_id
+    router_namespace = var.workspace_router_namespace
+    cluster_name     = module.eks_cluster.cluster_name
+    region           = data.aws_region.current.id
+  })
+  await_indent_str      = join("", [for i in range(6) : " "])
+  await_router_indented = join("\n${local.await_indent_str}", compact(split("\n", local.await_router_file)))
+}
+
+resource "null_resource" "wait_for_routing_ready" {
+  triggers = {
+    domain                = local.full_domain
+    cluster_name          = module.eks_cluster.cluster_name
+    router_chart_version  = helm_release.workspace_router.version
+    router_chart_revision = helm_release.workspace_router.metadata.revision
+  }
+
+  provisioner "local-exec" {
+    quiet   = true
+    command = <<DOC
+      ${local.await_router_indented}
+    DOC
+  }
+
+  depends_on = [
+    helm_release.workspace_router,
+    helm_release.jupyter_k8s,
+    aws_eks_identity_provider_config.dex,
+  ]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -1,0 +1,97 @@
+locals {
+  workspace_namespace       = "default"
+  access_strategy_name      = "oauth-access-strategy"
+  access_strategy_namespace = var.workspace_shared_namespace
+  workspace_storage_class   = "ebs-sc"
+}
+
+resource "kubernetes_namespace" "shared" {
+  metadata {
+    name = var.workspace_shared_namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "jupyter-deploy"
+    }
+  }
+
+  depends_on = [module.eks_cluster]
+}
+
+resource "helm_release" "workspace_defaults" {
+  name             = "workspace-defaults"
+  chart            = "${path.module}/../charts/workspace-defaults"
+  namespace        = var.workspace_shared_namespace
+  create_namespace = false
+
+  set = [
+    {
+      name  = "domain"
+      value = local.full_domain
+    },
+    {
+      name  = "sharedNamespace"
+      value = var.workspace_shared_namespace
+    },
+    {
+      name  = "routerNamespace"
+      value = var.workspace_router_namespace
+    },
+    {
+      name  = "operatorNamespace"
+      value = var.workspace_operator_namespace
+    },
+    {
+      name  = "accessStrategy.name"
+      value = local.access_strategy_name
+    },
+    {
+      name  = "workspaceTemplate.name"
+      value = "jupyterlab"
+    },
+    {
+      name  = "workspaceTemplate.isDefault"
+      value = "true"
+    },
+    {
+      name  = "workspaceTemplate.displayName"
+      value = "JupyterLab"
+    },
+    {
+      name  = "workspaceTemplate.description"
+      value = "JupyterLab workspace with persistent EBS storage"
+    },
+    {
+      name  = "workspaceTemplate.imageUri"
+      value = module.app_jupyterlab[0].image_uri
+    },
+    {
+      name  = "workspaceTemplate.appType"
+      value = var.workspace_app_jupyterlab_app_type
+    },
+    {
+      name  = "workspaceTemplate.accessType"
+      value = var.workspaces_default_access_type
+    },
+    {
+      name  = "workspaceTemplate.ownershipType"
+      value = var.workspaces_default_ownership_type
+    },
+    {
+      name  = "workspaceTemplate.storageClassName"
+      value = local.workspace_storage_class
+    },
+    {
+      name  = "workspaceTemplate.idleShutdown.enabled"
+      value = tostring(var.workspaces_idle_shutdown_enabled)
+    },
+    {
+      name  = "workspaceTemplate.idleShutdown.timeoutMinutes"
+      value = tostring(var.workspaces_idle_shutdown_timeout_default)
+    },
+    {
+      name  = "workspaceTemplate.idleShutdown.maxTimeoutMinutes"
+      value = tostring(var.workspaces_idle_shutdown_timeout_max)
+    },
+  ]
+
+  depends_on = [kubernetes_namespace.shared, helm_release.workspace_router]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -1,0 +1,76 @@
+schema_version: 1
+template:
+  name: tf-aws-eks-oidc
+  engine: terraform
+  version: 0.1.0
+requirements:
+- name: terraform
+- name: awscli
+- name: kubectl
+values:
+- name: deployment_id
+  source: output
+  source-key: deployment_id
+- name: open_url
+  source: output
+  source-key: get_started_url
+- name: aws_region
+  source: output
+  source-key: region
+project-store:
+  store-type: s3-only
+services: []
+secrets:
+- name: oauth_app_client_secret
+  source: output
+  source-key: secret_arn
+commands:
+- cmd: secret.reveal
+  sequence:
+  - api-name: aws.secretsmanager.get-secret-value
+    arguments:
+    - api-attribute: secret_id
+      source: cli
+      source-key: secret-id
+  results:
+  - result-name: secret-value
+    source: result
+    source-key: '[0].SecretString'
+supervised-execution:
+  config:
+    config.terraform-plan:
+      default-phase:
+        label: Reading data sources
+        progress-pattern: (Read complete after|Refreshing state)
+        progress-events-estimate: 120
+  up:
+    up.terraform-apply:
+      phases:
+      - enter-pattern: 'module.vpc'
+        exit-pattern: 'module.vpc.*Creation complete'
+        label: Creating VPC
+        weight: 5
+      - enter-pattern: 'module.eks_cluster'
+        exit-pattern: 'module.eks_cluster.*Creation complete'
+        label: Creating EKS cluster
+        weight: 40
+      - enter-pattern: 'aws_eks_addon'
+        exit-pattern: 'aws_eks_addon.*Creation complete'
+        label: Installing EKS add-ons
+        weight: 20
+      - enter-pattern: 'helm_release.jupyter_k8s'
+        exit-pattern: 'helm_release.jupyter_k8s.*Creation complete'
+        label: Deploying Jupyter K8s operator
+        weight: 10
+      - enter-pattern: 'helm_release.workspace_router'
+        exit-pattern: 'helm_release.workspace_router.*Creation complete'
+        label: Deploying OIDC routing
+        weight: 15
+      - enter-pattern: 'null_resource.wait_for_routing_ready'
+        exit-pattern: 'null_resource.wait_for_routing_ready.*Creation complete'
+        label: Waiting for routing to be ready
+        weight: 10
+      - enter-pattern: 'helm_release.workspace_defaults'
+        exit-pattern: 'helm_release.workspace_defaults.*Creation complete'
+        label: Creating workspace defaults
+        weight: 5

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+required:
+  domain: null
+  subdomain: null
+  letsencrypt_email: null
+  oauth_app_client_id: null
+  oauth_allowed_teams: null
+required_sensitive:
+  oauth_app_client_secret: null
+overrides: {}
+defaults:
+  cluster_name_prefix: jupyter-deploy-eks
+  region: us-west-2
+  kubernetes_version: "1.35"
+  node_groups:
+    - name: components
+      role: components
+      instance_type: t3.medium
+      ami_type: default
+      disk_size_gb: "50"
+      min_size: "1"
+      max_size: "3"
+      desired_size: "2"
+    - name: workspaces
+      role: workspaces
+      instance_type: c5.2xlarge
+      ami_type: default
+      disk_size_gb: "50"
+      min_size: "1"
+      max_size: "5"
+      desired_size: "1"
+  admin_role_names:
+    - Admin
+  cluster_log_retention_days: 30
+  custom_tags: {}
+  workspace_operator_namespace: jupyter-k8s-system
+  workspace_router_namespace: jupyter-k8s-router
+  workspace_shared_namespace: jupyter-k8s-shared
+  workspace_operator_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s
+  workspace_operator_chart_version: "0.1.0-rc.2"
+  workspace_router_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc
+  workspace_router_chart_version: "0.1.0-rc.2"
+  traefik_crd_chart_version: "1.15.0"
+  workspaces_default_access_type: OwnerOnly
+  workspaces_default_ownership_type: OwnerOnly
+  workspaces_idle_shutdown_enabled: true
+  workspaces_idle_shutdown_timeout_default: 60
+  workspaces_idle_shutdown_timeout_max: 480
+  workspace_app_jupyterlab_use: true
+  workspace_app_jupyterlab_app_type: jupyterlab
+  workspace_app_jupyterlab_image_name: jupyterlab-v0.1.0
+  workspace_app_jupyterlab_image_build: v1

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/pyproject.toml
@@ -1,0 +1,134 @@
+[project]
+name = "jupyter-deploy-tf-aws-eks-oidc"
+version = "0.1.0"
+description = "OIDC terraform template to deploy JupyterLab workspaces on AWS EKS with GitHub authentication."
+readme = "README.md"
+authors = [
+    { name = "Jonathan Guinegagne", email = "jggg@amazon.com" },
+]
+requires-python = ">=3.12"
+dependencies = [
+    "boto3",
+    "boto3-stubs",
+    "mypy-boto3-eks",
+    "mypy-boto3-sts",
+    "kubernetes>=31.0.0",
+]
+
+[project.license]
+file = "LICENSE"
+
+[project.entry-points."jupyter_deploy.terraform_templates"]
+aws_eks_oidc = "jupyter_deploy_tf_aws_eks_oidc.template:TEMPLATE_PATH"
+
+[project.urls]
+Homepage = "https://github.com/jupyter-infra/jupyter-deploy"
+github = "https://github.com/jupyter-infra/jupyter-deploy/tree/main/libs/jupyter-deploy-tf-aws-eks-oidc"
+
+[build-system]
+requires = [
+    "hatchling",
+]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = [
+    "jupyter_deploy_tf_aws_eks_oidc",
+]
+
+[tool.mypy]
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = true
+check_untyped_defs = true
+mypy_path = [
+    ".",
+]
+packages = [
+    "jupyter_deploy_tf_aws_eks_oidc",
+]
+
+[tool.ruff]
+extend-exclude = [
+    ".conda/",
+]
+line-length = 120
+
+[tool.ruff.lint]
+preview = true
+select = [
+    "E",
+    "F",
+    "UP",
+    "B",
+    "SIM",
+    "I",
+    "PLC0415",
+]
+ignore = [
+    "UP042",
+    "UP046",
+    "UP047",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "PLC0415",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+docstring-code-format = true
+docstring-code-line-length = 40
+
+[tool.pytest.ini_options]
+addopts = "--cov=jupyter_deploy_tf_aws_eks_oidc --cov-report=term-missing --cov-report=xml --cov-report=html"
+testpaths = [
+    "tests/unit",
+]
+markers = [
+    "e2e: End-to-end tests using playwright (deselect with '-m \"not e2e\"')",
+    "cli: Non-mutating CLI tests for release validation (select with '-m cli')",
+]
+
+[tool.coverage.run]
+source = [
+    "jupyter_deploy_tf_aws_eks_oidc",
+]
+omit = [
+    "tests/*",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "pass",
+    "raise ImportError",
+]
+fail_under = 80
+show_missing = true
+
+[tool.uv.sources.jupyter-deploy]
+workspace = true
+
+[tool.uv.sources.pytest-jupyter-deploy]
+workspace = true
+
+[dependency-groups]
+dev = [
+    "jupyter-deploy",
+    "pytest-jupyter-deploy[ui]",
+    "mypy>=1.15.0",
+    "pytest>=8.3.5",
+    "pytest-cov>=6.1.1",
+    "python-hcl2>=7.2.1",
+    "pyyaml>=6.0.2",
+    "ruff>=0.11.8",
+    "types-pyyaml>=6.0.12.20250516",
+    "yamllint>=1.35.0",
+]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/base.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/base.yaml
@@ -1,0 +1,45 @@
+schema_version: 1
+required:
+  domain: "${JD_E2E_VAR_DOMAIN}"
+  subdomain: "${JD_E2E_VAR_SUBDOMAIN}"
+  letsencrypt_email: "${JD_E2E_VAR_EMAIL}"
+  oauth_app_client_id: "${JD_E2E_VAR_OAUTH_APP_CLIENT_ID}"
+  oauth_allowed_teams: ${JD_E2E_VAR_OAUTH_ALLOWED_TEAMS}
+required_sensitive:
+  oauth_app_client_secret: "${JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET}"
+overrides: {}
+defaults:
+  cluster_name_prefix: jupyter-deploy-eks
+  region: us-west-2
+  kubernetes_version: "1.35"
+  node_groups:
+    - name: components
+      role: components
+      instance_type: t3.medium
+      ami_type: default
+      disk_size_gb: "50"
+      min_size: "1"
+      max_size: "3"
+      desired_size: "2"
+    - name: workspaces
+      role: workspaces
+      instance_type: c5.2xlarge
+      ami_type: default
+      disk_size_gb: "50"
+      min_size: "1"
+      max_size: "5"
+      desired_size: "1"
+  cluster_log_retention_days: 30
+  custom_tags: {}
+  workspace_operator_namespace: jupyter-k8s-system
+  workspace_router_namespace: jupyter-k8s-router
+  workspace_shared_namespace: jupyter-k8s-shared
+  workspace_operator_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s
+  workspace_operator_chart_version: "0.1.0-rc.2"
+  workspace_router_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc
+  workspace_router_chart_version: "0.1.0-rc.2"
+  traefik_crd_chart_version: "1.15.0"
+  workspace_app_jupyterlab_use: true
+  workspace_app_jupyterlab_app_type: jupyterlab
+  workspace_app_jupyterlab_image_name: jupyterlab-v0.1.0
+  workspace_app_jupyterlab_image_build: v1

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/conftest.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/conftest.py
@@ -1,0 +1,10 @@
+"""E2E test configuration for the EKS OIDC template."""
+
+import pytest
+
+
+def pytest_collection_modifyitems(items: list) -> None:
+    """Automatically mark all tests in this directory as e2e tests."""
+    for item in items:
+        if "e2e" in str(item.fspath):
+            item.add_marker(pytest.mark.e2e)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_configuration.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_configuration.py
@@ -1,0 +1,82 @@
+"""E2E tests for EKS OIDC template project configuration validation."""
+
+import re
+
+import pytest
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+from pytest_jupyter_deploy.undeployed_project import undeployed_project
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(
+    [
+        "JD_E2E_VAR_DOMAIN",
+        "JD_E2E_VAR_EMAIL",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+        "JD_E2E_VAR_SUBDOMAIN",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    ]
+)
+def test_project_is_configurable(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that an EKS project can be successfully configured (terraform init + plan)."""
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        e2e_deployment.configure_project(cli=cli)
+
+        engine_dir = project_path / "engine"
+        assert engine_dir.exists(), f"Engine directory should exist after config: {engine_dir}"
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(
+    [
+        "JD_E2E_VAR_DOMAIN",
+        "JD_E2E_VAR_EMAIL",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+        "JD_E2E_VAR_SUBDOMAIN",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    ]
+)
+def test_gitignore_generated_after_init(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that .gitignore is generated after jd init with correct patterns."""
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        gitignore_path = project_path / ".gitignore"
+        assert gitignore_path.exists(), f".gitignore should exist after init: {gitignore_path}"
+
+        gitignore_content = gitignore_path.read_text()
+
+        assert ".jd-history/" in gitignore_content
+        assert "jdout-" in gitignore_content
+        assert "jdinputs." in gitignore_content
+        assert ".terraform/" in gitignore_content
+        assert re.search(r"\*\.tfstate", gitignore_content)
+        assert ".terraform.lock.hcl" in gitignore_content
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(
+    [
+        "JD_E2E_VAR_DOMAIN",
+        "JD_E2E_VAR_EMAIL",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+        "JD_E2E_VAR_SUBDOMAIN",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    ]
+)
+def test_agent_md_generated_after_init(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that AGENT.md is generated after jd init with all snippets substituted."""
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        agent_path = project_path / "AGENT.md"
+        assert agent_path.exists(), f"AGENT.md should exist after init: {agent_path}"
+
+        agent_template_path = project_path / "AGENT.md.template"
+        assert not agent_template_path.exists(), "AGENT.md.template should be removed after init"
+
+        agent_content = agent_path.read_text()
+
+        assert "# Jupyter-deploy: Terraform AWS EKS OIDC template" in agent_content
+        assert "{{ " not in agent_content, "Should not contain template placeholders"
+        assert " }}" not in agent_content, "Should not contain template placeholders"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -1,0 +1,72 @@
+"""Tests for the template module."""
+
+import re
+from pathlib import Path
+
+import yaml
+
+from jupyter_deploy_tf_aws_eks_oidc.template import TEMPLATE_PATH
+
+MANDATORY_TEMPLATE_STRPATHS: list[str] = [
+    "manifest.yaml",
+    "variables.yaml",
+    "AGENT.md.template",
+    "engine/presets/defaults-all.tfvars",
+    "engine/presets/destroy.tfvars",
+    "engine/main.tf",
+    "engine/outputs.tf",
+    "engine/variables.tf",
+    "engine/waiter.tf",
+    "engine/local-await-router.sh.tftpl",
+    "charts/workspace-defaults/Chart.yaml",
+    "charts/console/Chart.yaml",
+]
+
+CHART_DIRS: list[str] = [
+    "charts/workspace-defaults",
+    "charts/console",
+]
+
+
+def test_template_path_exists() -> None:
+    assert TEMPLATE_PATH.exists()
+    assert TEMPLATE_PATH.is_dir()
+
+
+def test_mandatory_template_files_exist() -> None:
+    for file_str_path in MANDATORY_TEMPLATE_STRPATHS:
+        relative_path = Path(*file_str_path.split("/"))
+        full_path = TEMPLATE_PATH / relative_path
+
+        assert full_path.exists(), f"missing file: {relative_path}"
+        assert full_path.is_file(), f"not a file: {relative_path}"
+
+
+def test_chart_versions_match_template_version() -> None:
+    manifest_path = TEMPLATE_PATH / "manifest.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text())
+    template_version = manifest["template"]["version"]
+
+    for chart_dir in CHART_DIRS:
+        chart_yaml_path = TEMPLATE_PATH / chart_dir / "Chart.yaml"
+        chart = yaml.safe_load(chart_yaml_path.read_text())
+        chart_version = chart["version"]
+
+        assert chart_version == template_version, (
+            f"{chart_dir}/Chart.yaml version ({chart_version}) does not match manifest version ({template_version})"
+        )
+
+
+def test_main_tf_version_matches_template_version() -> None:
+    manifest_path = TEMPLATE_PATH / "manifest.yaml"
+    manifest = yaml.safe_load(manifest_path.read_text())
+    template_version = manifest["template"]["version"]
+
+    main_tf_path = TEMPLATE_PATH / "engine" / "main.tf"
+    main_tf_content = main_tf_path.read_text()
+    match = re.search(r'template_version\s*=\s*"([^"]+)"', main_tf_content)
+
+    assert match is not None, "template_version not found in main.tf"
+    assert match.group(1) == template_version, (
+        f"main.tf template_version ({match.group(1)}) does not match manifest version ({template_version})"
+    )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
@@ -1,0 +1,101 @@
+import re
+import unittest
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jupyter_deploy.handlers import base_project_handler
+
+from jupyter_deploy_tf_aws_eks_oidc.template import TEMPLATE_PATH
+
+
+class TestManifest(unittest.TestCase):
+    MANIFEST_PATH: Path = TEMPLATE_PATH / "manifest.yaml"
+    MANIFEST: dict[str, Any] | None = None
+    VARIABLES_CONFIG: dict[str, Any] | None = None
+    EXPECTED_REQUIREMENTS = ["terraform", "awscli", "kubectl"]
+    EXPECTED_VALUES = ["deployment_id", "open_url", "aws_region"]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        with open(cls.MANIFEST_PATH) as manifest_file:
+            cls.MANIFEST = yaml.safe_load(manifest_file)
+
+        variables_config_path = TEMPLATE_PATH / "variables.yaml"
+        with open(variables_config_path) as variables_config_file:
+            cls.VARIABLES_CONFIG = yaml.safe_load(variables_config_file)
+
+    def test_manifest_parses_as_yaml(self) -> None:
+        self.assertIsNotNone(self.MANIFEST)
+
+    def test_manifest_parses_as_a_dict(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+        self.assertIsInstance(self.MANIFEST, dict)
+
+    def test_manifest_parsable_by_jd(self) -> None:
+        manifest = base_project_handler.retrieve_project_manifest(self.MANIFEST_PATH)
+        self.assertIsNotNone(manifest)
+
+    def test_all_expected_requirements_declared(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        requirements = self.MANIFEST.get("requirements", [])
+        requirement_names = [req.get("name") for req in requirements]
+
+        for expected_req in self.EXPECTED_REQUIREMENTS:
+            self.assertIn(expected_req, requirement_names, f"Expected requirement {expected_req} missing from manifest")
+
+    def test_all_expected_values_declared(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        values = self.MANIFEST.get("values", [])
+        value_names = [val.get("name") for val in values]
+
+        for expected_val in self.EXPECTED_VALUES:
+            self.assertIn(expected_val, value_names, f"Expected value {expected_val} missing from manifest")
+
+    def test_output_sourced_values_have_matching_terraform_outputs(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        outputs_tf = (TEMPLATE_PATH / "engine" / "outputs.tf").read_text()
+        tf_output_names = set(re.findall(r'^output "(\w+)"', outputs_tf, re.MULTILINE))
+
+        for value in self.MANIFEST.get("values", []):
+            if value.get("source") != "output":
+                continue
+            source_key = value["source-key"]
+            self.assertIn(
+                source_key,
+                tf_output_names,
+                f"Manifest value '{value['name']}' references output '{source_key}' not found in outputs.tf",
+            )
+
+    def test_project_store_type_is_defined(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        project_store = self.MANIFEST.get("project-store")
+        self.assertIsNotNone(project_store, "Manifest must define 'project-store'")
+        self.assertIn("store-type", project_store, "project-store must define 'store-type'")
+        self.assertIn(
+            project_store["store-type"],
+            ["s3-only", "s3-ddb"],
+            f"Unexpected store-type: {project_store['store-type']}",
+        )
+
+    def test_secrets_names_map_to_required_sensitive_variables(self) -> None:
+        if self.MANIFEST is None or self.VARIABLES_CONFIG is None:
+            self.fail("MANIFEST or VARIABLES_CONFIG is None")
+
+        required_sensitive = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
+
+        for secret in self.MANIFEST.get("secrets", []):
+            self.assertIn(
+                secret["name"],
+                required_sensitive,
+                f"Manifest secret '{secret['name']}' not found in variables.yaml required_sensitive",
+            )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
@@ -1,0 +1,252 @@
+import tomllib
+import unittest
+from pathlib import Path
+
+import hcl2  # type: ignore[import-untyped]
+import yaml
+from jupyter_deploy.engine.terraform.tf_varfiles import strip_hcl2_quotes
+from jupyter_deploy.handlers import base_project_handler
+
+from jupyter_deploy_tf_aws_eks_oidc.template import TEMPLATE_PATH
+
+
+class TestVariablesYaml(unittest.TestCase):
+    VARIABLES_CONFIG_PATH: Path = TEMPLATE_PATH / "variables.yaml"
+    VARIABLES_CONFIG: dict
+    DEFAULTS_ALL_TFVARS: dict
+    TF_VARIABLES: dict
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        defaults_all_filepath = TEMPLATE_PATH / "engine" / "presets" / "defaults-all.tfvars"
+        variables_tf_filepath = TEMPLATE_PATH / "engine" / "variables.tf"
+
+        with open(cls.VARIABLES_CONFIG_PATH) as variables_config_file:
+            variable_config = yaml.safe_load(variables_config_file)
+
+        if not isinstance(variable_config, dict):
+            raise ValueError("Invalid variables.yaml file: not a dict")
+
+        TestVariablesYaml.VARIABLES_CONFIG = variable_config
+
+        with open(defaults_all_filepath) as defaults_tfvars_file:
+            defaults_tfvars_content = defaults_tfvars_file.read()
+            TestVariablesYaml.DEFAULTS_ALL_TFVARS = strip_hcl2_quotes(hcl2.loads(defaults_tfvars_content))
+
+        with open(variables_tf_filepath) as variables_tf_file:
+            variables_tf_content = variables_tf_file.read()
+            parsed_tf = strip_hcl2_quotes(hcl2.loads(variables_tf_content))
+
+            tf_variables = {}
+            for var in parsed_tf.get("variable", []):
+                for var_name, var_config in var.items():
+                    tf_variables[var_name] = var_config
+
+            TestVariablesYaml.TF_VARIABLES = tf_variables
+
+    def test_all_keys_are_present(self) -> None:
+        self.assertIn("required", self.VARIABLES_CONFIG)
+        self.assertIn("required_sensitive", self.VARIABLES_CONFIG)
+        self.assertIn("overrides", self.VARIABLES_CONFIG)
+        self.assertIn("defaults", self.VARIABLES_CONFIG)
+
+    def test_no_overlap_between_required_and_required_sensitive(self) -> None:
+        required_vars = set(self.VARIABLES_CONFIG["required"].keys())
+        required_sensitive_vars = set(self.VARIABLES_CONFIG["required_sensitive"].keys())
+
+        overlap = required_vars.intersection(required_sensitive_vars)
+        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
+
+    def test_no_overlap_between_required_and_defaults(self) -> None:
+        required_vars = set(self.VARIABLES_CONFIG["required"].keys())
+        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
+
+        overlap = required_vars.intersection(default_vars)
+        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
+
+    def test_no_overlap_between_required_sensitive_and_defaults(self) -> None:
+        required_sensitive_vars = set(self.VARIABLES_CONFIG["required_sensitive"].keys())
+        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
+
+        overlap = required_sensitive_vars.intersection(default_vars)
+        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
+
+    def test_all_required_set_to_none(self) -> None:
+        for var_name, var_value in self.VARIABLES_CONFIG["required"].items():
+            self.assertIsNone(var_value, f"Required variable {var_name} is not set to None")
+
+    def test_all_required_sensitive_set_to_none(self) -> None:
+        for var_name, var_value in self.VARIABLES_CONFIG["required_sensitive"].items():
+            self.assertIsNone(var_value, f"Required sensitive variable {var_name} is not set to None")
+
+    def test_no_overrides_set(self) -> None:
+        overrides = self.VARIABLES_CONFIG["overrides"]
+        self.assertTrue(
+            overrides is None or len(overrides) == 0,
+            f"Overrides should be empty, found: {overrides}",
+        )
+
+    def test_all_defaults_varname_exist_in_all_preset(self) -> None:
+        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        missing_vars = default_vars - preset_vars
+        self.assertEqual(
+            len(missing_vars), 0, f"Variables in defaults section not found in defaults-all.tfvars: {missing_vars}"
+        )
+
+    def test_defaults_varname_count_equal_varnames_in_all_preset(self) -> None:
+        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        self.assertEqual(
+            len(default_vars),
+            len(preset_vars),
+            f"Number of variables in defaults ({len(default_vars)}) does not match "
+            f"number in defaults-all.tfvars ({len(preset_vars)})",
+        )
+
+    def test_all_values_in_defaults_match_preset(self) -> None:
+        for var_name, var_value in self.VARIABLES_CONFIG["defaults"].items():
+            self.assertIn(var_name, self.DEFAULTS_ALL_TFVARS)
+
+            if var_value == {}:
+                self.assertEqual(
+                    self.DEFAULTS_ALL_TFVARS[var_name],
+                    {},
+                    f"Value mismatch for {var_name}",
+                )
+            elif var_value == []:
+                self.assertEqual(
+                    self.DEFAULTS_ALL_TFVARS[var_name],
+                    [],
+                    f"Value mismatch for {var_name}",
+                )
+            elif var_value is None:
+                self.assertIsNone(self.DEFAULTS_ALL_TFVARS[var_name], f"Value mismatch for {var_name}")
+            else:
+                self.assertEqual(
+                    var_value,
+                    self.DEFAULTS_ALL_TFVARS[var_name],
+                    f"Value mismatch for {var_name}: variables.yaml has {var_value}, "
+                    f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
+                )
+
+    def test_all_variables_in_yaml_exist_in_tf(self) -> None:
+        required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
+        required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
+        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
+
+        all_yaml_vars = required_vars.union(required_sensitive_vars).union(defaults_vars)
+        all_tf_vars = set(self.TF_VARIABLES.keys())
+
+        missing_vars = all_yaml_vars - all_tf_vars
+        self.assertEqual(len(missing_vars), 0, f"Variables in variables.yaml not found in variables.tf: {missing_vars}")
+
+    def test_all_variables_in_tf_are_referenced_in_yaml(self) -> None:
+        required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
+        required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
+        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
+
+        all_yaml_vars = required_vars.union(required_sensitive_vars).union(defaults_vars)
+        all_tf_vars = set(self.TF_VARIABLES.keys())
+
+        missing_vars = all_tf_vars - all_yaml_vars
+        self.assertEqual(
+            len(missing_vars), 0, f"Variables in variables.tf not referenced in variables.yaml: {missing_vars}"
+        )
+
+    def test_sensitive_variables_not_in_required_or_defaults(self) -> None:
+        sensitive_vars = set()
+        for var_name, var_config in self.TF_VARIABLES.items():
+            if var_config.get("sensitive") is True:
+                sensitive_vars.add(var_name)
+
+        required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
+        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
+
+        sensitive_in_required = sensitive_vars.intersection(required_vars)
+        sensitive_in_defaults = sensitive_vars.intersection(defaults_vars)
+
+        self.assertEqual(
+            len(sensitive_in_required), 0, f"Sensitive variables found in 'required' section: {sensitive_in_required}"
+        )
+        self.assertEqual(
+            len(sensitive_in_defaults), 0, f"Sensitive variables found in 'defaults' section: {sensitive_in_defaults}"
+        )
+
+    def test_required_sensitive_variables_are_marked_sensitive_in_tf(self) -> None:
+        sensitive_vars = set()
+        for var_name, var_config in self.TF_VARIABLES.items():
+            if var_config.get("sensitive") is True:
+                sensitive_vars.add(var_name)
+
+        required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
+
+        not_marked_sensitive = required_sensitive_vars - sensitive_vars
+        self.assertEqual(
+            len(not_marked_sensitive),
+            0,
+            f"Variables in 'required_sensitive' not marked as sensitive in variables.tf: {not_marked_sensitive}",
+        )
+
+    def test_variables_file_parsable_by_base_project_handler(self) -> None:
+        variables_config = base_project_handler.retrieve_variables_config(self.VARIABLES_CONFIG_PATH)
+        self.assertIsNotNone(variables_config)
+
+    def test_app_image_name_matches_pyproject_version(self) -> None:
+        apps_dir = TEMPLATE_PATH / "applications"
+        defaults = self.VARIABLES_CONFIG["defaults"]
+
+        for app_dir in apps_dir.iterdir():
+            if not app_dir.is_dir():
+                continue
+
+            pyproject_path = app_dir / "pyproject.toml"
+            if not pyproject_path.exists():
+                continue
+
+            app_name = app_dir.name
+            image_name_key = f"workspace_app_{app_name}_image_name"
+
+            with open(pyproject_path, "rb") as f:
+                pyproject = tomllib.load(f)
+
+            version = pyproject["project"]["version"]
+            expected_image_name = f"{app_name}-v{version}"
+
+            self.assertIn(image_name_key, defaults, f"Missing default for {image_name_key}")
+            self.assertEqual(
+                defaults[image_name_key],
+                expected_image_name,
+                f"{image_name_key} default '{defaults[image_name_key]}' does not match "
+                f"pyproject.toml version: expected '{expected_image_name}'",
+            )
+
+    def test_app_image_name_preset_matches_pyproject_version(self) -> None:
+        apps_dir = TEMPLATE_PATH / "applications"
+
+        for app_dir in apps_dir.iterdir():
+            if not app_dir.is_dir():
+                continue
+
+            pyproject_path = app_dir / "pyproject.toml"
+            if not pyproject_path.exists():
+                continue
+
+            app_name = app_dir.name
+            image_name_key = f"workspace_app_{app_name}_image_name"
+
+            with open(pyproject_path, "rb") as f:
+                pyproject = tomllib.load(f)
+
+            version = pyproject["project"]["version"]
+            expected_image_name = f"{app_name}-v{version}"
+
+            self.assertIn(image_name_key, self.DEFAULTS_ALL_TFVARS, f"Missing preset for {image_name_key}")
+            self.assertEqual(
+                self.DEFAULTS_ALL_TFVARS[image_name_key],
+                expected_image_name,
+                f"{image_name_key} in defaults-all.tfvars '{self.DEFAULTS_ALL_TFVARS[image_name_key]}' "
+                f"does not match pyproject.toml version: expected '{expected_image_name}'",
+            )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_version.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_version.py
@@ -1,0 +1,43 @@
+"""Tests for version consistency across the project."""
+
+import re
+import tomllib
+from pathlib import Path
+
+import yaml
+
+
+def test_version_consistency() -> None:
+    """Test that version numbers are consistent across pyproject.toml, __init__.py, manifest.yaml, and main.tf."""
+    project_path = Path(__file__).parent.parent.parent
+
+    with open(project_path / "pyproject.toml", "rb") as f:
+        pyproject_data = tomllib.load(f)
+    pyproject_version = pyproject_data["project"]["version"]
+
+    init_path = project_path / "jupyter_deploy_tf_aws_eks_oidc" / "__init__.py"
+    init_content = init_path.read_text()
+    init_version_match = re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', init_content)
+    assert init_version_match is not None, "Could not find __version__ in __init__.py"
+    init_version = init_version_match.group(1)
+
+    manifest_path = project_path / "jupyter_deploy_tf_aws_eks_oidc" / "template" / "manifest.yaml"
+    with open(manifest_path) as f:
+        manifest_data = yaml.safe_load(f)
+    manifest_version = manifest_data["template"]["version"]
+
+    main_tf_path = project_path / "jupyter_deploy_tf_aws_eks_oidc" / "template" / "engine" / "main.tf"
+    main_tf_content = main_tf_path.read_text()
+    main_tf_version_match = re.search(r'template_version\s*=\s*["\']([^"\']+)["\']', main_tf_content)
+    assert main_tf_version_match is not None, "Could not find template_version in main.tf"
+    main_tf_version = main_tf_version_match.group(1)
+
+    assert pyproject_version == init_version, (
+        f"Version mismatch: pyproject.toml ({pyproject_version}) != __init__.py ({init_version})"
+    )
+    assert pyproject_version == manifest_version, (
+        f"Version mismatch: pyproject.toml ({pyproject_version}) != manifest.yaml ({manifest_version})"
+    )
+    assert pyproject_version == main_tf_version, (
+        f"Version mismatch: pyproject.toml ({pyproject_version}) != main.tf template_version ({main_tf_version})"
+    )

--- a/libs/jupyter-deploy/jupyter_deploy/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/enum.py
@@ -152,6 +152,7 @@ class JupyterDeployTool(str, Enum):
     AWS_CLI = "aws-cli"
     AWS_SSM_PLUGIN = "aws-ssm-plugin"
     JQ = "jq"
+    KUBECTL = "kubectl"
     TERRAFORM = "terraform"
 
     @classmethod

--- a/libs/jupyter-deploy/jupyter_deploy/verify_utils.py
+++ b/libs/jupyter-deploy/jupyter_deploy/verify_utils.py
@@ -6,7 +6,9 @@ from jupyter_deploy.exceptions import ToolRequiredError
 from jupyter_deploy.manifest import JupyterDeployRequirementV1
 
 
-def _check_installation(tool_name: str, installation_url: str | None = None) -> None:
+def _check_installation(
+    tool_name: str, installation_url: str | None = None, version_cmds: list[str] | None = None
+) -> None:
     """Shell out to verify tool installation, raise ToolRequiredError if not found.
 
     Raises:
@@ -14,6 +16,7 @@ def _check_installation(tool_name: str, installation_url: str | None = None) -> 
     """
     installed, _, error_msg = cmd_utils.check_executable_installation(
         executable_name=tool_name,
+        version_cmds=version_cmds,
     )
 
     if not installed:
@@ -52,10 +55,20 @@ def _check_jq_installation() -> None:
     )
 
 
+def _check_kubectl_installation() -> None:
+    """Shell out to verify `kubectl` install, raise ToolRequiredError if not found."""
+    return _check_installation(
+        tool_name="kubectl",
+        installation_url="https://kubernetes.io/docs/tasks/tools/install-kubectl/",
+        version_cmds=["version", "--client"],
+    )
+
+
 _TOOL_VERIFICATION_FN_MAP: dict[JupyterDeployTool, Callable[[], None]] = {
     JupyterDeployTool.AWS_CLI: _check_aws_cli_installation,
     JupyterDeployTool.AWS_SSM_PLUGIN: _check_ssm_plugin_installation,
     JupyterDeployTool.JQ: _check_jq_installation,
+    JupyterDeployTool.KUBECTL: _check_kubectl_installation,
     JupyterDeployTool.TERRAFORM: _check_terraform_installation,
 }
 

--- a/libs/jupyter-deploy/tests/unit/test_verify_utils.py
+++ b/libs/jupyter-deploy/tests/unit/test_verify_utils.py
@@ -14,7 +14,7 @@ class TestVerifyInstallation(unittest.TestCase):
         mock_check.return_value = (True, "2.0.0", None)
         # Should not raise
         verify_utils._check_installation("my-tool")
-        mock_check.assert_called_once_with(executable_name="my-tool")
+        mock_check.assert_called_once_with(executable_name="my-tool", version_cmds=None)
 
     @patch("jupyter_deploy.cmd_utils.check_executable_installation")
     def test_raises_when_tool_not_installed(self, mock_check: Mock) -> None:

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
@@ -33,6 +33,11 @@ RUN curl -s 'https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ub
     dpkg -i session-manager-plugin.deb && \
     rm session-manager-plugin.deb
 
+# Install kubectl
+RUN curl -sLO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+    rm kubectl
+
 # Create user with configurable UID/GID (defaults to 1000:1000)
 ARG USER_UID=1000
 ARG USER_GID=1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ pytest-jupyter-deploy = { workspace = true }
 members = [
     "libs/jupyter-deploy",
     "libs/jupyter-deploy-tf-aws-ec2-base",
+    "libs/jupyter-deploy-tf-aws-eks-oidc",
     "libs/jupyter-infra-tf-aws-iam-ci",
     "libs/pytest-jupyter-deploy",
     "images/uvbase"
@@ -81,6 +82,7 @@ explicit_package_bases = true
 mypy_path = [
     "libs/jupyter-deploy",
     "libs/jupyter-deploy-tf-aws-ec2-base",
+    "libs/jupyter-deploy-tf-aws-eks-oidc",
     "libs/jupyter-infra-tf-aws-iam-ci",
     "libs/pytest-jupyter-deploy",
     "scripts",
@@ -89,13 +91,18 @@ plugins = ["pydantic.mypy"]
 files = [
     "libs/jupyter-deploy",
     "libs/jupyter-deploy-tf-aws-ec2-base",
+    "libs/jupyter-deploy-tf-aws-eks-oidc",
     "libs/jupyter-infra-tf-aws-iam-ci",
     "libs/pytest-jupyter-deploy",
     "scripts",
 ]
-# E2E tests excluded: conftest.py (pytest magic name, can't rename) causes
-# "Duplicate module" errors across templates sharing the tests/e2e/ structure.
+# Template test directories excluded: identical module paths (tests/unit/, tests/e2e/)
+# across template packages cause "Duplicate module" errors. Each template package
+# runs its own mypy via [tool.mypy] in its pyproject.toml.
 exclude = [
+    "libs/jupyter-deploy-tf-aws-ec2-base/tests/",
+    "libs/jupyter-deploy-tf-aws-eks-oidc/tests/",
+    "libs/jupyter-infra-tf-aws-iam-ci/tests/",
     "tests/e2e/",
 ]
 
@@ -109,6 +116,7 @@ follow_untyped_imports = true
 pythonpath = [
   "libs/jupyter-deploy",
   "libs/jupyter-deploy-tf-aws-ec2-base",
+  "libs/jupyter-deploy-tf-aws-eks-oidc",
   "libs/jupyter-infra-tf-aws-iam-ci",
   "libs/pytest-jupyter-deploy"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ members = [
     "jupyter-deploy",
     "jupyter-deploy-monorepo",
     "jupyter-deploy-tf-aws-ec2-base",
+    "jupyter-deploy-tf-aws-eks-oidc",
     "jupyter-infra-tf-aws-iam-ci",
     "pytest-jupyter-deploy",
 ]
@@ -603,6 +604,55 @@ requires-dist = [
     { name = "mypy-boto3-s3" },
     { name = "mypy-boto3-secretsmanager" },
     { name = "mypy-boto3-ssm" },
+    { name = "mypy-boto3-sts" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "jupyter-deploy", editable = "libs/jupyter-deploy" },
+    { name = "mypy", specifier = ">=1.15.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pytest-jupyter-deploy", extras = ["ui"], editable = "libs/pytest-jupyter-deploy" },
+    { name = "python-hcl2", specifier = ">=7.2.1" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
+    { name = "ruff", specifier = ">=0.11.8" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
+    { name = "yamllint", specifier = ">=1.35.0" },
+]
+
+[[package]]
+name = "jupyter-deploy-tf-aws-eks-oidc"
+version = "0.1.0"
+source = { editable = "libs/jupyter-deploy-tf-aws-eks-oidc" }
+dependencies = [
+    { name = "boto3" },
+    { name = "boto3-stubs" },
+    { name = "kubernetes" },
+    { name = "mypy-boto3-eks" },
+    { name = "mypy-boto3-sts" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "jupyter-deploy" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-jupyter-deploy", extra = ["ui"] },
+    { name = "python-hcl2" },
+    { name = "pyyaml" },
+    { name = "ruff" },
+    { name = "types-pyyaml" },
+    { name = "yamllint" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "boto3" },
+    { name = "boto3-stubs" },
+    { name = "kubernetes", specifier = ">=31.0.0" },
+    { name = "mypy-boto3-eks" },
     { name = "mypy-boto3-sts" },
 ]
 


### PR DESCRIPTION
This PR adds the EKS OIDC template (`libs/jupyter-deploy-tf-aws-eks-oidc`), the second template for jupyter-deploy. It deploys JupyterLab workspaces on an Amazon EKS cluster using the [jupyter-k8s](https://github.com/jupyter-infra/jupyter-k8s) operator and [jupyter-k8s-aws](https://github.com/jupyter-infra/jupyter-k8s-aws) OIDC routing chart.

This is Phase 2 of the EKS template plan (Phase 1 was #212). It covers `jd init`, `jd config`, `jd up`, and `jd down`. Manifest commands come in Phase 3.

### User experience

The user runs:
- `jd init -I eks -T oidc <project-dir>` to scaffold a new project
- configure variables (cluster prefix, domain, OAuth app, node groups, allowed teams) in `variables.yaml`
- run `jd config` & `jd up`

The full stack adds:
- VPC with public/private subnets across 2 AZs
- EKS cluster with role-based managed node groups (`components` + `workspaces`)
- EKS managed add-ons: vpc-cni, kube-proxy, coredns, pod-identity-agent, ebs-csi-driver, cert-manager, external-dns
- Helm releases: traefik-crds, jupyter-k8s operator, aws-oidc router (traefik + dex + oauth2-proxy + authmiddleware)
- OIDC identity provider on the cluster (GitHub OAuth via Dex) for kubectl authentication
- Console page at `/get-started/` with kubeconfig setup script
- Default workspace template + access strategy
- JupyterLab image in an ECR repository (built by a codebuild job started and awaited by the template)

After deploy, workspace users visit the console page to configure kubectl with OIDC, then create workspaces via the operator CRDs.

### Implementation

**CLI changes:**
- `kubectl` added to `JupyterDeployTool` enum with custom `version_cmds` support in `_check_installation`

**Template package** (`libs/jupyter-deploy-tf-aws-eks-oidc`):
- 10 Terraform modules: `iam_role`, `iam_policy`, `vpc`, `eks_cluster`, `node_group`, `s3_bucket`, `secret`, `ecr`, `codebuild_job`, `application`
- Core template files:
    - `main.tf` (providers, VPC, EKS, OIDC provider, admin access entries)
    - `iam.tf` (all roles), `eks_addons.tf` (managed add-ons with pod identity)
    - `helm.tf` (3 Helm releases)
    - additional files: `workspaces.tf`, `console.tf`, `applications.tf`
- Local Helm charts: `workspace-defaults` (access strategy + template CRDs), `console` (nginx onboarding page)
- `applications/jupyterlab/`: default workspace Dockerfile
- Router waiter script: handles DNS race condition on fresh deploys (CoreDNS cache flush + deployment restart)

**Key design decisions:**
- Exec-based K8s/Helm provider auth (`aws eks get-token`) — no static tokens expiring mid-apply
- `cluster_name_prefix` + `random_id` for multi-deployment support per account
- Role-based node groups with `jupyter-deploy/role` label for scheduling
- `bootstrap_cluster_creator_admin_permissions = true` — Terraform retains admin; additional admins via `admin_role_names`
- Pod identity for all add-on that need AWS creds (EBS CSI, cert-manager, external-dns)

**Workspace config:**
- New workspace member in root `pyproject.toml`
- `.yamllint` ignores Helm chart `templates/` directories
- Mypy excludes template test directories to avoid duplicate module errors
- `kubectl` added to E2E container Dockerfile

### Testing

- 1825 unit tests passing (template structure, variables, manifest, version)
- E2E configuration test: `terraform plan` succeeds with preset variables against sandbox-eks
- Deployed and validated against a live EKS cluster

### Screenshot

**Get started page**
<img width="1075" height="1305" alt="Screenshot 2026-05-07 at 6 19 17 PM" src="https://github.com/user-attachments/assets/cde64c42-d3d2-48e8-96bc-921c467f3003" />
