### PR TITLE
feat: eks OIDC host, server, open commands

### DIFF
--- a/.github/e2e-base/Dockerfile
+++ b/.github/e2e-base/Dockerfile
@@ -79,7 +79,9 @@ RUN if [ "$INSTALL_MODE" = "pypi" ]; then \
     else \
         cd /workspace && \
         rm -f .github/e2e-base/pyproject.release.toml .github/e2e-base/pyproject.canary.toml && \
-        uv sync --all-packages; \
+        uv sync --all-packages && \
+        uv run playwright install firefox && \
+        ln -sf ~/.cache/ms-playwright/firefox-*/firefox/firefox ~/.local/bin/firefox; \
     fi
 
 CMD ["sleep", "infinity"]

--- a/justfile
+++ b/justfile
@@ -616,6 +616,10 @@ e2e-all project_dir test_filter="" options="" no_cache="false" template=default-
 test-e2e-base project_dir="sandbox-e2e" test_filter="" options="":
     @just test-e2e {{project_dir}} "{{test_filter}}" "{{options}}" tf-aws-ec2-base
 
+# Run E2E tests for the EKS OIDC template (tf-aws-eks-oidc)
+test-e2e-eks-oidc project_dir="sandbox-eks" test_filter="" options="":
+    @just test-e2e {{project_dir}} "{{test_filter}}" "{{options}}" tf-aws-eks-oidc
+
 # Run E2E tests for the CI template (tf-aws-iam-ci)
 test-e2e-ci project_dir="sandbox-e2e-ci" test_filter="" options="":
     @just test-e2e {{project_dir}} "{{test_filter}}" "{{options}}" tf-aws-iam-ci

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/console/setup-config.html.tftpl
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/console/setup-config.html.tftpl
@@ -46,7 +46,7 @@
   <div class="step">
     <pre>kubectl get Workspaces</pre>
     <p>To get a workspace's access URL:</p>
-    <pre>kubectl get Workspace my-workspace -o jsonpath='{.spec.accessURL}'; echo</pre>
+    <pre>kubectl get Workspace my-workspace -o jsonpath='{.status.accessURL}'; echo</pre>
     <p>Once the workspace is <code>Available</code>, open the access URL in your browser.</p>
   </div>
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/outputs.tf
@@ -31,6 +31,10 @@ output "workspace_router_namespace" {
   value = var.workspace_router_namespace
 }
 
+output "workspace_shared_namespace" {
+  value = var.workspace_shared_namespace
+}
+
 output "workspace_base_url" {
   value = local.workspaces_base_url
 }
@@ -47,3 +51,32 @@ output "secret_arn" {
 output "jupyterlab_image_uri" {
   value = var.workspace_app_jupyterlab_use ? module.app_jupyterlab[0].image_uri : ""
 }
+
+output "kubeconfig_path" {
+  value = abspath("${path.root}/.kube/config")
+}
+
+output "workspace_crd_group" {
+  value = "workspace.jupyter.org"
+}
+
+output "workspace_crd_version" {
+  value = "v1alpha1"
+}
+
+output "workspace_crd_plural" {
+  value = "workspaces"
+}
+
+output "workspace_patch_start" {
+  value = "{\"spec\":{\"desiredStatus\":\"Running\"}}"
+}
+
+output "workspace_patch_stop" {
+  value = "{\"spec\":{\"desiredStatus\":\"Stopped\"}}"
+}
+
+output "server_default_scope" {
+  value = var.workspace_rbac_namespaces[0]
+}
+

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -17,9 +17,63 @@ values:
 - name: aws_region
   source: output
   source-key: region
+- name: kubeconfig_path
+  source: output
+  source-key: kubeconfig_path
+- name: workspace_shared_namespace
+  source: output
+  source-key: workspace_shared_namespace
+- name: cluster_name
+  source: output
+  source-key: cluster_name
+- name: cluster_endpoint
+  source: output
+  source-key: cluster_endpoint
+- name: cluster_ca_certificate
+  source: output
+  source-key: cluster_ca_certificate
+- name: workspace_base_url
+  source: output
+  source-key: workspace_base_url
+- name: workspace_patch_start
+  source: output
+  source-key: workspace_patch_start
+- name: workspace_patch_stop
+  source: output
+  source-key: workspace_patch_stop
+- name: server_default_scope
+  source: output
+  source-key: server_default_scope
 project-store:
   store-type: s3-only
+multi-host: true
+multi-server: true
 services: []
+server-status-rules:
+- display: Degraded
+  all:
+  - path: .status.conditions[type=Degraded].status
+    equals: "True"
+- display: Starting
+  all:
+  - path: .status.conditions[type=Progressing].status
+    equals: "True"
+  - path: .spec.desiredStatus
+    equals: Running
+- display: Stopping
+  all:
+  - path: .status.conditions[type=Progressing].status
+    equals: "True"
+  - path: .spec.desiredStatus
+    equals: Stopped
+- display: Stopped
+  all:
+  - path: .status.conditions[type=Stopped].status
+    equals: "True"
+- display: Running
+  all:
+  - path: .status.conditions[type=Available].status
+    equals: "True"
 secrets:
 - name: oauth_app_client_secret
   source: output
@@ -36,6 +90,322 @@ commands:
   - result-name: secret-value
     source: result
     source-key: '[0].SecretString'
+- cmd: host.list
+  sequence:
+  - api-name: k8s.core.list-nodes
+    arguments:
+    - api-attribute: query
+      source: cli
+      source-key: query
+    - api-attribute: page_size
+      source: cli
+      source-key: limit
+    - api-attribute: pagination_token
+      source: cli
+      source-key: continue_from
+  results:
+  - result-name: host.list
+    source: result
+    source-key: '[0].NodeNames'
+  - result-name: host.list.next_token
+    source: result
+    source-key: '[0].NextToken'
+- cmd: host.status
+  sequence:
+  - api-name: k8s.core.get-node
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: host.status
+    source: result
+    source-key: '[0].Status'
+- cmd: host.show
+  sequence:
+  - api-name: k8s.core.get-node
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: host.show.name
+    source: result
+    source-key: '[0].Name'
+  - result-name: host.show.status
+    source: result
+    source-key: '[0].Status'
+  - result-name: host.show.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: server.list
+  sequence:
+  - api-name: k8s.custom.list
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: page_size
+      source: cli
+      source-key: limit
+    - api-attribute: pagination_token
+      source: cli
+      source-key: continue_from
+  results:
+  - result-name: server.list
+    source: result
+    source-key: '[0].Names'
+  - result-name: server.list.items
+    source: result
+    source-key: '[0].Items'
+  - result-name: server.list.next_token
+    source: result
+    source-key: '[0].NextToken'
+- cmd: server.status
+  sequence:
+  - api-name: k8s.custom.get
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: server.status
+    source: result
+    source-key: '[0].Name'
+  - result-name: server.status.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: server.show
+  sequence:
+  - api-name: k8s.custom.get
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: server.show.name
+    source: result
+    source-key: '[0].Name'
+  - result-name: server.show.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: server.start
+  sequence:
+  - api-name: k8s.custom.patch
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: body
+      source: output
+      source-key: workspace_patch_start
+- cmd: server.stop
+  sequence:
+  - api-name: k8s.custom.patch
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: body
+      source: output
+      source-key: workspace_patch_stop
+- cmd: server.logs
+  sequence:
+  - api-name: k8s.custom.get
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+  - api-name: k8s.core.deployment-logs
+    arguments:
+    - api-attribute: name
+      source: result
+      source-key: '[0].Resource'
+      extract: status.deploymentName
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: container
+      source: cli
+      source-key: service
+    - api-attribute: tail_lines
+      source: cli
+      source-key: extra
+  results:
+  - result-name: server.logs
+    source: result
+    source-key: '[1].Logs'
+  - result-name: server.errors
+    source: result
+    source-key: '[1].Logs'
+- cmd: server.exec
+  sequence:
+  - api-name: k8s.custom.get
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+  - api-name: k8s.core.exec-pod
+    arguments:
+    - api-attribute: deployment_name
+      source: result
+      source-key: '[0].Resource'
+      extract: status.deploymentName
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: command
+      source: cli
+      source-key: commands
+    - api-attribute: container
+      source: cli
+      source-key: service
+  results:
+  - result-name: server.exec.stdout
+    source: result
+    source-key: '[1].Stdout'
+  - result-name: server.exec.stderr
+    source: result
+    source-key: '[1].Stderr'
+  - result-name: server.exec.returncode
+    source: result
+    source-key: '[1].ReturnCode'
+- cmd: open.server
+  sequence:
+  - api-name: k8s.custom.get
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: open.server.url
+    source: result
+    source-key: '[0].Resource'
+    extract: status.accessURL
+- cmd: server.connect
+  sequence:
+  - api-name: k8s.custom.get
+    arguments:
+    - api-attribute: group
+      source: output
+      source-key: workspace_crd_group
+    - api-attribute: version
+      source: output
+      source-key: workspace_crd_version
+    - api-attribute: plural
+      source: output
+      source-key: workspace_crd_plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+  - api-name: k8s.core.exec-pod-interactive
+    arguments:
+    - api-attribute: deployment_name
+      source: result
+      source-key: '[0].Resource'
+      extract: status.deploymentName
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: container
+      source: cli
+      source-key: service
 supervised-execution:
   config:
     config.terraform-plan:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_host.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_host.py
@@ -124,7 +124,7 @@ def test_host_status_happy_case(e2e_deployment: EndToEndDeployment) -> None:
     data = _list_hosts_json(e2e_deployment)
     first_host = data["hosts"][0]
 
-    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "status", first_host])
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "status", "--name", first_host])
     assert "Host status:" in result.stdout, f"Expected 'Host status:' in output:\n{result.stdout}"
 
 
@@ -133,7 +133,7 @@ def test_host_status_not_found(e2e_deployment: EndToEndDeployment) -> None:
     e2e_deployment.ensure_deployed()
 
     with pytest.raises(JDCliError):
-        e2e_deployment.cli.run_command(["jupyter-deploy", "host", "status", "i-do-not-exist"])
+        e2e_deployment.cli.run_command(["jupyter-deploy", "host", "status", "--name", "i-do-not-exist"])
 
 
 # ── host show ────────────────────────────────────────────────────────────────
@@ -146,7 +146,7 @@ def test_host_show_happy_case(e2e_deployment: EndToEndDeployment) -> None:
     data = _list_hosts_json(e2e_deployment)
     first_host = data["hosts"][0]
 
-    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", first_host])
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", "--name", first_host])
     assert result.stdout, f"Expected non-empty output for host show {first_host}"
 
 
@@ -157,7 +157,7 @@ def test_host_show_json(e2e_deployment: EndToEndDeployment) -> None:
     data = _list_hosts_json(e2e_deployment)
     first_host = data["hosts"][0]
 
-    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", first_host, "--json"])
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", "--name", first_host, "--json"])
     show_data = json.loads(result.stdout, strict=False)
     assert "name" in show_data, f"Expected 'name' in JSON response, got: {list(show_data.keys())}"
     assert "status" in show_data, "Expected 'status' in JSON response"
@@ -170,4 +170,4 @@ def test_host_show_not_found(e2e_deployment: EndToEndDeployment) -> None:
     e2e_deployment.ensure_deployed()
 
     with pytest.raises(JDCliError):
-        e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", "i-do-not-exist"])
+        e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", "--name", "i-do-not-exist"])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_host.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_host.py
@@ -1,0 +1,173 @@
+"""E2E tests for host (node) commands on the EKS OIDC template."""
+
+import json
+
+import pytest
+from pytest_jupyter_deploy.cli import JDCliError
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+
+
+def _list_hosts_json(
+    e2e_deployment: EndToEndDeployment, limit: int | None = None, continue_from: str | None = None
+) -> dict:
+    cmd = ["jupyter-deploy", "host", "list", "--json"]
+    if limit is not None:
+        cmd.extend(["-n", str(limit)])
+    if continue_from is not None:
+        cmd.extend(["--continue-from", continue_from])
+    result = e2e_deployment.cli.run_command(cmd)
+    return json.loads(result.stdout)
+
+
+# ── host list ────────────────────────────────────────────────────────────────
+
+
+def test_host_list_no_pagination(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that the cluster has at least 3 nodes (2 components + 1 workspace)."""
+    e2e_deployment.ensure_deployed()
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "list"])
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    assert len(lines) >= 3, f"Expected at least 3 hosts, got {len(lines)}: {lines}"
+    assert "--continue-from" not in result.stdout, "Expected no pagination hint when listing all hosts"
+
+
+def test_host_list_json(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that jd host list --json returns valid JSON with expected keys."""
+    e2e_deployment.ensure_deployed()
+
+    data = _list_hosts_json(e2e_deployment)
+    assert "hosts" in data, f"Expected 'hosts' key in JSON response, got: {list(data.keys())}"
+    assert isinstance(data["hosts"], list), f"Expected 'hosts' to be a list, got {type(data['hosts'])}"
+    for host in data["hosts"]:
+        assert isinstance(host, str), f"Expected host name to be a string, got {type(host)}: {host}"
+
+
+def test_host_list_paginate_full(e2e_deployment: EndToEndDeployment) -> None:
+    """Paginate through hosts one at a time and verify we get distinct hosts."""
+    e2e_deployment.ensure_deployed()
+
+    # Page 1: request 1 host
+    page1 = _list_hosts_json(e2e_deployment, limit=1)
+    assert len(page1["hosts"]) == 1, f"Expected 1 host on page 1, got {len(page1['hosts'])}"
+    token1 = page1.get("continue_from")
+    assert token1, "Expected a pagination token after requesting 1 of 3+ hosts"
+
+    # Page 2: continue with token1, still limit 1
+    page2 = _list_hosts_json(e2e_deployment, limit=1, continue_from=token1)
+    assert len(page2["hosts"]) == 1, f"Expected 1 host on page 2, got {len(page2['hosts'])}"
+    assert page2["hosts"][0] != page1["hosts"][0], f"Page 2 returned the same host as page 1: {page2['hosts'][0]}"
+    token2 = page2.get("continue_from")
+    assert token2, "Expected a pagination token after requesting 2 of 3+ hosts"
+
+    # Page 3: continue with token2, no limit (get the rest)
+    page3 = _list_hosts_json(e2e_deployment, continue_from=token2)
+    assert len(page3["hosts"]) >= 1, f"Expected at least 1 host on page 3, got {len(page3['hosts'])}"
+    seen = {page1["hosts"][0], page2["hosts"][0]}
+    assert page3["hosts"][0] not in seen, (
+        f"Page 3 first host '{page3['hosts'][0]}' was already seen in pages 1-2: {seen}"
+    )
+
+
+def test_host_list_query_filter(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that --query filters hosts by label selector."""
+    e2e_deployment.ensure_deployed()
+
+    all_data = _list_hosts_json(e2e_deployment)
+    all_count = len(all_data["hosts"])
+
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "host", "list", "--json", "--query", "jupyter-deploy/role=components"]
+    )
+    filtered = json.loads(result.stdout)
+    assert len(filtered["hosts"]) >= 2, (
+        f"Expected at least 2 component hosts, got {len(filtered['hosts'])}: {filtered['hosts']}"
+    )
+    assert len(filtered["hosts"]) < all_count, (
+        f"Expected fewer hosts with filter, got {len(filtered['hosts'])} out of {all_count}"
+    )
+
+
+def test_host_list_invalid_continuation_token(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that an invalid continuation token fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "host", "list", "--continue-from", "invalid-token"])
+
+
+def test_host_list_paginate_token_hint(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify the plain-text pagination hint includes the continuation token."""
+    e2e_deployment.ensure_deployed()
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "list", "-n", "1"])
+    output = result.stdout
+
+    assert "--continue-from" in output, f"Expected pagination hint in output:\n{output}"
+    # The hint line should contain a base64-encoded token after --continue-from
+    for line in output.splitlines():
+        if "--continue-from" in line:
+            parts = line.split("--continue-from")
+            assert len(parts) == 2, f"Expected exactly one --continue-from in hint line: {line}"
+            token = parts[1].strip()
+            assert token, f"Expected non-empty token after --continue-from in: {line}"
+            break
+
+
+# ── host status ──────────────────────────────────────────────────────────────
+
+
+def test_host_status_happy_case(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that host status returns a non-empty status for the first node."""
+    e2e_deployment.ensure_deployed()
+
+    data = _list_hosts_json(e2e_deployment)
+    first_host = data["hosts"][0]
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "status", first_host])
+    assert "Host status:" in result.stdout, f"Expected 'Host status:' in output:\n{result.stdout}"
+
+
+def test_host_status_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that host status for a non-existent node fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "host", "status", "i-do-not-exist"])
+
+
+# ── host show ────────────────────────────────────────────────────────────────
+
+
+def test_host_show_happy_case(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that host show returns details with expected keys."""
+    e2e_deployment.ensure_deployed()
+
+    data = _list_hosts_json(e2e_deployment)
+    first_host = data["hosts"][0]
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", first_host])
+    assert result.stdout, f"Expected non-empty output for host show {first_host}"
+
+
+def test_host_show_json(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that host show --json returns valid JSON with expected fields."""
+    e2e_deployment.ensure_deployed()
+
+    data = _list_hosts_json(e2e_deployment)
+    first_host = data["hosts"][0]
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", first_host, "--json"])
+    show_data = json.loads(result.stdout, strict=False)
+    assert "name" in show_data, f"Expected 'name' in JSON response, got: {list(show_data.keys())}"
+    assert "status" in show_data, "Expected 'status' in JSON response"
+    assert "resource" in show_data, "Expected 'resource' in JSON response"
+    assert show_data["name"] == first_host
+
+
+def test_host_show_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that host show for a non-existent node fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "host", "show", "i-do-not-exist"])

--- a/libs/jupyter-deploy/jupyter_deploy/api/aws/sts/eks_token.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/aws/sts/eks_token.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import base64
+
+from botocore.auth import SigV4QueryAuth
+from botocore.awsrequest import AWSRequest
+from botocore.session import Session as BotocoreSession
+
+_TOKEN_PREFIX = "k8s-aws-v1."
+_TOKEN_EXPIRY_SECONDS = 60
+_CLUSTER_ID_HEADER = "x-k8s-aws-id"
+_STS_ACTION = "Action=GetCallerIdentity&Version=2011-06-15"
+
+
+def get_eks_bearer_token(cluster_name: str, region: str) -> str:
+    """Generate an EKS bearer token using a presigned STS GetCallerIdentity URL.
+
+    Uses the default credential chain (env vars, profile, IMDS, etc.).
+    """
+    session = BotocoreSession()
+    credentials = session.get_credentials().get_frozen_credentials()
+
+    endpoint = f"https://sts.{region}.amazonaws.com/?{_STS_ACTION}"
+    request = AWSRequest(method="GET", url=endpoint, headers={_CLUSTER_ID_HEADER: cluster_name})
+
+    signer = SigV4QueryAuth(credentials, "sts", region, expires=_TOKEN_EXPIRY_SECONDS)
+    signer.add_auth(request)
+
+    signed_url: str = request.url  # type: ignore[assignment]
+    token_body = base64.urlsafe_b64encode(signed_url.encode("utf-8")).rstrip(b"=").decode("utf-8")
+    return f"{_TOKEN_PREFIX}{token_body}"

--- a/libs/jupyter-deploy/jupyter_deploy/api/k8s/core.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/k8s/core.py
@@ -1,7 +1,9 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
-from kubernetes.client import CoreV1Api
+from kubernetes.client import ApiClient, AppsV1Api, CoreV1Api
+from kubernetes.stream import stream as k8s_stream
 
 
 class NodeConditionStatus(str, Enum):
@@ -22,6 +24,7 @@ class PodPhase(str, Enum):
 class NodeInfo:
     name: str
     status: NodeConditionStatus
+    resource: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -77,7 +80,8 @@ def list_nodes(
 def get_node(api: CoreV1Api, name: str) -> NodeInfo:
     node = api.read_node(name=name)
     node_name = node.metadata.name if node.metadata else ""
-    return NodeInfo(name=node_name, status=_parse_node_status(node))
+    resource: dict[str, Any] = ApiClient().sanitize_for_serialization(node)
+    return NodeInfo(name=node_name, status=_parse_node_status(node), resource=resource)
 
 
 def list_pods(
@@ -110,3 +114,71 @@ def get_pod(api: CoreV1Api, name: str, namespace: str) -> PodInfo:
     pod = api.read_namespaced_pod(name=name, namespace=namespace)
     pod_name = pod.metadata.name if pod.metadata else ""
     return PodInfo(name=pod_name, phase=_parse_pod_phase(pod))
+
+
+def get_deployment_logs(
+    core_api: CoreV1Api,
+    apps_api: AppsV1Api,
+    name: str,
+    namespace: str,
+    container: str | None = None,
+    tail_lines: int | None = None,
+) -> str:
+    deployment = apps_api.read_namespaced_deployment(name=name, namespace=namespace)
+    match_labels = deployment.spec.selector.match_labels or {}
+    label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
+    if not label_selector:
+        return ""
+
+    pods = core_api.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
+    if not pods.items:
+        return ""
+
+    pod_name = pods.items[0].metadata.name if pods.items[0].metadata else ""
+    if not pod_name:
+        return ""
+
+    kwargs: dict[str, str | int] = {"name": pod_name, "namespace": namespace}
+    if container:
+        kwargs["container"] = container
+    if tail_lines:
+        kwargs["tail_lines"] = tail_lines
+
+    result: str = core_api.read_namespaced_pod_log(**kwargs)
+    return result
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+def exec_pod(
+    api: CoreV1Api,
+    name: str,
+    namespace: str,
+    command: list[str],
+    container: str | None = None,
+) -> ExecResult:
+    kwargs: dict[str, object] = {
+        "name": name,
+        "namespace": namespace,
+        "command": command,
+        "stderr": True,
+        "stdin": False,
+        "stdout": True,
+        "tty": False,
+        "_preload_content": False,
+    }
+    if container:
+        kwargs["container"] = container
+
+    resp = k8s_stream(api.connect_get_namespaced_pod_exec, **kwargs)
+    resp.run_forever(timeout=60)
+
+    stdout = resp.read_stdout() or ""
+    stderr = resp.read_stderr() or ""
+    returncode = resp.returncode if hasattr(resp, "returncode") and resp.returncode is not None else 0
+    return ExecResult(stdout=stdout, stderr=stderr, returncode=returncode)

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -589,6 +589,8 @@ def down(
 
 @runner.app.command()
 def open(
+    server_name: Annotated[str | None, typer.Argument(help="Name of the server to open.")] = None,
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
     project_dir: Annotated[Path | None, typer.Option("--path", "-p", help="Directory of the project to open.")] = None,
 ) -> None:
     """Open the app in your web browser.
@@ -597,6 +599,9 @@ def open(
     or pass --path <project-dir>.
 
     Call <jd config> and <jd up> first.
+
+    For a multi-apps template, open a specific app with: <jd open SERVER_NAME>.
+    Pass --scope <scope>.
     """
     console = Console()
     with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
@@ -606,7 +611,7 @@ def open(
         url_unavailable = False
 
         try:
-            url = handler.open()
+            url = handler.open(name=server_name, scope=scope or None)
             console.print(f"\nOpening app at: {url}", style="green")
         except UrlNotAvailableError as e:
             # URL not available - show helpful message but don't fail (project not deployed)

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -589,7 +589,7 @@ def down(
 
 @runner.app.command()
 def open(
-    server_name: Annotated[str | None, typer.Argument(help="Name of the server to open.")] = None,
+    server_name: Annotated[str | None, typer.Option("--name", help="Name of the server to open.")] = None,
     scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
     project_dir: Annotated[Path | None, typer.Option("--path", "-p", help="Directory of the project to open.")] = None,
 ) -> None:
@@ -600,7 +600,7 @@ def open(
 
     Call <jd config> and <jd up> first.
 
-    For a multi-apps template, open a specific app with: <jd open SERVER_NAME>.
+    For a multi-apps template, open a specific app with: <jd open --name SERVER_NAME>.
     Pass --scope <scope>.
     """
     console = Console()

--- a/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
@@ -38,6 +38,8 @@ from jupyter_deploy.exceptions import (
     ProviderPermissionError,
     ReadConfigurationError,
     ReadManifestError,
+    ResourceNameRequiredError,
+    ResourceNotFoundError,
     SupervisedExecutionError,
     ToolRequiredError,
     UnreachableHostError,
@@ -180,6 +182,16 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         console.print(f":x: {e}", style="bold red")
         console.line()
         console.print(":bulb: To see available logs: [bold cyan]jd history list CMD[/]")
+        raise typer.Exit(code=1) from None
+
+    except ResourceNameRequiredError as e:
+        console.print(f":x: {e}", style="bold red")
+        console.line()
+        console.print(f":bulb: Run [bold cyan]{e.list_command}[/] to see available {e.resource_type}s.")
+        raise typer.Exit(code=1) from None
+
+    except ResourceNotFoundError as e:
+        console.print(f":x: {e}", style="bold red")
         raise typer.Exit(code=1) from None
 
     except (

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -11,13 +12,17 @@ from jupyter_deploy.enum import HostStatusType
 from jupyter_deploy.handlers.resource import host_handler
 
 host_app = typer.Typer(
-    help="Interact with the host machine running your app.",
+    help="Interact with the host machine(s) running your app(s).",
     no_args_is_help=True,
 )
 
 
 @host_app.command()
 def status(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the host to check status for."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project whose host to check status."),
@@ -44,12 +49,16 @@ def status(
             return
 
         with simple_display_manager.spinner("Checking host status..."):
-            result = handler.get_host_status()
+            result = handler.get_host_status(name=name)
             console.print(f"Host status: [bold cyan]{result}[/]")
 
 
 @host_app.command()
 def stop(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the host to stop."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project whose host to stop."),
@@ -66,11 +75,15 @@ def stop(
         handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Stopping host..."):
-            handler.stop_host()
+            handler.stop_host(name=name)
 
 
 @host_app.command()
 def start(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the host to start."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project whose host to start."),
@@ -87,11 +100,15 @@ def start(
         handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Starting host..."):
-            handler.start_host()
+            handler.start_host(name=name)
 
 
 @host_app.command()
 def restart(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the host to restart."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project."),
@@ -108,11 +125,15 @@ def restart(
         handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Restarting host..."):
-            handler.restart_host()
+            handler.restart_host(name=name)
 
 
 @host_app.command()
 def connect(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the host to connect to."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project."),
@@ -129,12 +150,16 @@ def connect(
         handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Connecting to host..."):
-            handler.connect()
+            handler.connect(name=name)
 
 
 @host_app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})
 def exec(
     ctx: typer.Context,
+    name: Annotated[
+        str | None,
+        typer.Option("--name", help="Name of the host on which to execute the command."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project."),
@@ -165,7 +190,7 @@ def exec(
         handler = host_handler.HostHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Executing command..."):
-            stdout, stderr, returncode = handler.exec_command(command_args)
+            stdout, stderr, returncode = handler.exec_command(command_args, name=name)
 
         if stdout:
             console.rule("stdout")
@@ -184,3 +209,79 @@ def exec(
         # However, just in case the instruction runner setup is incorrect, handle it here as well.
         if returncode != 0:
             raise typer.Exit(code=returncode)
+
+
+@host_app.command(name="list")
+def list_hosts(
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project whose hosts to list."),
+    ] = None,
+    query: Annotated[str, typer.Option("--query", help="Filter expression to narrow the list of hosts.")] = "",
+    limit: Annotated[int | None, typer.Option("--limit", "-n", help="Maximum number of hosts to return.")] = None,
+    continue_from: Annotated[
+        str | None,
+        typer.Option("--continue-from", help="Continuation token from a previous list call."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+) -> None:
+    """List the hosts in the project.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = host_handler.HostHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner("Listing hosts..."):
+            result, next_token = handler.list_hosts(query=query, limit=limit, continue_from=continue_from)
+
+        if json_output:
+            data: dict[str, object] = {"hosts": result}
+            if next_token:
+                data["continue_from"] = next_token
+            console.print(json.dumps(data), highlight=False, markup=False, soft_wrap=True)
+            return
+
+        if result:
+            for name in result:
+                console.print(f"[bold cyan]{name}[/]")
+        else:
+            console.print("[bold cyan]None[/]")
+
+        if next_token:
+            console.line()
+            console.print(
+                f":bulb: more hosts are available, use [bold cyan]--continue-from {next_token}[/]", soft_wrap=True
+            )
+
+
+@host_app.command()
+def show(
+    name: Annotated[str, typer.Argument(help="Name of the host to show details for.")],
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+) -> None:
+    """Display detailed information about a host.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = host_handler.HostHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner(f"Getting host details for {name}..."):
+            details = handler.show_host(name=name)
+
+        if json_output:
+            console.print(json.dumps(details), highlight=False, markup=False)
+            return
+
+        console.print_json(json.dumps(details))

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -21,7 +21,7 @@ host_app = typer.Typer(
 def status(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the host to check status for."),
+        typer.Option("--name", help="Name of the host to check status for."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -57,7 +57,7 @@ def status(
 def stop(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the host to stop."),
+        typer.Option("--name", help="Name of the host to stop."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -82,7 +82,7 @@ def stop(
 def start(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the host to start."),
+        typer.Option("--name", help="Name of the host to start."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -107,7 +107,7 @@ def start(
 def restart(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the host to restart."),
+        typer.Option("--name", help="Name of the host to restart."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -132,7 +132,7 @@ def restart(
 def connect(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the host to connect to."),
+        typer.Option("--name", help="Name of the host to connect to."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -260,7 +260,7 @@ def list_hosts(
 
 @host_app.command()
 def show(
-    name: Annotated[str, typer.Argument(help="Name of the host to show details for.")],
+    name: Annotated[str, typer.Option("--name", help="Name of the host to show details for.")],
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project."),

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -20,7 +20,7 @@ servers_app = typer.Typer(
 def status(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the server to check status for."),
+        typer.Option("--name", help="Name of the server to check status for."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -48,7 +48,7 @@ def status(
 def start(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the server to start."),
+        typer.Option("--name", help="Name of the server to start."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -84,7 +84,7 @@ def start(
 def stop(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the server to stop."),
+        typer.Option("--name", help="Name of the server to stop."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -120,7 +120,7 @@ def stop(
 def restart(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the server to restart."),
+        typer.Option("--name", help="Name of the server to restart."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -152,12 +152,12 @@ def restart(
             simple_display_manager.success(f"Restarted the '{service}' service.")
 
 
-@servers_app.command(context_settings={"allow_extra_args": True})
+@servers_app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})
 def logs(
     ctx: typer.Context,
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the server whose logs to display."),
+        typer.Option("--name", help="Name of the server whose logs to display."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -218,12 +218,12 @@ def logs(
             raise typer.Exit(code=returncode)
 
 
-@servers_app.command(context_settings={"allow_extra_args": True})
+@servers_app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})
 def exec(
     ctx: typer.Context,
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the server in which to execute the command."),
+        typer.Option("--name", help="Name of the server in which to execute the command."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -243,9 +243,9 @@ def exec(
 
     Pass the command after '--', for example:
 
-    <jd server exec SERVER_NAME -- pwd>
+    <jd server exec -- pwd>
 
-    <jd server exec SERVER_NAME -s SERVICE -- "df -h">
+    <jd server exec -s SERVICE -- "df -h">
 
     Note: the commands you can execute depend on the service;
     distroless images in particular expose very limited commands.
@@ -256,7 +256,7 @@ def exec(
     if not command_args:
         console = Console()
         console.print(":x: No command provided. Pass a command after '--'", style="red")
-        console.print("Example: jd server exec SERVER_NAME -- pwd", style="red")
+        console.print("Example: jd server exec -- pwd", style="red")
         raise typer.Exit(code=1)
 
     console = Console()
@@ -292,7 +292,7 @@ def exec(
 def connect(
     name: Annotated[
         str | None,
-        typer.Argument(help="Name of the server to connect to."),
+        typer.Option("--name", help="Name of the server to connect to."),
     ] = None,
     project_dir: Annotated[
         Path | None,
@@ -375,7 +375,7 @@ def list_servers(
 
 @servers_app.command()
 def show(
-    name: Annotated[str, typer.Argument(help="Name of the server to show details for.")],
+    name: Annotated[str, typer.Option("--name", help="Name of the server to show details for.")],
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project."),

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -10,17 +11,22 @@ from jupyter_deploy.cli.simple_display import SimpleDisplayManager
 from jupyter_deploy.handlers.resource import server_handler
 
 servers_app = typer.Typer(
-    help="Interact with the services running your app.",
+    help="Interact with the server(s) running your app(s).",
     no_args_is_help=True,
 )
 
 
 @servers_app.command()
 def status(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the server to check status for."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project whose server to send a health check."),
     ] = None,
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
 ) -> None:
     """Sends a health check to the services.
 
@@ -33,13 +39,17 @@ def status(
         handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Checking server status..."):
-            server_status = handler.get_server_status()
+            server_status = handler.get_server_status(name=name, scope=scope or None)
 
         console.print(f"Server status: [bold cyan]{server_status}[/]")
 
 
 @servers_app.command()
 def start(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the server to start."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project whose server to start."),
@@ -47,6 +57,7 @@ def start(
     service: Annotated[
         str, typer.Option("--service", "-s", help="Service to start ('all', 'jupyter', or other available services).")
     ] = "all",
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
 ) -> None:
     """Start the services.
 
@@ -61,7 +72,7 @@ def start(
         handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Starting server..."):
-            handler.start_server(service)
+            handler.start_server(service, name=name, scope=scope or None)
 
         if service == "all":
             simple_display_manager.success("Started all services.")
@@ -71,6 +82,10 @@ def start(
 
 @servers_app.command()
 def stop(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the server to stop."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project whose server to stop."),
@@ -78,6 +93,7 @@ def stop(
     service: Annotated[
         str, typer.Option("--service", "-s", help="Service to stop ('all', 'jupyter', or other available services).")
     ] = "all",
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
 ) -> None:
     """Stop the services.
 
@@ -92,7 +108,7 @@ def stop(
         handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Stopping server..."):
-            handler.stop_server(service)
+            handler.stop_server(service, name=name, scope=scope or None)
 
         if service == "all":
             simple_display_manager.success("Stopped all services.")
@@ -102,6 +118,10 @@ def stop(
 
 @servers_app.command()
 def restart(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the server to restart."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project whose server to restart."),
@@ -109,6 +129,7 @@ def restart(
     service: Annotated[
         str, typer.Option("--service", "-s", help="Service to restart ('all', 'jupyter', or other available services).")
     ] = "all",
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
 ) -> None:
     """Restart the services.
 
@@ -123,7 +144,7 @@ def restart(
         handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Restarting server..."):
-            handler.restart_server(service)
+            handler.restart_server(service, name=name, scope=scope or None)
 
         if service == "all":
             simple_display_manager.success("Restarted all services.")
@@ -131,9 +152,13 @@ def restart(
             simple_display_manager.success(f"Restarted the '{service}' service.")
 
 
-@servers_app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})
+@servers_app.command(context_settings={"allow_extra_args": True})
 def logs(
     ctx: typer.Context,
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the server whose logs to display."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project whose server logs to display."),
@@ -141,6 +166,7 @@ def logs(
     service: Annotated[
         str, typer.Option("--service", "-s", help="Name of the service whose logs to display.")
     ] = "default",
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
 ) -> None:
     """Print the logs of the service to terminal.
 
@@ -167,7 +193,9 @@ def logs(
         handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Fetching logs..."):
-            logs, err_logs, returncode = handler.get_server_logs(service=service, extra=extra)
+            logs, err_logs, returncode = handler.get_server_logs(
+                service=service, extra=extra, name=name, scope=scope or None
+            )
 
         if logs:
             console.rule("stdout")
@@ -190,9 +218,13 @@ def logs(
             raise typer.Exit(code=returncode)
 
 
-@servers_app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})
+@servers_app.command(context_settings={"allow_extra_args": True})
 def exec(
     ctx: typer.Context,
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the server in which to execute the command."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project."),
@@ -200,6 +232,7 @@ def exec(
     service: Annotated[
         str, typer.Option("--service", "-s", help="Name of the service in which to execute the command.")
     ] = "default",
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
 ) -> None:
     """Execute a non-interactive command inside a service container.
 
@@ -210,9 +243,9 @@ def exec(
 
     Pass the command after '--', for example:
 
-    <jd server exec -s SERVICE -- pwd>
+    <jd server exec SERVER_NAME -- pwd>
 
-    <jd server exec -s SERVICE -- "df -h">
+    <jd server exec SERVER_NAME -s SERVICE -- "df -h">
 
     Note: the commands you can execute depend on the service;
     distroless images in particular expose very limited commands.
@@ -223,7 +256,7 @@ def exec(
     if not command_args:
         console = Console()
         console.print(":x: No command provided. Pass a command after '--'", style="red")
-        console.print("Example: jd server exec -s SERVICE -- pwd", style="red")
+        console.print("Example: jd server exec SERVER_NAME -- pwd", style="red")
         raise typer.Exit(code=1)
 
     console = Console()
@@ -232,7 +265,9 @@ def exec(
         handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Executing command..."):
-            stdout, stderr, returncode = handler.exec_command(service=service, command_args=command_args)
+            stdout, stderr, returncode = handler.exec_command(
+                service=service, command_args=command_args, name=name, scope=scope or None
+            )
 
         if stdout:
             console.rule("stdout")
@@ -255,11 +290,16 @@ def exec(
 
 @servers_app.command()
 def connect(
+    name: Annotated[
+        str | None,
+        typer.Argument(help="Name of the server to connect to."),
+    ] = None,
     project_dir: Annotated[
         Path | None,
         typer.Option("--path", "-p", help="Directory of the project."),
     ] = None,
     service: Annotated[str, typer.Option("--service", "-s", help="Name of the service to connect to.")] = "default",
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
 ) -> None:
     """Start an interactive shell session inside a service container.
 
@@ -283,4 +323,81 @@ def connect(
         handler = server_handler.ServerHandler(display_manager=simple_display_manager)
 
         with simple_display_manager.spinner("Connecting to service..."):
-            handler.connect(service=service)
+            handler.connect(service=service, name=name, scope=scope or None)
+
+
+@servers_app.command(name="list")
+def list_servers(
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project whose servers to list."),
+    ] = None,
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group to list servers from.")] = "",
+    limit: Annotated[int | None, typer.Option("--limit", "-n", help="Maximum number of servers to return.")] = None,
+    continue_from: Annotated[
+        str | None,
+        typer.Option("--continue-from", help="Continuation token from a previous list call."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+) -> None:
+    """List servers in the project.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner("Listing servers..."):
+            result, next_token = handler.list_servers(scope=scope or None, limit=limit, continue_from=continue_from)
+
+        if json_output:
+            data: dict[str, object] = {"servers": result}
+            if next_token:
+                data["continue_from"] = next_token
+            console.print(json.dumps(data), highlight=False, markup=False, soft_wrap=True)
+            return
+
+        if result:
+            for name in result:
+                console.print(f"[bold cyan]{name}[/]")
+        else:
+            console.print("[bold cyan]None[/]")
+
+        if next_token:
+            console.line()
+            console.print(
+                f":bulb: more servers are available, use [bold cyan]--continue-from {next_token}[/]", soft_wrap=True
+            )
+
+
+@servers_app.command()
+def show(
+    name: Annotated[str, typer.Argument(help="Name of the server to show details for.")],
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+    scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+) -> None:
+    """Display detailed information about a server.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = server_handler.ServerHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner(f"Getting server details for {name}..."):
+            details = handler.show_server(name=name, scope=scope or None)
+
+        if json_output:
+            console.print(json.dumps(details), highlight=False, markup=False)
+            return
+
+        console.print_json(json.dumps(details))

--- a/libs/jupyter-deploy/jupyter_deploy/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/enum.py
@@ -203,6 +203,7 @@ class ProviderType(str, Enum):
     """Cloud provider types."""
 
     AWS = "AWS"
+    K8S = "Kubernetes"
 
     @classmethod
     def from_string(cls, value: str) -> "ProviderType":

--- a/libs/jupyter-deploy/jupyter_deploy/exceptions.py
+++ b/libs/jupyter-deploy/jupyter_deploy/exceptions.py
@@ -319,6 +319,44 @@ class HostCommandInstructionError(InstructionError, RuntimeError):
         super().__init__(message)
 
 
+class ResourceNameRequiredError(JupyterDeployError, ValueError):
+    """Raised when a resource name is required but not provided.
+
+    Attributes:
+        resource_type: The type of resource (e.g., 'host', 'server')
+        list_command: The CLI command to list available resources
+    """
+
+    def __init__(self, resource_type: str, list_command: str) -> None:
+        self.resource_type = resource_type
+        self.list_command = list_command
+        super().__init__(
+            f"This template manages multiple {resource_type}s. "
+            f"Specify a name — use {list_command} to see available {resource_type}s."
+        )
+
+
+class ResourceNotFoundError(InstructionError, RuntimeError):
+    """Raised when a provider resource is not found (e.g., node, pod, deployment).
+
+    Attributes:
+        resource_kind: The kind of resource (e.g., 'node', 'pod', 'workspace')
+        resource_name: The name that was looked up
+        original_message: Original error message from the provider SDK
+        scope: Optional namespace or scope where the resource was looked up
+    """
+
+    def __init__(self, resource_kind: str, resource_name: str, original_message: str, scope: str | None = None) -> None:
+        self.resource_kind = resource_kind
+        self.resource_name = resource_name
+        self.original_message = original_message
+        self.scope = scope
+        msg = f"{resource_kind} '{resource_name}' not found"
+        if scope:
+            msg += f" in '{scope}'"
+        super().__init__(msg)
+
+
 class InstructionNotFoundError(InstructionError, RuntimeError):
     """Raised when an instruction cannot be found or is not implemented."""
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/open_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/open_handler.py
@@ -1,11 +1,15 @@
 import webbrowser
+from typing import Any
 
 from jupyter_deploy.engine.engine_open import EngineOpenHandler
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
 from jupyter_deploy.engine.supervised_execution import NullDisplay
-from jupyter_deploy.engine.terraform import tf_open
-from jupyter_deploy.exceptions import OpenWebBrowserError, UrlNotSecureError
+from jupyter_deploy.engine.terraform import tf_open, tf_variables
+from jupyter_deploy.exceptions import OpenWebBrowserError, UrlNotAvailableError, UrlNotSecureError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
+from jupyter_deploy.provider import manifest_command_runner as cmd_runner
+from jupyter_deploy.provider.resolved_clidefs import ResolvedCliParameter, StrResolvedCliParameter
 
 
 class OpenHandler(BaseProjectHandler):
@@ -20,8 +24,25 @@ class OpenHandler(BaseProjectHandler):
                 project_path=self.project_path,
                 project_manifest=self.project_manifest,
             )
+            self._variable_handler = tf_variables.TerraformVariablesHandler(
+                project_path=self.project_path,
+                project_manifest=self.project_manifest,
+                display_manager=self.display_manager,
+            )
         else:
             raise NotImplementedError(f"OpenHandler implementation not found for engine: {self.engine}")
+
+    def _resolve_scope(self, scope: str | None) -> str:
+        output_handler = self._handler.output_handler
+        if scope:
+            return scope
+        try:
+            scope_def = output_handler.get_declared_output_def("server_default_scope", StrTemplateOutputDefinition)
+            if scope_def.value:
+                return scope_def.value
+        except (NotImplementedError, KeyError, ValueError):
+            pass
+        return "default"
 
     def get_url(self) -> str:
         """Return the URL to access the Jupyter app.
@@ -31,10 +52,49 @@ class OpenHandler(BaseProjectHandler):
         """
         return self._handler.get_url()
 
-    def open(self) -> str:
-        """Open the application with the correct protocol.
+    def get_server_url(self, name: str, scope: str | None = None) -> str:
+        """Resolve and return the URL for a specific server.
 
-        Currently only supports webbrowser protocol.
+        Runs the open.server manifest command which fetches the server resource
+        and extracts the access URL from it.
+
+        Raises:
+            CommandNotImplementedError: If open.server is not in the manifest
+            ResourceNotFoundError: If the server does not exist
+            UrlNotAvailableError: If the server has no access URL
+        """
+        resolved_scope = self._resolve_scope(scope)
+        command = self.project_manifest.get_command("open.server")
+        output_handler = self._handler.output_handler
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=output_handler,
+            variable_handler=self._variable_handler,
+        )
+        cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {
+            "name": StrResolvedCliParameter(parameter_name="name", value=name),
+            "scope": StrResolvedCliParameter(parameter_name="scope", value=resolved_scope),
+        }
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+
+        try:
+            url = runner.get_result_value(command, "open.server.url", str)
+        except KeyError as e:
+            raise UrlNotAvailableError(
+                f"Could not resolve URL for server '{name}' in scope '{resolved_scope}'. Is the server running?"
+            ) from e
+        if not url:
+            raise UrlNotAvailableError(
+                f"Could not resolve URL for server '{name}' in scope '{resolved_scope}'. Is the server running?"
+            )
+
+        return url
+
+    def open(self, name: str | None = None, scope: str | None = None) -> str:
+        """Open the application or a specific server in the browser.
+
+        When name is provided, resolves the server URL via the open.server
+        manifest command. Otherwise falls back to the project open_url output.
 
         Returns:
             str: The URL that was opened
@@ -43,8 +103,10 @@ class OpenHandler(BaseProjectHandler):
             UrlNotAvailableError: If URL cannot be retrieved or is empty
             UrlNotSecureError: If URL is not HTTPS
             OpenWebBrowserError: If opening URL in browser fails
+            CommandNotImplementedError: If name given but open.server not in manifest
+            ResourceNotFoundError: If the named server does not exist
         """
-        url = self.get_url()
+        url = self.get_url() if name is None else self.get_server_url(name, scope)
 
         if not url.startswith("https://"):
             raise UrlNotSecureError("Insecure URL detected. Only HTTPS URLs are allowed for security reasons.", url)

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
@@ -1,11 +1,17 @@
+from typing import Any
+
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
+from jupyter_deploy.exceptions import ResourceNameRequiredError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
+from jupyter_deploy.handlers.resource.resource_utils import collect_results
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
 from jupyter_deploy.provider.resolved_clidefs import (
     ListStrResolvedCliParameter,
+    ResolvedCliParameter,
+    StrResolvedCliParameter,
 )
 
 
@@ -30,52 +36,99 @@ class HostHandler(BaseProjectHandler):
         else:
             raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
 
-    def get_host_status(self) -> str:
+    def list_hosts(
+        self, query: str, limit: int | None = None, continue_from: str | None = None
+    ) -> tuple[list[str], str | None]:
+        """Returns a list of host names and an optional continuation token."""
+        command = self.project_manifest.get_command("host.list")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {
+            "query": StrResolvedCliParameter(parameter_name="query", value=query),
+            "limit": StrResolvedCliParameter(parameter_name="limit", value=str(limit) if limit is not None else ""),
+            "continue_from": StrResolvedCliParameter(parameter_name="continue_from", value=continue_from or ""),
+        }
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+        names = runner.get_result_value(command, "host.list", list)
+        next_token = runner.get_result_value_with_fallback(command, "host.list.next_token", str, "") or None
+        return names, next_token
+
+    def _require_name(self, name: str | None) -> None:
+        if name is None and self.project_manifest.multi_host:
+            raise ResourceNameRequiredError("host", "jd host list")
+
+    def get_host_status(self, name: str | None = None) -> str:
         """Returns the status of the host machine."""
+        self._require_name(name)
         command = self.project_manifest.get_command("host.status")
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(command, cli_paramdefs={})
+        cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {}
+        if name is not None:
+            cli_paramdefs["name"] = StrResolvedCliParameter(parameter_name="name", value=name)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
         return runner.get_result_value(command, "host.status", str)
 
-    def stop_host(self) -> None:
+    def show_host(self, name: str) -> dict[str, Any]:
+        """Returns detailed information about a host."""
+        command = self.project_manifest.get_command("host.show")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        runner.run_command_sequence(
+            command,
+            cli_paramdefs={
+                "name": StrResolvedCliParameter(parameter_name="name", value=name),
+            },
+        )
+        return collect_results(runner, command)
+
+    def _build_cli_paramdefs(self, name: str | None = None) -> dict[str, ResolvedCliParameter[Any]]:
+        cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {}
+        if name is not None:
+            cli_paramdefs["name"] = StrResolvedCliParameter(parameter_name="name", value=name)
+        return cli_paramdefs
+
+    def stop_host(self, name: str | None = None) -> None:
         """Stop the host machine."""
+        self._require_name(name)
         command = self.project_manifest.get_command("host.stop")
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(command, cli_paramdefs={})
+        runner.run_command_sequence(command, cli_paramdefs=self._build_cli_paramdefs(name=name))
 
-    def start_host(self) -> None:
+    def start_host(self, name: str | None = None) -> None:
         """Start the host machine."""
+        self._require_name(name)
         command = self.project_manifest.get_command("host.start")
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={},
-        )
+        runner.run_command_sequence(command, cli_paramdefs=self._build_cli_paramdefs(name=name))
 
-    def restart_host(self) -> None:
+    def restart_host(self, name: str | None = None) -> None:
         """Restart the host machine."""
+        self._require_name(name)
         command = self.project_manifest.get_command("host.restart")
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={},
-        )
+        runner.run_command_sequence(command, cli_paramdefs=self._build_cli_paramdefs(name=name))
 
     def get_connection_status(self) -> str:
         """Returns the Session Manager connection status of the host."""
@@ -88,35 +141,30 @@ class HostHandler(BaseProjectHandler):
         runner.run_command_sequence(command, cli_paramdefs={})
         return runner.get_result_value(command, "host.status-for-connection", str)
 
-    def connect(self) -> None:
+    def connect(self, name: str | None = None) -> None:
         """Start an SSH-style connection to the host."""
+        self._require_name(name)
         command = self.project_manifest.get_command("host.connect")
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={},
-        )
+        runner.run_command_sequence(command, cli_paramdefs=self._build_cli_paramdefs(name=name))
 
-    def exec_command(self, command_args: list[str]) -> tuple[str, str, int]:
+    def exec_command(self, command_args: list[str], name: str | None = None) -> tuple[str, str, int]:
         """Execute a command on the host, return the stdout, stderr, and exit code."""
+        self._require_name(name)
         command = self.project_manifest.get_command("host.exec")
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        # Join command arguments into a single command string for AWS-RunShellScript
         command_string = " ".join(command_args)
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={
-                "commands": ListStrResolvedCliParameter(parameter_name="commands", value=[command_string]),
-            },
-        )
+        cli_paramdefs = self._build_cli_paramdefs(name=name)
+        cli_paramdefs["commands"] = ListStrResolvedCliParameter(parameter_name="commands", value=[command_string])
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
         stdout = runner.get_result_value(command, "host.exec.stdout", str)
         stderr = runner.get_result_value(command, "host.exec.stderr", str)
         returncode = runner.get_result_value_with_fallback(command, "host.exec.returncode", int, 0)

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/resource_utils.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/resource_utils.py
@@ -1,0 +1,76 @@
+import contextlib
+import json
+import re
+from typing import Any
+
+from jupyter_deploy.manifest import JupyterDeployStatusRuleV1
+from jupyter_deploy.provider import manifest_command_runner as cmd_runner
+
+_ARRAY_FILTER_RE = re.compile(r"^([^\[]+)\[([^=]+)=([^\]]+)\]$")
+
+
+def resolve_path(resource: dict[str, Any], path: str) -> str | None:
+    """Resolve a dotted path against a resource dict.
+
+    Supports two segment forms:
+      - Simple key: .spec.desiredStatus
+      - Array filter: .status.conditions[type=Degraded].status
+    """
+    segments = [s for s in path.split(".") if s]
+    current: Any = resource
+    for segment in segments:
+        if not isinstance(current, dict):
+            return None
+        match = _ARRAY_FILTER_RE.match(segment)
+        if match:
+            array_key, filter_key, filter_val = match.group(1), match.group(2), match.group(3)
+            items = current.get(array_key)
+            if not isinstance(items, list):
+                return None
+            current = next(
+                (item for item in items if isinstance(item, dict) and item.get(filter_key) == filter_val), None
+            )
+            if current is None:
+                return None
+        else:
+            current = current.get(segment)
+            if current is None:
+                return None
+    if isinstance(current, str):
+        return current
+    return None
+
+
+def evaluate_status_rules(resource_json: str, rules: list[JupyterDeployStatusRuleV1]) -> str:
+    try:
+        resource = json.loads(resource_json)
+    except (json.JSONDecodeError, TypeError):
+        return "Unknown"
+
+    if not isinstance(resource, dict):
+        return "Unknown"
+
+    for rule in rules:
+        if all(resolve_path(resource, m.path) == m.equals for m in rule.all):
+            return rule.display
+
+    return "Unknown"
+
+
+def collect_results(
+    runner: cmd_runner.ManifestCommandRunner,
+    command: cmd_runner.JupyterDeployCommandV1,
+) -> dict[str, Any]:
+    """Collect all results from a command, stripping the command prefix from keys.
+
+    JSON string values are parsed into dicts/lists so callers get structured data.
+    """
+    prefix = f"{command.cmd}."
+    result: dict[str, Any] = {}
+    for result_def in command.results or []:
+        key = result_def.result_name.removeprefix(prefix)
+        value: Any = runner.get_result_value_with_fallback(command, result_def.result_name, str, "")
+        with contextlib.suppress(json.JSONDecodeError, TypeError):
+            value = json.loads(value)
+        result[key] = value
+    return result

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
@@ -1,10 +1,15 @@
+from typing import Any
+
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
+from jupyter_deploy.exceptions import ResourceNameRequiredError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
+from jupyter_deploy.handlers.resource.resource_utils import collect_results, evaluate_status_rules
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
-from jupyter_deploy.provider.resolved_clidefs import StrResolvedCliParameter
+from jupyter_deploy.provider.resolved_clidefs import ResolvedCliParameter, StrResolvedCliParameter
 
 
 class ServerHandler(BaseProjectHandler):
@@ -28,128 +33,191 @@ class ServerHandler(BaseProjectHandler):
         else:
             raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
 
-    def get_server_status(self) -> str:
+    def _resolve_scope(self, scope: str | None) -> str:
+        """Return the scope, falling back to the manifest-declared default."""
+        if scope:
+            return scope
+        try:
+            scope_def = self._output_handler.get_declared_output_def(
+                "server_default_scope", StrTemplateOutputDefinition
+            )
+            if scope_def.value:
+                return scope_def.value
+        except (NotImplementedError, KeyError, ValueError):
+            pass
+        return "default"
+
+    def list_servers(
+        self, scope: str | None = None, limit: int | None = None, continue_from: str | None = None
+    ) -> tuple[list[str], str | None]:
+        """Returns a list of server names and an optional continuation token."""
+        resolved_scope = self._resolve_scope(scope)
+        command = self.project_manifest.get_command("server.list")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {
+            "scope": StrResolvedCliParameter(parameter_name="scope", value=resolved_scope),
+            "limit": StrResolvedCliParameter(parameter_name="limit", value=str(limit) if limit is not None else ""),
+            "continue_from": StrResolvedCliParameter(parameter_name="continue_from", value=continue_from or ""),
+        }
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+        names = runner.get_result_value(command, "server.list", list)
+        next_token = runner.get_result_value_with_fallback(command, "server.list.next_token", str, "") or None
+        return names, next_token
+
+    def _require_name(self, name: str | None) -> None:
+        if name is None and self.project_manifest.multi_server:
+            raise ResourceNameRequiredError("server", "jd server list")
+
+    def get_server_status(self, name: str | None = None, scope: str | None = None) -> str:
         """Sends an health check to the jupyter server app, return status."""
+        self._require_name(name)
+        resolved_scope = self._resolve_scope(scope)
         command = self.project_manifest.get_command("server.status")
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(command, cli_paramdefs={})
-        return runner.get_result_value(command, "server.status", str)
+        cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {
+            "scope": StrResolvedCliParameter(parameter_name="scope", value=resolved_scope),
+        }
+        if name is not None:
+            cli_paramdefs["name"] = StrResolvedCliParameter(parameter_name="name", value=name)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
 
-    def start_server(self, service: str) -> None:
-        """Start the jupyter server and optionally all its sidecars."""
+        rules = self.project_manifest.server_status_rules
+        if not rules:
+            return runner.get_result_value(command, "server.status", str)
+
+        resource_json = runner.get_result_value(command, "server.status.resource", str)
+        return evaluate_status_rules(resource_json, rules)
+
+    def show_server(self, name: str, scope: str | None = None) -> dict[str, Any]:
+        """Returns detailed information about a server."""
+        resolved_scope = self._resolve_scope(scope)
+        command = self.project_manifest.get_command("server.show")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        runner.run_command_sequence(
+            command,
+            cli_paramdefs={
+                "name": StrResolvedCliParameter(parameter_name="name", value=name),
+                "scope": StrResolvedCliParameter(parameter_name="scope", value=resolved_scope),
+            },
+        )
+        return collect_results(runner, command)
+
+    def _build_cli_paramdefs(
+        self,
+        service: str | None = None,
+        allow_all_services: bool = True,
+        name: str | None = None,
+        scope: str | None = None,
+    ) -> dict[str, ResolvedCliParameter[Any]]:
+        resolved_scope = self._resolve_scope(scope)
+        cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {
+            "scope": StrResolvedCliParameter(parameter_name="scope", value=resolved_scope),
+        }
+        if service is not None:
+            validated_service = self.project_manifest.get_validated_service(service, allow_all=allow_all_services)
+            cli_paramdefs["service"] = StrResolvedCliParameter(parameter_name="service", value=validated_service)
+        if name is not None:
+            cli_paramdefs["name"] = StrResolvedCliParameter(parameter_name="name", value=name)
+        return cli_paramdefs
+
+    def start_server(self, service: str, name: str | None = None, scope: str | None = None) -> None:
+        """Start the server or workspace."""
+        self._require_name(name)
         command = self.project_manifest.get_command("server.start")
-        validated_service = self.project_manifest.get_validated_service(service, allow_all=True)
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={
-                "action": StrResolvedCliParameter(parameter_name="action", value="start"),
-                "service": StrResolvedCliParameter(parameter_name="service", value=validated_service),
-            },
-        )
+        cli_paramdefs = self._build_cli_paramdefs(service=service, name=name, scope=scope)
+        cli_paramdefs["action"] = StrResolvedCliParameter(parameter_name="action", value="start")
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
 
-    def stop_server(self, service: str) -> None:
-        """Stop the jupyter server and optionally all its sidecars."""
+    def stop_server(self, service: str, name: str | None = None, scope: str | None = None) -> None:
+        """Stop the server or workspace."""
+        self._require_name(name)
         command = self.project_manifest.get_command("server.stop")
-        validated_service = self.project_manifest.get_validated_service(service, allow_all=True)
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={
-                "action": StrResolvedCliParameter(parameter_name="action", value="stop"),
-                "service": StrResolvedCliParameter(parameter_name="service", value=validated_service),
-            },
-        )
+        cli_paramdefs = self._build_cli_paramdefs(service=service, name=name, scope=scope)
+        cli_paramdefs["action"] = StrResolvedCliParameter(parameter_name="action", value="stop")
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
 
-    def restart_server(self, service: str) -> None:
-        """Restart the jupyter-server and optionally all its sidecars."""
+    def restart_server(self, service: str, name: str | None = None, scope: str | None = None) -> None:
+        """Restart the server or workspace."""
+        self._require_name(name)
         command = self.project_manifest.get_command("server.restart")
-        validated_service = self.project_manifest.get_validated_service(service, allow_all=True)
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={
-                "action": StrResolvedCliParameter(parameter_name="action", value="restart"),
-                "service": StrResolvedCliParameter(parameter_name="service", value=validated_service),
-            },
-        )
+        cli_paramdefs = self._build_cli_paramdefs(service=service, name=name, scope=scope)
+        cli_paramdefs["action"] = StrResolvedCliParameter(parameter_name="action", value="restart")
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
 
-    def get_server_logs(self, service: str, extra: list[str]) -> tuple[str, str, int]:
-        """Sends a logs command to the host for the service, return the stdout, stderr, and exit code."""
+    def get_server_logs(
+        self, service: str, extra: list[str], name: str | None = None, scope: str | None = None
+    ) -> tuple[str, str, int]:
+        """Return the stdout, stderr, and exit code from the server logs command."""
+        self._require_name(name)
         command = self.project_manifest.get_command("server.logs")
-        validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={
-                "service": StrResolvedCliParameter(parameter_name="service", value=validated_service),
-                "extra": StrResolvedCliParameter(parameter_name="extra", value=" ".join(extra)),
-            },
-        )
+        cli_paramdefs = self._build_cli_paramdefs(service=service, allow_all_services=False, name=name, scope=scope)
+        cli_paramdefs["extra"] = StrResolvedCliParameter(parameter_name="extra", value=" ".join(extra))
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
         stdout = runner.get_result_value(command, "server.logs", str)
         stderr = runner.get_result_value(command, "server.errors", str)
         returncode = runner.get_result_value_with_fallback(command, "server.logs.returncode", int, 0)
         return stdout, stderr, returncode
 
-    def exec_command(self, service: str, command_args: list[str]) -> tuple[str, str, int]:
+    def exec_command(
+        self, service: str, command_args: list[str], name: str | None = None, scope: str | None = None
+    ) -> tuple[str, str, int]:
         """Execute a command inside a service container, return the stdout, stderr, and exit code."""
+        self._require_name(name)
         command = self.project_manifest.get_command("server.exec")
-        validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-
-        # Join command arguments into a single command string for docker exec
         command_string = " ".join(command_args)
-
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={
-                "service": StrResolvedCliParameter(parameter_name="service", value=validated_service),
-                "commands": StrResolvedCliParameter(parameter_name="commands", value=command_string),
-            },
-        )
+        cli_paramdefs = self._build_cli_paramdefs(service=service, allow_all_services=False, name=name, scope=scope)
+        cli_paramdefs["commands"] = StrResolvedCliParameter(parameter_name="commands", value=command_string)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
         stdout = runner.get_result_value(command, "server.exec.stdout", str)
         stderr = runner.get_result_value(command, "server.exec.stderr", str)
         returncode = runner.get_result_value_with_fallback(command, "server.exec.returncode", int, 0)
         return stdout, stderr, returncode
 
-    def connect(self, service: str) -> None:
+    def connect(self, service: str, name: str | None = None, scope: str | None = None) -> None:
         """Start an interactive shell session inside a service container."""
+        self._require_name(name)
         command = self.project_manifest.get_command("server.connect")
-        validated_service = self.project_manifest.get_validated_service(service, allow_all=False)
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
             output_handler=self._output_handler,
             variable_handler=self._variable_handler,
         )
-
-        runner.run_command_sequence(
-            command,
-            cli_paramdefs={
-                "service": StrResolvedCliParameter(parameter_name="service", value=validated_service),
-            },
-        )
+        cli_paramdefs = self._build_cli_paramdefs(service=service, allow_all_services=False, name=name, scope=scope)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)

--- a/libs/jupyter-deploy/jupyter_deploy/manifest.py
+++ b/libs/jupyter-deploy/jupyter_deploy/manifest.py
@@ -60,6 +60,7 @@ class JupyterDeployInstructionArgumentV1(BaseModel):
     api_attribute: str = Field(alias="api-attribute")
     source: str
     source_key: str = Field(alias="source-key")
+    extract: str | None = None
 
     def get_source_type(self) -> InstructionArgumentSource:
         """Return the instruction argument source type."""
@@ -72,6 +73,7 @@ class JupyterDeployInstructionResultV1(BaseModel):
     source: str
     source_key: str = Field(alias="source-key")
     transform: str | None = None
+    extract: str | None = None
 
     def get_source_type(self) -> ResultSource:
         """Return the instruction argument source type."""
@@ -234,6 +236,18 @@ class JupyterDeploySupervisedExecutionV1(BaseModel):
     down: dict[str, JupyterDeploySupervisedCommandExecutionV1] | None = None
 
 
+class JupyterDeployStatusRuleMatchV1(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    path: str
+    equals: str
+
+
+class JupyterDeployStatusRuleV1(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    display: str
+    all: list[JupyterDeployStatusRuleMatchV1]
+
+
 class JupyterDeployProjectStoreV1(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
     store_type: str = Field(alias="store-type")
@@ -257,8 +271,11 @@ class JupyterDeployManifestV1(BaseModel):
     requirements: list[JupyterDeployRequirementV1] | None = None
     values: list[JupyterDeployValueV1] | None = None
     services: list[str] | None = None
+    multi_host: bool = Field(alias="multi-host", default=False)
+    multi_server: bool = Field(alias="multi-server", default=False)
     commands: list[JupyterDeployCommandV1] | None = None
     secrets: list[JupyterDeploySecretV1] | None = None
+    server_status_rules: list[JupyterDeployStatusRuleV1] | None = Field(alias="server-status-rules", default=None)
     supervised_execution: JupyterDeploySupervisedExecutionV1 | None = Field(alias="supervised-execution", default=None)
     project_store: JupyterDeployProjectStoreV1 | None = Field(alias="project-store", default=None)
 

--- a/libs/jupyter-deploy/jupyter_deploy/provider/instruction_runner_factory.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/instruction_runner_factory.py
@@ -38,14 +38,38 @@ class InstructionRunnerFactory:
             return runner
 
         if api_group == ApiGroup.K8S:
-            kubeconfig_def = outputs_handler.get_declared_output_def("kubeconfig_path", StrTemplateOutputDefinition)
+            cluster_endpoint: str | None = None
+            cluster_ca_data: str | None = None
+            cluster_name: str | None = None
+            region: str | None = None
+            kubeconfig_path: str | None = None
+
+            try:
+                endpoint_def = outputs_handler.get_declared_output_def("cluster_endpoint", StrTemplateOutputDefinition)
+                ca_def = outputs_handler.get_declared_output_def("cluster_ca_certificate", StrTemplateOutputDefinition)
+                name_def = outputs_handler.get_declared_output_def("cluster_name", StrTemplateOutputDefinition)
+                region_def = outputs_handler.get_declared_output_def("aws_region", StrTemplateOutputDefinition)
+                cluster_endpoint = endpoint_def.value
+                cluster_ca_data = ca_def.value
+                cluster_name = name_def.value
+                region = region_def.value
+            except (NotImplementedError, KeyError, ValueError):
+                pass
+
+            if not all([cluster_endpoint, cluster_ca_data, cluster_name, region]):
+                kubeconfig_def = outputs_handler.get_declared_output_def("kubeconfig_path", StrTemplateOutputDefinition)
+                kubeconfig_path = kubeconfig_def.value
 
             # do NOT move import to top level
             from jupyter_deploy.provider.k8s import k8s_runner
 
             runner = k8s_runner.K8sApiRunner(
                 display_manager=display_manager,
-                kubeconfig_path=kubeconfig_def.value,
+                kubeconfig_path=kubeconfig_path,
+                cluster_endpoint=cluster_endpoint,
+                cluster_ca_data=cluster_ca_data,
+                cluster_name=cluster_name,
+                region=region,
             )
             InstructionRunnerFactory._api_group_runner_map[api_group] = runner
             return runner

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_client_factory.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_client_factory.py
@@ -1,10 +1,46 @@
+from __future__ import annotations
+
+import base64
+import tempfile
+
 from kubernetes import client, config
 
 
 class K8sClientFactory:
-    """Build Kubernetes API clients from kubeconfig."""
+    """Build Kubernetes API clients from kubeconfig or in-memory config."""
 
     @staticmethod
     def from_kubeconfig(kubeconfig_path: str | None = None) -> client.ApiClient:
         api_client: client.ApiClient = config.new_client_from_config(config_file=kubeconfig_path)
         return api_client
+
+    @staticmethod
+    def from_eks_cluster(
+        endpoint: str,
+        ca_data_b64: str,
+        cluster_name: str,
+        region: str,
+    ) -> client.ApiClient:
+        """Build an ApiClient in-memory for an EKS cluster.
+
+        Uses STS presigned URL as bearer token, refreshed on each API call.
+        """
+        from jupyter_deploy.api.aws.sts.eks_token import get_eks_bearer_token  # noqa: PLC0415
+
+        ca_cert_data = base64.b64decode(ca_data_b64)
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".crt") as ca_cert_file:
+            ca_cert_file.write(ca_cert_data)
+            ca_cert_path = ca_cert_file.name
+
+        configuration = client.Configuration()
+        configuration.host = endpoint
+        configuration.ssl_ca_cert = ca_cert_path
+        configuration.api_key_prefix["authorization"] = "Bearer"
+        configuration.api_key["authorization"] = get_eks_bearer_token(cluster_name, region)
+
+        def _refresh_token(cfg: client.Configuration) -> None:
+            cfg.api_key["authorization"] = get_eks_bearer_token(cluster_name, region)
+
+        configuration.refresh_api_key_hook = _refresh_token
+
+        return client.ApiClient(configuration=configuration)

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_core_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_core_runner.py
@@ -1,10 +1,12 @@
+import json
 from enum import Enum
 
 from kubernetes import client
 
+from jupyter_deploy import cmd_utils
 from jupyter_deploy.api.k8s import core as k8s_core
 from jupyter_deploy.engine.supervised_execution import DisplayManager
-from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.exceptions import InstructionNotFoundError, InteractiveSessionError, InteractiveSessionTimeoutError
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
 from jupyter_deploy.provider.resolved_argdefs import (
     ResolvedInstructionArgument,
@@ -13,6 +15,7 @@ from jupyter_deploy.provider.resolved_argdefs import (
     retrieve_optional_arg,
 )
 from jupyter_deploy.provider.resolved_resultdefs import (
+    ListStrResolvedInstructionResult,
     ResolvedInstructionResult,
     StrResolvedInstructionResult,
 )
@@ -25,14 +28,21 @@ class K8sCoreInstruction(str, Enum):
     GET_NODE = "get-node"
     LIST_PODS = "list-pods"
     GET_POD = "get-pod"
+    DEPLOYMENT_LOGS = "deployment-logs"
+    EXEC_POD = "exec-pod"
+    EXEC_POD_INTERACTIVE = "exec-pod-interactive"
 
 
 class K8sCoreRunner(InstructionRunner):
     """Runner class for Kubernetes Core API instructions."""
 
-    def __init__(self, display_manager: DisplayManager, api_client: client.ApiClient) -> None:
+    def __init__(
+        self, display_manager: DisplayManager, api_client: client.ApiClient, kubeconfig_path: str | None = None
+    ) -> None:
         super().__init__(display_manager)
         self.core_api = client.CoreV1Api(api_client)
+        self.apps_api = client.AppsV1Api(api_client)
+        self._kubeconfig_path = kubeconfig_path
 
     def _list_nodes(
         self, resolved_arguments: dict[str, ResolvedInstructionArgument]
@@ -53,7 +63,7 @@ class K8sCoreRunner(InstructionRunner):
 
         node_names = [node.name for node in nodes]
         return {
-            "NodeNames": StrResolvedInstructionResult(result_name="NodeNames", value=",".join(node_names)),
+            "NodeNames": ListStrResolvedInstructionResult(result_name="NodeNames", value=node_names),
             "NextToken": StrResolvedInstructionResult(result_name="NextToken", value=next_token or ""),
         }
 
@@ -68,6 +78,7 @@ class K8sCoreRunner(InstructionRunner):
         return {
             "Name": StrResolvedInstructionResult(result_name="Name", value=node.name),
             "Status": StrResolvedInstructionResult(result_name="Status", value=node.status.value),
+            "Resource": StrResolvedInstructionResult(result_name="Resource", value=json.dumps(node.resource)),
         }
 
     def _list_pods(
@@ -109,6 +120,114 @@ class K8sCoreRunner(InstructionRunner):
             "Phase": StrResolvedInstructionResult(result_name="Phase", value=pod.phase.value),
         }
 
+    def _deployment_logs(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+        container_arg = retrieve_optional_arg(resolved_arguments, "container", StrResolvedInstructionArgument, "")
+        tail_lines_arg = retrieve_optional_arg(resolved_arguments, "tail_lines", StrResolvedInstructionArgument, "")
+
+        container = container_arg.value if container_arg.value and container_arg.value != "default" else None
+        self.display_manager.info(f"Getting logs for deployment {name_arg.value} in namespace: {scope_arg.value}")
+        logs = k8s_core.get_deployment_logs(
+            self.core_api,
+            self.apps_api,
+            name=name_arg.value,
+            namespace=scope_arg.value,
+            container=container,
+            tail_lines=int(tail_lines_arg.value) if tail_lines_arg.value else None,
+        )
+
+        return {
+            "Logs": StrResolvedInstructionResult(result_name="Logs", value=logs),
+        }
+
+    def _resolve_pod_name(self, deployment_name: str, namespace: str) -> str:
+        deployment = self.apps_api.read_namespaced_deployment(name=deployment_name, namespace=namespace)
+        match_labels = deployment.spec.selector.match_labels or {}
+        label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
+        if not label_selector:
+            raise ValueError(f"Deployment {deployment_name} has no selector labels")
+        pods, _ = k8s_core.list_pods(self.core_api, namespace=namespace, label_selector=label_selector, limit=1)
+        if not pods:
+            raise ValueError(f"No pods found for deployment {deployment_name} in namespace {namespace}")
+        return pods[0].name
+
+    def _exec_pod(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+        command_arg = require_arg(resolved_arguments, "command", StrResolvedInstructionArgument)
+        container_arg = retrieve_optional_arg(resolved_arguments, "container", StrResolvedInstructionArgument, "")
+        deployment_name_arg = retrieve_optional_arg(
+            resolved_arguments, "deployment_name", StrResolvedInstructionArgument, ""
+        )
+        name_arg = retrieve_optional_arg(resolved_arguments, "name", StrResolvedInstructionArgument, "")
+
+        if deployment_name_arg.value:
+            pod_name = self._resolve_pod_name(deployment_name_arg.value, scope_arg.value)
+        elif name_arg.value:
+            pod_name = name_arg.value
+        else:
+            raise ValueError("Either 'name' (pod name) or 'deployment_name' must be provided")
+
+        container = container_arg.value if container_arg.value and container_arg.value != "default" else None
+        command_parts = command_arg.value.split()
+        self.display_manager.info(f"Executing command on pod: {pod_name}")
+        result = k8s_core.exec_pod(
+            self.core_api,
+            name=pod_name,
+            namespace=scope_arg.value,
+            command=command_parts,
+            container=container,
+        )
+
+        return {
+            "Stdout": StrResolvedInstructionResult(result_name="Stdout", value=result.stdout),
+            "Stderr": StrResolvedInstructionResult(result_name="Stderr", value=result.stderr),
+            "ReturnCode": StrResolvedInstructionResult(result_name="ReturnCode", value=str(result.returncode)),
+        }
+
+    def _exec_pod_interactive(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+        command_arg = retrieve_optional_arg(resolved_arguments, "command", StrResolvedInstructionArgument, "/bin/bash")
+        container_arg = retrieve_optional_arg(resolved_arguments, "container", StrResolvedInstructionArgument, "")
+        deployment_name_arg = retrieve_optional_arg(
+            resolved_arguments, "deployment_name", StrResolvedInstructionArgument, ""
+        )
+        name_arg = retrieve_optional_arg(resolved_arguments, "name", StrResolvedInstructionArgument, "")
+
+        if deployment_name_arg.value:
+            pod_name = self._resolve_pod_name(deployment_name_arg.value, scope_arg.value)
+        elif name_arg.value:
+            pod_name = name_arg.value
+        else:
+            raise ValueError("Either 'name' (pod name) or 'deployment_name' must be provided")
+
+        container = container_arg.value if container_arg.value and container_arg.value != "default" else None
+
+        kubectl_cmd = ["kubectl", "exec", "-it", pod_name, "-n", scope_arg.value]
+        if self._kubeconfig_path:
+            kubectl_cmd.extend(["--kubeconfig", self._kubeconfig_path])
+        if container:
+            kubectl_cmd.extend(["-c", container])
+        kubectl_cmd.extend(["--", command_arg.value])
+
+        self.display_manager.hint("Type 'exit' to close the session.")
+        self.display_manager.stop_spinning()
+
+        retcode, timed_out = cmd_utils.run_cmd_and_pipe_to_terminal(kubectl_cmd)
+
+        if timed_out:
+            raise InteractiveSessionTimeoutError("kubectl exec session timed out")
+        if retcode:
+            raise InteractiveSessionError("kubectl exec session failed")
+
+        return {}
+
     def execute_instruction(
         self,
         instruction_name: str,
@@ -127,5 +246,11 @@ class K8sCoreRunner(InstructionRunner):
             return self._list_pods(resolved_arguments)
         elif instruction == K8sCoreInstruction.GET_POD:
             return self._get_pod(resolved_arguments)
+        elif instruction == K8sCoreInstruction.DEPLOYMENT_LOGS:
+            return self._deployment_logs(resolved_arguments)
+        elif instruction == K8sCoreInstruction.EXEC_POD:
+            return self._exec_pod(resolved_arguments)
+        elif instruction == K8sCoreInstruction.EXEC_POD_INTERACTIVE:
+            return self._exec_pod_interactive(resolved_arguments)
 
         raise InstructionNotFoundError(f"Unknown K8s core instruction: '{instruction_name}'")

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_custom_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_custom_runner.py
@@ -15,6 +15,7 @@ from jupyter_deploy.provider.resolved_argdefs import (
     retrieve_optional_arg,
 )
 from jupyter_deploy.provider.resolved_resultdefs import (
+    ListStrResolvedInstructionResult,
     ResolvedInstructionResult,
     StrResolvedInstructionResult,
 )
@@ -66,7 +67,7 @@ class K8sCustomRunner(InstructionRunner):
 
         names = [item.get("metadata", {}).get("name", "") for item in items]
         return {
-            "Names": StrResolvedInstructionResult(result_name="Names", value=",".join(names)),
+            "Names": ListStrResolvedInstructionResult(result_name="Names", value=names),
             "Items": StrResolvedInstructionResult(result_name="Items", value=json.dumps(items)),
             "NextToken": StrResolvedInstructionResult(result_name="NextToken", value=next_token or ""),
         }
@@ -123,7 +124,7 @@ class K8sCustomRunner(InstructionRunner):
 
         names = [item.get("metadata", {}).get("name", "") for item in items]
         return {
-            "Names": StrResolvedInstructionResult(result_name="Names", value=",".join(names)),
+            "Names": ListStrResolvedInstructionResult(result_name="Names", value=names),
             "Items": StrResolvedInstructionResult(result_name="Items", value=json.dumps(items)),
             "NextToken": StrResolvedInstructionResult(result_name="NextToken", value=next_token or ""),
         }

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_error_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_error_handler.py
@@ -1,0 +1,73 @@
+import json
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from kubernetes.client.exceptions import ApiException
+
+from jupyter_deploy.enum import ProviderType
+from jupyter_deploy.exceptions import (
+    InvalidInstructionArgumentError,
+    InvalidProviderCredentialsError,
+    ProviderPermissionError,
+    ResourceNotFoundError,
+)
+
+
+def _parse_api_exception_body(e: ApiException) -> tuple[str, str]:
+    """Extract message and resource kind from K8s API error body."""
+    message = ""
+    kind = ""
+    if e.body:
+        try:
+            body = json.loads(e.body)
+            message = body.get("message", "")
+            details = body.get("details", {})
+            kind = details.get("kind", "")
+        except (json.JSONDecodeError, AttributeError):
+            pass
+    return message, kind
+
+
+def _parse_resource_name_from_message(message: str) -> str:
+    """Extract the resource name from K8s error message like 'nodes "foo" not found'."""
+    start = message.find('"')
+    end = message.find('"', start + 1) if start >= 0 else -1
+    if start >= 0 and end > start:
+        return message[start + 1 : end]
+    return ""
+
+
+@contextmanager
+def k8s_error_context_manager(scope: str | None = None) -> Generator[None, None, None]:
+    """Catch kubernetes exceptions and re-raise as jupyter-deploy provider errors."""
+    try:
+        yield
+    except ApiException as e:
+        message, kind = _parse_api_exception_body(e)
+
+        if e.status == 401:
+            raise InvalidProviderCredentialsError(
+                provider_name=ProviderType.K8S,
+                original_message=message or str(e),
+            ) from e
+
+        if e.status == 400:
+            raise InvalidInstructionArgumentError(message or str(e)) from e
+
+        if e.status == 403:
+            raise ProviderPermissionError(
+                provider_name=ProviderType.K8S,
+                operation=None,
+                original_message=message or str(e),
+            ) from e
+
+        if e.status == 404:
+            resource_name = _parse_resource_name_from_message(message)
+            raise ResourceNotFoundError(
+                resource_kind=kind or "resource",
+                resource_name=resource_name,
+                original_message=message or str(e),
+                scope=scope,
+            ) from e
+
+        raise

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_runner.py
@@ -8,6 +8,7 @@ from jupyter_deploy.provider.instruction_runner import InstructionRunner
 from jupyter_deploy.provider.k8s.k8s_client_factory import K8sClientFactory
 from jupyter_deploy.provider.k8s.k8s_core_runner import K8sCoreRunner
 from jupyter_deploy.provider.k8s.k8s_custom_runner import K8sCustomRunner
+from jupyter_deploy.provider.k8s.k8s_error_handler import k8s_error_context_manager
 from jupyter_deploy.provider.resolved_argdefs import ResolvedInstructionArgument
 from jupyter_deploy.provider.resolved_resultdefs import ResolvedInstructionResult
 
@@ -22,25 +23,46 @@ class K8sService(str, Enum):
 class K8sApiRunner(InstructionRunner):
     """Routes k8s.{service}.{instruction} to the appropriate sub-runner."""
 
-    def __init__(self, display_manager: DisplayManager, kubeconfig_path: str | None = None) -> None:
+    def __init__(
+        self,
+        display_manager: DisplayManager,
+        kubeconfig_path: str | None = None,
+        cluster_endpoint: str | None = None,
+        cluster_ca_data: str | None = None,
+        cluster_name: str | None = None,
+        region: str | None = None,
+    ) -> None:
         super().__init__(display_manager)
         self.kubeconfig_path = kubeconfig_path
+        self._cluster_endpoint = cluster_endpoint
+        self._cluster_ca_data = cluster_ca_data
+        self._cluster_name = cluster_name
+        self._region = region
         self._api_client: client.ApiClient | None = None
         self._service_runners: dict[str, InstructionRunner] = {}
 
     def _get_api_client(self) -> client.ApiClient:
         if self._api_client is None:
-            self._api_client = K8sClientFactory.from_kubeconfig(kubeconfig_path=self.kubeconfig_path)
+            if self._cluster_endpoint and self._cluster_ca_data and self._cluster_name and self._region:
+                self._api_client = K8sClientFactory.from_eks_cluster(
+                    endpoint=self._cluster_endpoint,
+                    ca_data_b64=self._cluster_ca_data,
+                    cluster_name=self._cluster_name,
+                    region=self._region,
+                )
+            else:
+                self._api_client = K8sClientFactory.from_kubeconfig(kubeconfig_path=self.kubeconfig_path)
         return self._api_client
 
     @staticmethod
     def _get_service_and_sub_instruction_name(instruction_name: str) -> tuple[str, str]:
+        # expect k8s.<service-name>.<instruction>
         parts = instruction_name.split(".")
-        if len(parts) < 2 or not parts[0] or not parts[1]:
+        if len(parts) < 3 or not parts[1] or not parts[2]:
             raise ValueError(
-                f"Invalid instruction: {instruction_name}; should be of the form service-name.instruction-name"
+                f"Invalid instruction: {instruction_name}; should be of the form k8s.service-name.instruction-name"
             )
-        return parts[0], ".".join(parts[1:])
+        return parts[1], ".".join(parts[2:])
 
     def _get_service_runner(self, service_name: str) -> InstructionRunner:
         service_runner = self._service_runners.get(service_name)
@@ -50,7 +72,9 @@ class K8sApiRunner(InstructionRunner):
         api_client = self._get_api_client()
 
         if service_name == K8sService.CORE:
-            service_runner = K8sCoreRunner(self.display_manager, api_client=api_client)
+            service_runner = K8sCoreRunner(
+                self.display_manager, api_client=api_client, kubeconfig_path=self.kubeconfig_path
+            )
             self._service_runners[service_name] = service_runner
             return service_runner
         elif service_name == K8sService.CUSTOM:
@@ -65,9 +89,12 @@ class K8sApiRunner(InstructionRunner):
         instruction_name: str,
         resolved_arguments: dict[str, ResolvedInstructionArgument],
     ) -> dict[str, ResolvedInstructionResult]:
-        service_name, sub_instruction_name = K8sApiRunner._get_service_and_sub_instruction_name(instruction_name)
-        service_runner = self._get_service_runner(service_name)
-        return service_runner.execute_instruction(
-            instruction_name=sub_instruction_name,
-            resolved_arguments=resolved_arguments,
-        )
+        scope_arg = resolved_arguments.get("scope")
+        scope = scope_arg.value if scope_arg and hasattr(scope_arg, "value") else None
+        with k8s_error_context_manager(scope=scope):
+            service_name, sub_instruction_name = K8sApiRunner._get_service_and_sub_instruction_name(instruction_name)
+            service_runner = self._get_service_runner(service_name)
+            return service_runner.execute_instruction(
+                instruction_name=sub_instruction_name,
+                resolved_arguments=resolved_arguments,
+            )

--- a/libs/jupyter-deploy/jupyter_deploy/provider/manifest_command_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/manifest_command_runner.py
@@ -10,6 +10,7 @@ from jupyter_deploy.manifest import JupyterDeployCommandV1
 from jupyter_deploy.provider.instruction_runner_factory import InstructionRunnerFactory
 from jupyter_deploy.provider.resolved_argdefs import (
     ResolvedInstructionArgument,
+    _extract_json_path,
     resolve_cliparam_argdef,
     resolve_output_argdef,
     resolve_result_argdef,
@@ -69,7 +70,10 @@ class ManifestCommandRunner:
                     )
                 elif arg_source_type == InstructionArgumentSource.INSTRUCTION_RESULT:
                     resolved_argdefs[arg_name] = resolve_result_argdef(
-                        resultdefs=resolved_resultdefs, arg_name=arg_name, source_key=source_key
+                        resultdefs=resolved_resultdefs,
+                        arg_name=arg_name,
+                        source_key=source_key,
+                        extract=arg_def.extract,
                     )
                 elif arg_source_type == InstructionArgumentSource.CLI_ARGUMENT:
                     resolved_argdefs[arg_name] = resolve_cliparam_argdef(
@@ -109,10 +113,15 @@ class ManifestCommandRunner:
             )
         result_def = self._resolved_resultdefs[source_key]
 
-        value = transform_fn(result_def.value)
+        value = result_def.value
+        if result.extract:
+            value = _extract_json_path(str(value), result.extract)
+        value = transform_fn(value)
 
         base_type = get_origin(expect_type) or expect_type
         if not isinstance(value, base_type):
+            if isinstance(value, str) and base_type is int and value.lstrip("-").isdigit():
+                return int(value)  # type: ignore
             raise TypeError(
                 f"Expected result '{result_name}' to be of type {expect_type.__name__}, got {type(value).__name__}"
             )

--- a/libs/jupyter-deploy/jupyter_deploy/provider/resolved_argdefs.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/resolved_argdefs.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict
@@ -75,8 +76,27 @@ def resolve_output_argdef(
     raise NotImplementedError(f"No resolved argument class for type: {type(outdef).__name__}")
 
 
+def _extract_json_path(value: str, path: str) -> str:
+    """Extract a value from a JSON string using a dot-separated path.
+
+    Raises:
+        KeyError if a path segment is not found.
+    """
+    obj = json.loads(value)
+    for segment in path.split("."):
+        if isinstance(obj, dict):
+            if segment not in obj:
+                raise KeyError(f"Key '{segment}' not found in JSON at path '{path}'")
+            obj = obj[segment]
+        else:
+            raise KeyError(f"Cannot traverse non-dict value at '{segment}' in path '{path}'")
+    if not isinstance(obj, str):
+        return json.dumps(obj)
+    return obj
+
+
 def resolve_result_argdef(
-    resultdefs: dict[str, ResolvedInstructionResult], arg_name: str, source_key: str
+    resultdefs: dict[str, ResolvedInstructionResult], arg_name: str, source_key: str, extract: str | None = None
 ) -> ResolvedInstructionArgument:
     """Instantiates the resolved argdef of the corresponding type.
 
@@ -89,7 +109,10 @@ def resolve_result_argdef(
         raise KeyError(f"Output name '{source_key}' not found in previous results: {list(resultdefs.keys())}")
     resultdef = resultdefs[source_key]
     if isinstance(resultdef, StrResolvedInstructionResult):
-        return StrResolvedInstructionArgument(argument_name=arg_name, value=resultdef.value)
+        value = resultdef.value
+        if extract:
+            value = _extract_json_path(value, extract)
+        return StrResolvedInstructionArgument(argument_name=arg_name, value=value)
     elif isinstance(resultdef, IntResolvedInstructionResult):
         return IntResolvedInstructionArgument(argument_name=arg_name, value=resultdef.value)
     elif isinstance(resultdef, ListStrResolvedInstructionResult):

--- a/libs/jupyter-deploy/tests/unit/api/aws/sts/test_eks_token.py
+++ b/libs/jupyter-deploy/tests/unit/api/aws/sts/test_eks_token.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from jupyter_deploy.api.aws.sts.eks_token import get_eks_bearer_token
+
+
+class TestGetEksBearerToken(unittest.TestCase):
+    @patch("jupyter_deploy.api.aws.sts.eks_token.SigV4QueryAuth")
+    @patch("jupyter_deploy.api.aws.sts.eks_token.BotocoreSession")
+    def test_returns_prefixed_base64url_token(self, mock_session_cls: Mock, mock_signer_cls: Mock) -> None:
+        mock_session: Mock = Mock()
+        mock_session_cls.return_value = mock_session
+        mock_creds: Mock = Mock()
+        mock_session.get_credentials.return_value.get_frozen_credentials.return_value = mock_creds
+
+        mock_signer: Mock = Mock()
+        mock_signer_cls.return_value = mock_signer
+
+        token = get_eks_bearer_token("my-cluster", "us-west-2")
+
+        self.assertTrue(token.startswith("k8s-aws-v1."))
+        mock_signer_cls.assert_called_once_with(mock_creds, "sts", "us-west-2", expires=60)
+        mock_signer.add_auth.assert_called_once()
+
+    @patch("jupyter_deploy.api.aws.sts.eks_token.SigV4QueryAuth")
+    @patch("jupyter_deploy.api.aws.sts.eks_token.BotocoreSession")
+    def test_uses_correct_sts_endpoint(self, mock_session_cls: Mock, mock_signer_cls: Mock) -> None:
+        mock_session_cls.return_value = Mock()
+        mock_signer_cls.return_value = Mock()
+
+        get_eks_bearer_token("my-cluster", "eu-west-1")
+
+        request_arg = mock_signer_cls.return_value.add_auth.call_args[0][0]
+        self.assertIn("sts.eu-west-1.amazonaws.com", request_arg.url)
+        self.assertEqual(request_arg.headers["x-k8s-aws-id"], "my-cluster")

--- a/libs/jupyter-deploy/tests/unit/api/k8s/test_core.py
+++ b/libs/jupyter-deploy/tests/unit/api/k8s/test_core.py
@@ -1,12 +1,15 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
-from kubernetes.client import CoreV1Api
+from kubernetes.client import AppsV1Api, CoreV1Api
 from kubernetes.client.exceptions import ApiException
 
 from jupyter_deploy.api.k8s.core import (
+    ExecResult,
     NodeConditionStatus,
     PodPhase,
+    exec_pod,
+    get_deployment_logs,
     get_node,
     get_pod,
     list_nodes,
@@ -103,14 +106,17 @@ class TestListNodes(unittest.TestCase):
 
 
 class TestGetNode(unittest.TestCase):
-    def test_returns_node_info(self) -> None:
+    @patch("jupyter_deploy.api.k8s.core.ApiClient")
+    def test_returns_node_info(self, mock_api_client_cls: Mock) -> None:
         mock_api: Mock = Mock(spec=CoreV1Api)
         mock_api.read_node.return_value = _mock_node("node-1")
+        mock_api_client_cls.return_value.sanitize_for_serialization.return_value = {"metadata": {"name": "node-1"}}
 
         result = get_node(mock_api, name="node-1")
 
         self.assertEqual(result.name, "node-1")
         self.assertEqual(result.status, NodeConditionStatus.READY)
+        self.assertEqual(result.resource, {"metadata": {"name": "node-1"}})
         mock_api.read_node.assert_called_once_with(name="node-1")
 
     def test_raises_on_api_error(self) -> None:
@@ -184,3 +190,130 @@ class TestGetPod(unittest.TestCase):
 
         with self.assertRaises(ApiException):
             get_pod(mock_api, name="nonexistent", namespace="default")
+
+
+def _mock_deployment(match_labels: dict[str, str] | None = None) -> Mock:
+    deployment: Mock = Mock()
+    deployment.spec.selector.match_labels = match_labels
+    return deployment
+
+
+class TestGetDeploymentLogs(unittest.TestCase):
+    def test_returns_logs_from_first_pod(self) -> None:
+        mock_core: Mock = Mock(spec=CoreV1Api)
+        mock_apps: Mock = Mock(spec=AppsV1Api)
+        mock_apps.read_namespaced_deployment.return_value = _mock_deployment({"app": "web"})
+        mock_core.list_namespaced_pod.return_value = _mock_pod_list([_mock_pod("pod-1")])
+        mock_core.read_namespaced_pod_log.return_value = "log line 1\nlog line 2"
+
+        result = get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="default")
+
+        self.assertEqual(result, "log line 1\nlog line 2")
+        mock_apps.read_namespaced_deployment.assert_called_once_with(name="my-deploy", namespace="default")
+        mock_core.list_namespaced_pod.assert_called_once_with(namespace="default", label_selector="app=web")
+        mock_core.read_namespaced_pod_log.assert_called_once_with(name="pod-1", namespace="default")
+
+    def test_returns_empty_when_no_pods(self) -> None:
+        mock_core: Mock = Mock(spec=CoreV1Api)
+        mock_apps: Mock = Mock(spec=AppsV1Api)
+        mock_apps.read_namespaced_deployment.return_value = _mock_deployment({"app": "web"})
+        mock_core.list_namespaced_pod.return_value = _mock_pod_list([])
+
+        result = get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="default")
+
+        self.assertEqual(result, "")
+        mock_core.read_namespaced_pod_log.assert_not_called()
+
+    def test_returns_empty_when_no_match_labels(self) -> None:
+        mock_core: Mock = Mock(spec=CoreV1Api)
+        mock_apps: Mock = Mock(spec=AppsV1Api)
+        mock_apps.read_namespaced_deployment.return_value = _mock_deployment(None)
+
+        result = get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="default")
+
+        self.assertEqual(result, "")
+        mock_core.list_namespaced_pod.assert_not_called()
+
+    def test_passes_container_and_tail_lines(self) -> None:
+        mock_core: Mock = Mock(spec=CoreV1Api)
+        mock_apps: Mock = Mock(spec=AppsV1Api)
+        mock_apps.read_namespaced_deployment.return_value = _mock_deployment({"app": "web"})
+        mock_core.list_namespaced_pod.return_value = _mock_pod_list([_mock_pod("pod-1")])
+        mock_core.read_namespaced_pod_log.return_value = "last line"
+
+        get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="ns", container="main", tail_lines=10)
+
+        mock_core.read_namespaced_pod_log.assert_called_once_with(
+            name="pod-1", namespace="ns", container="main", tail_lines=10
+        )
+
+    def test_raises_on_api_error(self) -> None:
+        mock_core: Mock = Mock(spec=CoreV1Api)
+        mock_apps: Mock = Mock(spec=AppsV1Api)
+        mock_apps.read_namespaced_deployment.side_effect = _NOT_FOUND
+
+        with self.assertRaises(ApiException):
+            get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="default")
+
+
+class TestExecPod(unittest.TestCase):
+    @patch("jupyter_deploy.api.k8s.core.k8s_stream")
+    def test_returns_exec_result(self, mock_stream: Mock) -> None:
+        mock_resp: Mock = Mock()
+        mock_resp.read_stdout.return_value = "hello"
+        mock_resp.read_stderr.return_value = ""
+        mock_resp.returncode = 0
+        mock_stream.return_value = mock_resp
+        mock_api: Mock = Mock(spec=CoreV1Api)
+
+        result = exec_pod(mock_api, name="pod-1", namespace="default", command=["echo", "hello"])
+
+        self.assertEqual(result, ExecResult(stdout="hello", stderr="", returncode=0))
+        mock_stream.assert_called_once_with(
+            mock_api.connect_get_namespaced_pod_exec,
+            name="pod-1",
+            namespace="default",
+            command=["echo", "hello"],
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+            _preload_content=False,
+        )
+
+    @patch("jupyter_deploy.api.k8s.core.k8s_stream")
+    def test_passes_container(self, mock_stream: Mock) -> None:
+        mock_resp: Mock = Mock()
+        mock_resp.read_stdout.return_value = ""
+        mock_resp.read_stderr.return_value = ""
+        mock_resp.returncode = 0
+        mock_stream.return_value = mock_resp
+        mock_api: Mock = Mock(spec=CoreV1Api)
+
+        exec_pod(mock_api, name="pod-1", namespace="default", command=["ls"], container="main")
+
+        mock_stream.assert_called_once_with(
+            mock_api.connect_get_namespaced_pod_exec,
+            name="pod-1",
+            namespace="default",
+            command=["ls"],
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+            _preload_content=False,
+            container="main",
+        )
+
+    @patch("jupyter_deploy.api.k8s.core.k8s_stream")
+    def test_returns_stderr_and_nonzero_returncode(self, mock_stream: Mock) -> None:
+        mock_resp: Mock = Mock()
+        mock_resp.read_stdout.return_value = ""
+        mock_resp.read_stderr.return_value = "error"
+        mock_resp.returncode = 1
+        mock_stream.return_value = mock_resp
+        mock_api: Mock = Mock(spec=CoreV1Api)
+
+        result = exec_pod(mock_api, name="pod-1", namespace="default", command=["false"])
+
+        self.assertEqual(result, ExecResult(stdout="", stderr="error", returncode=1))

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
@@ -325,7 +325,7 @@ class TestOpenCommand(unittest.TestCase):
         mock_open_handler_cls.return_value = mock_open_handler_instance
 
         runner = CliRunner()
-        result = runner.invoke(app_runner.app, ["open", "my-ws"])
+        result = runner.invoke(app_runner.app, ["open", "--name", "my-ws"])
 
         self.assertEqual(result.exit_code, 0)
         mock_open_fns["open"].assert_called_once_with(name="my-ws", scope=None)
@@ -342,7 +342,7 @@ class TestOpenCommand(unittest.TestCase):
         mock_open_handler_cls.return_value = mock_open_handler_instance
 
         runner = CliRunner()
-        result = runner.invoke(app_runner.app, ["open", "my-ws", "--scope", "team-a"])
+        result = runner.invoke(app_runner.app, ["open", "--name", "my-ws", "--scope", "team-a"])
 
         self.assertEqual(result.exit_code, 0)
         mock_open_fns["open"].assert_called_once_with(name="my-ws", scope="team-a")

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
@@ -40,7 +40,7 @@ class TestOpenCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         mock_project_ctx_manager.assert_called_once_with(None)
-        mock_open_fns["open"].assert_called_once()
+        mock_open_fns["open"].assert_called_once_with(name=None, scope=None)
 
     @patch("jupyter_deploy.cli.app.OpenHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -54,7 +54,7 @@ class TestOpenCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         mock_project_ctx_manager.assert_called_once_with(Path("/custom/path"))
-        mock_open_fns["open"].assert_called_once()
+        mock_open_fns["open"].assert_called_once_with(name=None, scope=None)
 
     @patch("jupyter_deploy.cli.app.OpenHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -72,7 +72,7 @@ class TestOpenCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["open"])
 
         self.assertEqual(result.exit_code, 1)
-        mock_open_fns["open"].assert_called_once()
+        mock_open_fns["open"].assert_called_once_with(name=None, scope=None)
         self.assertIn("Failed to open URL in browser", result.output)
 
     @patch("jupyter_deploy.cli.app.OpenHandler")
@@ -267,7 +267,7 @@ class TestOpenCommand(unittest.TestCase):
         result = runner.invoke(app_runner.app, ["open"])
 
         self.assertNotEqual(result.exit_code, 0)
-        mock_open_fns["open"].assert_called_once()
+        mock_open_fns["open"].assert_called_once_with(name=None, scope=None)
 
     @patch("jupyter_deploy.cli.app.OpenHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -315,3 +315,49 @@ class TestOpenCommand(unittest.TestCase):
         # Should display the error message
         self.assertIn("Insecure URL detected", result.output)
         self.assertIn("HTTPS", result.output)
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_with_server_name(self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock) -> None:
+        """Test that open command passes server name to handler."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler()
+        mock_open_fns["open"].return_value = "https://example.com/workspaces/default/my-ws/"
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open", "my-ws"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_open_fns["open"].assert_called_once_with(name="my-ws", scope=None)
+        self.assertIn("Opening app at:", result.output)
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_with_server_name_and_scope(
+        self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock
+    ) -> None:
+        """Test that open command passes server name and scope to handler."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler()
+        mock_open_fns["open"].return_value = "https://example.com/workspaces/team-a/my-ws/"
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open", "my-ws", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_open_fns["open"].assert_called_once_with(name="my-ws", scope="team-a")
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_scope_without_server_name(
+        self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock
+    ) -> None:
+        """Test that open command with only --scope still opens the default URL."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler()
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_open_fns["open"].assert_called_once_with(name=None, scope="team-a")

--- a/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -15,7 +16,7 @@ class TestHostApp(unittest.TestCase):
         result = runner.invoke(host_app, ["--help"])
 
         self.assertEqual(result.exit_code, 0)
-        for cmd in ["status", "start", "stop", "restart"]:
+        for cmd in ["status", "start", "stop", "restart", "list", "show"]:
             self.assertTrue(result.stdout.index(cmd) > 0, f"missing command: {cmd}")
 
     def test_no_arg_defaults_to_help(self) -> None:
@@ -161,7 +162,20 @@ class TestHostStartCommand(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_host_handler_class.assert_called_once()
-        mock_handler_fns["start_host"].assert_called_once()
+        mock_handler_fns["start_host"].assert_called_once_with(name=None)
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["start", "node-1"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["start_host"].assert_called_once_with(name="node-1")
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -226,7 +240,20 @@ class TestHostStopCommand(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_host_handler_class.assert_called_once()
-        mock_handler_fns["stop_host"].assert_called_once()
+        mock_handler_fns["stop_host"].assert_called_once_with(name=None)
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["stop", "node-1"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["stop_host"].assert_called_once_with(name="node-1")
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -291,7 +318,20 @@ class TestHostRestartCommand(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_host_handler_class.assert_called_once()
-        mock_handler_fns["restart_host"].assert_called_once()
+        mock_handler_fns["restart_host"].assert_called_once_with(name=None)
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["restart", "node-1"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["restart_host"].assert_called_once_with(name="node-1")
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -456,7 +496,35 @@ class TestHostConnectCommand(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_host_handler_class.assert_called_once()
-        mock_handler_fns["connect"].assert_called_once()
+        mock_handler_fns["connect"].assert_called_once_with(name=None)
+
+    @patch("jupyter_deploy.cli.host_app.SimpleDisplayManager")
+    @patch("jupyter_deploy.cli.host_app.Console")
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name(
+        self,
+        mock_project_dir: Mock,
+        mock_host_handler_class: Mock,
+        mock_console_class: Mock,
+        mock_simple_display_manager_class: Mock,
+    ) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_spinner = Mock()
+        mock_spinner.__enter__ = Mock(return_value=None)
+        mock_spinner.__exit__ = Mock(return_value=None)
+        mock_simple_display_manager = Mock()
+        mock_simple_display_manager.spinner.return_value = mock_spinner
+        mock_simple_display_manager_class.return_value = mock_simple_display_manager
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["connect", "node-1"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["connect"].assert_called_once_with(name="node-1")
 
     @patch("jupyter_deploy.cli.host_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.host_app.Console")
@@ -564,7 +632,7 @@ class TestHostExecCommand(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_host_handler_class.assert_called_once()
-        mock_handler_fns["exec_command"].assert_called_once_with(["df", "-h"])
+        mock_handler_fns["exec_command"].assert_called_once_with(["df", "-h"], name=None)
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -580,7 +648,7 @@ class TestHostExecCommand(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_handler_fns["exec_command"].assert_called_once_with(["echo", "hello world"])
+        mock_handler_fns["exec_command"].assert_called_once_with(["echo", "hello world"], name=None)
 
     @patch("jupyter_deploy.cli.host_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.host_app.Console")
@@ -636,7 +704,7 @@ class TestHostExecCommand(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 127)
-        mock_handler_fns["exec_command"].assert_called_once_with(["command_that_does_not_exist"])
+        mock_handler_fns["exec_command"].assert_called_once_with(["command_that_does_not_exist"], name=None)
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -671,6 +739,19 @@ class TestHostExecCommand(unittest.TestCase):
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["exec", "--name", "node-1", "--", "whoami"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["exec_command"].assert_called_once_with(["whoami"], name="node-1")
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_raises_when_handler_exec_command_raises(
         self, mock_project_dir: Mock, mock_host_handler_class: Mock
     ) -> None:
@@ -685,4 +766,221 @@ class TestHostExecCommand(unittest.TestCase):
         result = runner.invoke(host_app, ["exec", "--", "whoami"])
 
         # Assert
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestHostListCommand(unittest.TestCase):
+    def get_mock_host_handler(self) -> tuple[Mock, dict[str, Mock]]:
+        mock_list_hosts = Mock()
+        mock_host_handler = Mock()
+
+        mock_host_handler.list_hosts = mock_list_hosts
+        mock_list_hosts.return_value = ("node-1,node-2", None)
+
+        return mock_host_handler, {
+            "list_hosts": mock_list_hosts,
+        }
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_instantiates_host_handler_and_calls_list(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["list"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_host_handler_class.assert_called_once()
+        mock_handler_fns["list_hosts"].assert_called_once_with(query="", limit=None, continue_from=None)
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_query_option(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["list", "--query", "role=worker"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["list_hosts"].assert_called_once_with(query="role=worker", limit=None, continue_from=None)
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_pagination_options(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["list", "-n", "10", "--continue-from", "abc123"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["list_hosts"].assert_called_once_with(query="", limit=10, continue_from="abc123")
+
+    @patch("jupyter_deploy.cli.host_app.SimpleDisplayManager")
+    @patch("jupyter_deploy.cli.host_app.Console")
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_prints_next_token_when_present(
+        self,
+        mock_project_dir: Mock,
+        mock_host_handler_class: Mock,
+        mock_console_class: Mock,
+        mock_simple_display_manager_class: Mock,
+    ) -> None:
+        mock_host_handler = Mock()
+        mock_host_handler.list_hosts.return_value = ("node-1", "next-token-xyz")
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_console = Mock()
+        mock_console_class.return_value = mock_console
+
+        mock_spinner = Mock()
+        mock_spinner.__enter__ = Mock(return_value=None)
+        mock_spinner.__exit__ = Mock(return_value=None)
+        mock_simple_display_manager = Mock()
+        mock_simple_display_manager.spinner.return_value = mock_spinner
+        mock_simple_display_manager_class.return_value = mock_simple_display_manager
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["list", "-n", "1"])
+
+        self.assertEqual(result.exit_code, 0)
+        print_calls = [str(call) for call in mock_console.print.mock_calls]
+        self.assertTrue(any("next-token-xyz" in call for call in print_calls))
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_switches_dir_when_passed_a_project(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, _ = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["list", "--path", "/test/project/path"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_json_output_with_pagination_token(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler = Mock()
+        mock_host_handler.list_hosts.return_value = (["node-1", "node-2"], "next-page-token")
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["list", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["hosts"], ["node-1", "node-2"])
+        self.assertEqual(data["continue_from"], "next-page-token")
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_json_output_without_pagination_token(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler = Mock()
+        mock_host_handler.list_hosts.return_value = (["node-1", "node-2"], None)
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["list", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["hosts"], ["node-1", "node-2"])
+        self.assertNotIn("continue_from", data)
+
+
+class TestHostShowCommand(unittest.TestCase):
+    def get_mock_host_handler(self) -> tuple[Mock, dict[str, Mock]]:
+        mock_show_host = Mock()
+        mock_host_handler = Mock()
+
+        mock_host_handler.show_host = mock_show_host
+        mock_show_host.return_value = {"name": "node-1", "status": "Ready"}
+
+        return mock_host_handler, {
+            "show_host": mock_show_host,
+        }
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_instantiates_host_handler_and_calls_show(
+        self, mock_project_dir: Mock, mock_host_handler_class: Mock
+    ) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["show", "node-1"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_host_handler_class.assert_called_once()
+        mock_handler_fns["show_host"].assert_called_once_with(name="node-1")
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_requires_name_argument(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, _ = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["show"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_switches_dir_when_passed_a_project(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, _ = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["show", "node-1", "--path", "/test/project/path"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_json_output(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler = Mock()
+        mock_host_handler.show_host.return_value = {"name": "node-1", "status": "Ready", "resource": '{"spec": {}}'}
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["show", "node-1", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["name"], "node-1")
+        self.assertEqual(data["status"], "Ready")
+        self.assertIn("resource", data)
+
+    @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_raises_when_handler_raises(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+        mock_host_handler, mock_handler_fns = self.get_mock_host_handler()
+        mock_host_handler_class.return_value = mock_host_handler
+        mock_handler_fns["show_host"].side_effect = Exception("Test error")
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(host_app, ["show", "node-1"])
+
         self.assertNotEqual(result.exit_code, 0)

--- a/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
@@ -172,7 +172,7 @@ class TestHostStartCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(host_app, ["start", "node-1"])
+        result = runner.invoke(host_app, ["start", "--name", "node-1"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["start_host"].assert_called_once_with(name="node-1")
@@ -250,7 +250,7 @@ class TestHostStopCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(host_app, ["stop", "node-1"])
+        result = runner.invoke(host_app, ["stop", "--name", "node-1"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["stop_host"].assert_called_once_with(name="node-1")
@@ -328,7 +328,7 @@ class TestHostRestartCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(host_app, ["restart", "node-1"])
+        result = runner.invoke(host_app, ["restart", "--name", "node-1"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["restart_host"].assert_called_once_with(name="node-1")
@@ -521,7 +521,7 @@ class TestHostConnectCommand(unittest.TestCase):
         mock_simple_display_manager_class.return_value = mock_simple_display_manager
 
         runner = CliRunner()
-        result = runner.invoke(host_app, ["connect", "node-1"])
+        result = runner.invoke(host_app, ["connect", "--name", "node-1"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["connect"].assert_called_once_with(name="node-1")
@@ -924,7 +924,7 @@ class TestHostShowCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(host_app, ["show", "node-1"])
+        result = runner.invoke(host_app, ["show", "--name", "node-1"])
 
         self.assertEqual(result.exit_code, 0)
         mock_host_handler_class.assert_called_once()
@@ -932,7 +932,7 @@ class TestHostShowCommand(unittest.TestCase):
 
     @patch("jupyter_deploy.handlers.resource.host_handler.HostHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
-    def test_requires_name_argument(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
+    def test_requires_name_option(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
         mock_host_handler, _ = self.get_mock_host_handler()
         mock_host_handler_class.return_value = mock_host_handler
         mock_project_dir.return_value.__enter__.return_value = None
@@ -950,7 +950,7 @@ class TestHostShowCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(host_app, ["show", "node-1", "--path", "/test/project/path"])
+        result = runner.invoke(host_app, ["show", "--name", "node-1", "--path", "/test/project/path"])
 
         self.assertEqual(result.exit_code, 0)
         mock_project_dir.assert_called_once_with(Path("/test/project/path"))
@@ -964,7 +964,7 @@ class TestHostShowCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(host_app, ["show", "node-1", "--json"])
+        result = runner.invoke(host_app, ["show", "--name", "node-1", "--json"])
 
         self.assertEqual(result.exit_code, 0)
         data = json.loads(result.stdout)
@@ -981,6 +981,6 @@ class TestHostShowCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(host_app, ["show", "node-1"])
+        result = runner.invoke(host_app, ["show", "--name", "node-1"])
 
         self.assertNotEqual(result.exit_code, 0)

--- a/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -16,7 +17,7 @@ class TestServersApp(unittest.TestCase):
         result = runner.invoke(servers_app, ["--help"])
 
         self.assertEqual(result.exit_code, 0)
-        for cmd in ["status", "start", "stop", "restart"]:
+        for cmd in ["status", "start", "stop", "restart", "list", "show"]:
             self.assertTrue(result.stdout.index(cmd) > 0, f"missing command: {cmd}")
 
     def test_no_arg_defaults_to_help(self) -> None:
@@ -172,7 +173,7 @@ class TestServerStartCmd(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_server_handler_class.assert_called_once()
-        mock_handler_fns["start_server"].assert_called_once_with("all")
+        mock_handler_fns["start_server"].assert_called_once_with("all", name=None, scope=None)
 
     @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.servers_app.Console")
@@ -270,7 +271,20 @@ class TestServerStartCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_handler_fns["start_server"].assert_called_once_with("jupyter")
+        mock_handler_fns["start_server"].assert_called_once_with("jupyter", name=None, scope=None)
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name_and_scope(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["start", "my-ws", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["start_server"].assert_called_once_with("all", name="my-ws", scope="team-a")
 
 
 class TestServerStopCmd(unittest.TestCase):
@@ -307,7 +321,7 @@ class TestServerStopCmd(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_server_handler_class.assert_called_once()
-        mock_handler_fns["stop_server"].assert_called_once_with("all")
+        mock_handler_fns["stop_server"].assert_called_once_with("all", name=None, scope=None)
 
     @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.servers_app.Console")
@@ -405,7 +419,20 @@ class TestServerStopCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_handler_fns["stop_server"].assert_called_once_with("jupyter")
+        mock_handler_fns["stop_server"].assert_called_once_with("jupyter", name=None, scope=None)
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name_and_scope(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["stop", "my-ws", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["stop_server"].assert_called_once_with("all", name="my-ws", scope="team-a")
 
 
 class TestServerRestartCmd(unittest.TestCase):
@@ -442,7 +469,7 @@ class TestServerRestartCmd(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_server_handler_class.assert_called_once()
-        mock_handler_fns["restart_server"].assert_called_once_with("all")
+        mock_handler_fns["restart_server"].assert_called_once_with("all", name=None, scope=None)
 
     @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.servers_app.Console")
@@ -540,7 +567,20 @@ class TestServerRestartCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_handler_fns["restart_server"].assert_called_once_with("jupyter")
+        mock_handler_fns["restart_server"].assert_called_once_with("jupyter", name=None, scope=None)
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name_and_scope(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["restart", "my-ws", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["restart_server"].assert_called_once_with("all", name="my-ws", scope="team-a")
 
 
 class TestServerLogsCmd(unittest.TestCase):
@@ -598,7 +638,7 @@ class TestServerLogsCmd(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_server_handler_class.assert_called_once()
-        mock_handler_fns["get_server_logs"].assert_called_once_with(service="default", extra=[])
+        mock_handler_fns["get_server_logs"].assert_called_once_with(service="default", extra=[], name=None, scope=None)
         mock_console.print.assert_called()
         mock_console.rule.assert_called()
 
@@ -686,6 +726,41 @@ class TestServerLogsCmd(unittest.TestCase):
         self.assertTrue("no logs were retrieved" in mock_call[1][0])
         self.assertTrue("yellow" in mock_call[2]["style"])
 
+    @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
+    @patch("jupyter_deploy.cli.servers_app.Console")
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name_and_scope(
+        self,
+        mock_project_dir: Mock,
+        mock_server_handler_class: Mock,
+        mock_console_class: Mock,
+        mock_simple_display_manager_class: Mock,
+    ) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_console = Mock()
+        mock_console_class.return_value = mock_console
+
+        mock_spinner = Mock()
+        mock_spinner.__enter__ = Mock(return_value=None)
+        mock_spinner.__exit__ = Mock(return_value=None)
+        mock_simple_display_manager = Mock()
+        mock_simple_display_manager.spinner.return_value = mock_spinner
+        mock_simple_display_manager_class.return_value = mock_simple_display_manager
+
+        mock_handler_fns["get_server_logs"].return_value = "some-logs", "", 0
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["logs", "my-ws", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["get_server_logs"].assert_called_once_with(
+            service="default", extra=[], name="my-ws", scope="team-a"
+        )
+
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_instantiates_raises_when_server_handler_raises(
@@ -763,12 +838,14 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "pwd"])
+        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "pwd"])
 
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_server_handler_class.assert_called_once()
-        mock_handler_fns["exec_command"].assert_called_once_with(service="jupyter", command_args=["pwd"])
+        mock_handler_fns["exec_command"].assert_called_once_with(
+            service="jupyter", command_args=["pwd"], name="my-ws", scope=None
+        )
 
     @patch("jupyter_deploy.cli.servers_app.Console")
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
@@ -783,11 +860,13 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "ls", "-la"])
+        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "ls", "-la"])
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_handler_fns["exec_command"].assert_called_once_with(service="jupyter", command_args=["ls", "-la"])
+        mock_handler_fns["exec_command"].assert_called_once_with(
+            service="jupyter", command_args=["ls", "-la"], name="my-ws", scope=None
+        )
 
     @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.servers_app.Console")
@@ -818,7 +897,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "whoami"])
+        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "whoami"])
 
         # Assert
         self.assertEqual(result.exit_code, 0)
@@ -841,11 +920,13 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "false"])
+        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "false"])
 
         # Assert
         self.assertEqual(result.exit_code, 1)
-        mock_handler_fns["exec_command"].assert_called_once_with(service="jupyter", command_args=["false"])
+        mock_handler_fns["exec_command"].assert_called_once_with(
+            service="jupyter", command_args=["false"], name="my-ws", scope=None
+        )
 
     @patch("jupyter_deploy.cli.servers_app.Console")
     def test_fails_when_no_command_provided(self, mock_console_class: Mock) -> None:
@@ -855,7 +936,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "-s", "jupyter"])
+        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter"])
 
         # Assert
         self.assertEqual(result.exit_code, 1)
@@ -892,7 +973,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "-s", "invalid_service", "--", "pwd"])
+        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "invalid_service", "--", "pwd"])
 
         # Assert
         self.assertEqual(result.exit_code, 1)
@@ -902,6 +983,39 @@ class TestServerExecCmd(unittest.TestCase):
         first_call = mock_console.print.mock_calls[0]
         self.assertTrue("Invalid service" in first_call[1][0])
         self.assertTrue("red" in first_call[2]["style"])
+
+    @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
+    @patch("jupyter_deploy.cli.servers_app.Console")
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name_and_scope(
+        self,
+        mock_project_dir: Mock,
+        mock_server_handler_class: Mock,
+        mock_console_class: Mock,
+        mock_simple_display_manager_class: Mock,
+    ) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_console = Mock()
+        mock_console_class.return_value = mock_console
+
+        mock_spinner = Mock()
+        mock_spinner.__enter__ = Mock(return_value=None)
+        mock_spinner.__exit__ = Mock(return_value=None)
+        mock_simple_display_manager = Mock()
+        mock_simple_display_manager.spinner.return_value = mock_spinner
+        mock_simple_display_manager_class.return_value = mock_simple_display_manager
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["exec", "my-ws", "--scope", "team-a", "-s", "jupyter", "--", "pwd"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["exec_command"].assert_called_once_with(
+            service="jupyter", command_args=["pwd"], name="my-ws", scope="team-a"
+        )
 
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -916,7 +1030,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "-s", "jupyter", "--", "whoami"])
+        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "whoami"])
 
         # Assert
         self.assertNotEqual(result.exit_code, 0)
@@ -985,7 +1099,7 @@ class TestServerConnectCmd(unittest.TestCase):
         # Assert
         self.assertEqual(result.exit_code, 0)
         mock_server_handler_class.assert_called_once()
-        mock_handler_fns["connect"].assert_called_once_with(service="jupyter")
+        mock_handler_fns["connect"].assert_called_once_with(service="jupyter", name=None, scope=None)
 
     @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.servers_app.Console")
@@ -1016,7 +1130,7 @@ class TestServerConnectCmd(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.exit_code, 0)
-        mock_handler_fns["connect"].assert_called_once_with(service="default")
+        mock_handler_fns["connect"].assert_called_once_with(service="default", name=None, scope=None)
 
     @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
     @patch("jupyter_deploy.cli.servers_app.Console")
@@ -1059,6 +1173,34 @@ class TestServerConnectCmd(unittest.TestCase):
         self.assertTrue("Invalid service" in first_call[1][0])
         self.assertTrue("red" in first_call[2]["style"])
 
+    @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
+    @patch("jupyter_deploy.cli.servers_app.Console")
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_name_and_scope(
+        self,
+        mock_project_dir: Mock,
+        mock_server_handler_class: Mock,
+        mock_console_class: Mock,
+        mock_simple_display_manager_class: Mock,
+    ) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_spinner = Mock()
+        mock_spinner.__enter__ = Mock(return_value=None)
+        mock_spinner.__exit__ = Mock(return_value=None)
+        mock_simple_display_manager = Mock()
+        mock_simple_display_manager.spinner.return_value = mock_spinner
+        mock_simple_display_manager_class.return_value = mock_simple_display_manager
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["connect", "my-ws", "--scope", "team-a", "-s", "jupyter"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["connect"].assert_called_once_with(service="jupyter", name="my-ws", scope="team-a")
+
     @patch("jupyter_deploy.cli.servers_app.Console")
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
@@ -1076,4 +1218,222 @@ class TestServerConnectCmd(unittest.TestCase):
         result = runner.invoke(servers_app, ["connect", "-s", "jupyter"])
 
         # Assert
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestServerListCmd(unittest.TestCase):
+    def get_mock_server_handler(self) -> tuple[Mock, dict[str, Mock]]:
+        mock_list_servers = Mock()
+        mock_server_handler = Mock()
+
+        mock_server_handler.list_servers = mock_list_servers
+        mock_list_servers.return_value = ("ws-1,ws-2", None)
+
+        return mock_server_handler, {
+            "list_servers": mock_list_servers,
+        }
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_instantiates_server_handler_and_calls_list(
+        self, mock_project_dir: Mock, mock_server_handler_class: Mock
+    ) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["list"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_server_handler_class.assert_called_once()
+        mock_handler_fns["list_servers"].assert_called_once_with(scope=None, limit=None, continue_from=None)
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_scope_option(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["list", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["list_servers"].assert_called_once_with(scope="team-a", limit=None, continue_from=None)
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_pagination_options(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["list", "-n", "5", "--continue-from", "token-abc"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["list_servers"].assert_called_once_with(scope=None, limit=5, continue_from="token-abc")
+
+    @patch("jupyter_deploy.cli.servers_app.SimpleDisplayManager")
+    @patch("jupyter_deploy.cli.servers_app.Console")
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_prints_next_token_when_present(
+        self,
+        mock_project_dir: Mock,
+        mock_server_handler_class: Mock,
+        mock_console_class: Mock,
+        mock_simple_display_manager_class: Mock,
+    ) -> None:
+        mock_server_handler = Mock()
+        mock_server_handler.list_servers.return_value = ("ws-1", "next-token-xyz")
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        mock_console = Mock()
+        mock_console_class.return_value = mock_console
+
+        mock_spinner = Mock()
+        mock_spinner.__enter__ = Mock(return_value=None)
+        mock_spinner.__exit__ = Mock(return_value=None)
+        mock_simple_display_manager = Mock()
+        mock_simple_display_manager.spinner.return_value = mock_spinner
+        mock_simple_display_manager_class.return_value = mock_simple_display_manager
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["list", "-n", "1"])
+
+        self.assertEqual(result.exit_code, 0)
+        print_calls = [str(call) for call in mock_console.print.mock_calls]
+        self.assertTrue(any("next-token-xyz" in call for call in print_calls))
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_switches_dir_when_passed_a_project(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, _ = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["list", "--path", "/test/project/path"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/test/project/path"))
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_json_output_with_pagination_token(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler = Mock()
+        mock_server_handler.list_servers.return_value = (["ws-1", "ws-2"], "next-page-token")
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["list", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["servers"], ["ws-1", "ws-2"])
+        self.assertEqual(data["continue_from"], "next-page-token")
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_json_output_without_pagination_token(
+        self, mock_project_dir: Mock, mock_server_handler_class: Mock
+    ) -> None:
+        mock_server_handler = Mock()
+        mock_server_handler.list_servers.return_value = (["ws-1", "ws-2"], None)
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["list", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["servers"], ["ws-1", "ws-2"])
+        self.assertNotIn("continue_from", data)
+
+
+class TestServerShowCmd(unittest.TestCase):
+    def get_mock_server_handler(self) -> tuple[Mock, dict[str, Mock]]:
+        mock_show_server = Mock()
+        mock_server_handler = Mock()
+
+        mock_server_handler.show_server = mock_show_server
+        mock_show_server.return_value = {"name": "my-ws", "resource": '{"spec": {}}'}
+
+        return mock_server_handler, {
+            "show_server": mock_show_server,
+        }
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_instantiates_server_handler_and_calls_show(
+        self, mock_project_dir: Mock, mock_server_handler_class: Mock
+    ) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["show", "my-ws"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_server_handler_class.assert_called_once()
+        mock_handler_fns["show_server"].assert_called_once_with(name="my-ws", scope=None)
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_passes_scope_option(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["show", "my-ws", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler_fns["show_server"].assert_called_once_with(name="my-ws", scope="team-a")
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_requires_name_argument(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, _ = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["show"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_json_output(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler = Mock()
+        mock_server_handler.show_server.return_value = {"name": "my-ws", "resource": '{"spec": {}}'}
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["show", "my-ws", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        data = json.loads(result.stdout)
+        self.assertEqual(data["name"], "my-ws")
+        self.assertIn("resource", data)
+
+    @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_raises_when_handler_raises(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+        mock_server_handler, mock_handler_fns = self.get_mock_server_handler()
+        mock_server_handler_class.return_value = mock_server_handler
+        mock_handler_fns["show_server"].side_effect = Exception("Test error")
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(servers_app, ["show", "my-ws"])
+
         self.assertNotEqual(result.exit_code, 0)

--- a/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
@@ -281,7 +281,7 @@ class TestServerStartCmd(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["start", "my-ws", "--scope", "team-a"])
+        result = runner.invoke(servers_app, ["start", "--name", "my-ws", "--scope", "team-a"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["start_server"].assert_called_once_with("all", name="my-ws", scope="team-a")
@@ -429,7 +429,7 @@ class TestServerStopCmd(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["stop", "my-ws", "--scope", "team-a"])
+        result = runner.invoke(servers_app, ["stop", "--name", "my-ws", "--scope", "team-a"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["stop_server"].assert_called_once_with("all", name="my-ws", scope="team-a")
@@ -577,7 +577,7 @@ class TestServerRestartCmd(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["restart", "my-ws", "--scope", "team-a"])
+        result = runner.invoke(servers_app, ["restart", "--name", "my-ws", "--scope", "team-a"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["restart_server"].assert_called_once_with("all", name="my-ws", scope="team-a")
@@ -754,7 +754,7 @@ class TestServerLogsCmd(unittest.TestCase):
         mock_handler_fns["get_server_logs"].return_value = "some-logs", "", 0
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["logs", "my-ws", "--scope", "team-a"])
+        result = runner.invoke(servers_app, ["logs", "--name", "my-ws", "--scope", "team-a"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["get_server_logs"].assert_called_once_with(
@@ -838,7 +838,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "pwd"])
+        result = runner.invoke(servers_app, ["exec", "--name", "my-ws", "-s", "jupyter", "--", "pwd"])
 
         # Assert
         self.assertEqual(result.exit_code, 0)
@@ -860,7 +860,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "ls", "-la"])
+        result = runner.invoke(servers_app, ["exec", "--name", "my-ws", "-s", "jupyter", "--", "ls", "-la"])
 
         # Assert
         self.assertEqual(result.exit_code, 0)
@@ -897,7 +897,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "whoami"])
+        result = runner.invoke(servers_app, ["exec", "--name", "my-ws", "-s", "jupyter", "--", "whoami"])
 
         # Assert
         self.assertEqual(result.exit_code, 0)
@@ -920,7 +920,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "false"])
+        result = runner.invoke(servers_app, ["exec", "--name", "my-ws", "-s", "jupyter", "--", "false"])
 
         # Assert
         self.assertEqual(result.exit_code, 1)
@@ -936,7 +936,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter"])
+        result = runner.invoke(servers_app, ["exec", "--name", "my-ws", "-s", "jupyter"])
 
         # Assert
         self.assertEqual(result.exit_code, 1)
@@ -973,7 +973,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "invalid_service", "--", "pwd"])
+        result = runner.invoke(servers_app, ["exec", "--name", "my-ws", "-s", "invalid_service", "--", "pwd"])
 
         # Assert
         self.assertEqual(result.exit_code, 1)
@@ -1010,7 +1010,9 @@ class TestServerExecCmd(unittest.TestCase):
         mock_simple_display_manager_class.return_value = mock_simple_display_manager
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "my-ws", "--scope", "team-a", "-s", "jupyter", "--", "pwd"])
+        result = runner.invoke(
+            servers_app, ["exec", "--name", "my-ws", "--scope", "team-a", "-s", "jupyter", "--", "pwd"]
+        )
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["exec_command"].assert_called_once_with(
@@ -1030,7 +1032,7 @@ class TestServerExecCmd(unittest.TestCase):
 
         # Execute
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["exec", "my-ws", "-s", "jupyter", "--", "whoami"])
+        result = runner.invoke(servers_app, ["exec", "--name", "my-ws", "-s", "jupyter", "--", "whoami"])
 
         # Assert
         self.assertNotEqual(result.exit_code, 0)
@@ -1196,7 +1198,7 @@ class TestServerConnectCmd(unittest.TestCase):
         mock_simple_display_manager_class.return_value = mock_simple_display_manager
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["connect", "my-ws", "--scope", "team-a", "-s", "jupyter"])
+        result = runner.invoke(servers_app, ["connect", "--name", "my-ws", "--scope", "team-a", "-s", "jupyter"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["connect"].assert_called_once_with(service="jupyter", name="my-ws", scope="team-a")
@@ -1378,7 +1380,7 @@ class TestServerShowCmd(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["show", "my-ws"])
+        result = runner.invoke(servers_app, ["show", "--name", "my-ws"])
 
         self.assertEqual(result.exit_code, 0)
         mock_server_handler_class.assert_called_once()
@@ -1392,14 +1394,14 @@ class TestServerShowCmd(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["show", "my-ws", "--scope", "team-a"])
+        result = runner.invoke(servers_app, ["show", "--name", "my-ws", "--scope", "team-a"])
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_fns["show_server"].assert_called_once_with(name="my-ws", scope="team-a")
 
     @patch("jupyter_deploy.handlers.resource.server_handler.ServerHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
-    def test_requires_name_argument(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
+    def test_requires_name_option(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
         mock_server_handler, _ = self.get_mock_server_handler()
         mock_server_handler_class.return_value = mock_server_handler
         mock_project_dir.return_value.__enter__.return_value = None
@@ -1418,7 +1420,7 @@ class TestServerShowCmd(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["show", "my-ws", "--json"])
+        result = runner.invoke(servers_app, ["show", "--name", "my-ws", "--json"])
 
         self.assertEqual(result.exit_code, 0)
         data = json.loads(result.stdout)
@@ -1434,6 +1436,6 @@ class TestServerShowCmd(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(servers_app, ["show", "my-ws"])
+        result = runner.invoke(servers_app, ["show", "--name", "my-ws"])
 
         self.assertNotEqual(result.exit_code, 0)

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_open_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_open_handler.py
@@ -1,15 +1,49 @@
-from unittest.mock import patch
-
-import pytest
+import unittest
+from unittest.mock import Mock, patch
 
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.exceptions import UrlNotAvailableError
 from jupyter_deploy.handlers.project.open_handler import OpenHandler
 from jupyter_deploy.manifest import JupyterDeployManifestV1
 
 
-@pytest.fixture
-def mock_manifest() -> JupyterDeployManifestV1:
-    """Create a mock manifest."""
+def _make_open_server_manifest() -> JupyterDeployManifestV1:
+    return _make_manifest(
+        values=[
+            {"name": "open_url", "source": "output", "source-key": "jupyter_url"},
+            {"name": "server_default_scope", "source": "output", "source-key": "server_default_scope"},
+        ],
+        commands=[
+            {
+                "cmd": "open.server",
+                "sequence": [
+                    {
+                        "api-name": "k8s.custom.get",
+                        "arguments": [
+                            {"api-attribute": "group", "source": "output", "source-key": "workspace_crd_group"},
+                            {"api-attribute": "version", "source": "output", "source-key": "workspace_crd_version"},
+                            {"api-attribute": "plural", "source": "output", "source-key": "workspace_crd_plural"},
+                            {"api-attribute": "scope", "source": "cli", "source-key": "scope"},
+                            {"api-attribute": "name", "source": "cli", "source-key": "name"},
+                        ],
+                    }
+                ],
+                "results": [
+                    {
+                        "result-name": "open.server.url",
+                        "source": "result",
+                        "source-key": "[0].Resource",
+                        "extract": "status.accessURL",
+                    }
+                ],
+            }
+        ],
+    )
+
+
+def _make_manifest(
+    values: list[dict[str, str]] | None = None, commands: list[dict] | None = None
+) -> JupyterDeployManifestV1:
     return JupyterDeployManifestV1(
         **{  # type: ignore
             "schema_version": 1,
@@ -18,33 +52,34 @@ def mock_manifest() -> JupyterDeployManifestV1:
                 "engine": "terraform",
                 "version": "1.0.0",
             },
-            "values": [{"name": "open_url", "source": "output", "source-key": "jupyter_url"}],
+            "values": values or [{"name": "open_url", "source": "output", "source-key": "jupyter_url"}],
+            "commands": commands or [],
         }
     )
 
 
-class TestOpenHandler:
-    def test_init(self, mock_manifest: JupyterDeployManifestV1) -> None:
-        """Test that the OpenHandler initializes correctly."""
+class TestOpenHandler(unittest.TestCase):
+    def test_init(self) -> None:
+        mock_manifest = _make_manifest()
         with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve_manifest:
             mock_retrieve_manifest.return_value = mock_manifest
             handler = OpenHandler()
-            assert handler._handler is not None
-            assert handler.engine == EngineType.TERRAFORM
-            assert handler.project_manifest == mock_manifest
+            self.assertIsNotNone(handler._handler)
+            self.assertEqual(handler.engine, EngineType.TERRAFORM)
+            self.assertEqual(handler.project_manifest, mock_manifest)
 
-    def test_get_url_success(self, mock_manifest: JupyterDeployManifestV1) -> None:
-        """Test that get_url returns the correct URL."""
+    def test_get_url_success(self) -> None:
+        mock_manifest = _make_manifest()
         with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve_manifest:
             mock_retrieve_manifest.return_value = mock_manifest
             handler = OpenHandler()
             with patch.object(handler._handler, "get_url", return_value="https://example.com/jupyter") as mock_get_url:
                 url = handler.get_url()
                 mock_get_url.assert_called_once()
-                assert url == "https://example.com/jupyter"
+                self.assertEqual(url, "https://example.com/jupyter")
 
-    def test_open_success(self, mock_manifest: JupyterDeployManifestV1) -> None:
-        """Test that open() successfully opens URL."""
+    def test_open_success(self) -> None:
+        mock_manifest = _make_manifest()
         with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve_manifest:
             mock_retrieve_manifest.return_value = mock_manifest
             handler = OpenHandler()
@@ -53,5 +88,69 @@ class TestOpenHandler:
                 patch("jupyter_deploy.handlers.project.open_handler.webbrowser.open", return_value=True) as mock_open,
             ):
                 url = handler.open()
-                assert url == "https://example.com/jupyter"
+                self.assertEqual(url, "https://example.com/jupyter")
                 mock_open.assert_called_once_with("https://example.com/jupyter", new=2)
+
+    def test_open_with_server_name(self) -> None:
+        mock_manifest = _make_open_server_manifest()
+        with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve:
+            mock_retrieve.return_value = mock_manifest
+            handler = OpenHandler()
+
+            with (
+                patch(
+                    "jupyter_deploy.handlers.project.open_handler.cmd_runner.ManifestCommandRunner"
+                ) as mock_runner_cls,
+                patch("jupyter_deploy.handlers.project.open_handler.webbrowser.open", return_value=True) as mock_open,
+            ):
+                mock_runner = Mock()
+                mock_runner.get_result_value.return_value = "https://example.com/workspaces/team-a/my-ws/"
+                mock_runner_cls.return_value = mock_runner
+
+                url = handler.open(name="my-ws", scope="team-a")
+                self.assertEqual(url, "https://example.com/workspaces/team-a/my-ws/")
+                mock_runner.run_command_sequence.assert_called_once()
+                mock_open.assert_called_once_with("https://example.com/workspaces/team-a/my-ws/", new=2)
+
+    def test_get_server_url_empty_url(self) -> None:
+        mock_manifest = _make_open_server_manifest()
+        with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve:
+            mock_retrieve.return_value = mock_manifest
+            handler = OpenHandler()
+
+            with (
+                patch(
+                    "jupyter_deploy.handlers.project.open_handler.cmd_runner.ManifestCommandRunner"
+                ) as mock_runner_cls,
+            ):
+                mock_runner = Mock()
+                mock_runner.get_result_value.return_value = ""
+                mock_runner_cls.return_value = mock_runner
+
+                with self.assertRaises(UrlNotAvailableError):
+                    handler.get_server_url("my-ws", scope="default")
+
+    def test_resolve_scope_uses_default_from_output(self) -> None:
+        mock_manifest = _make_manifest(
+            values=[
+                {"name": "open_url", "source": "output", "source-key": "jupyter_url"},
+                {"name": "server_default_scope", "source": "output", "source-key": "server_default_scope"},
+            ],
+        )
+        with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve:
+            mock_retrieve.return_value = mock_manifest
+            handler = OpenHandler()
+
+            mock_output_def = Mock()
+            mock_output_def.value = "production-ns"
+            with patch.object(handler._handler.output_handler, "get_declared_output_def", return_value=mock_output_def):
+                result = handler._resolve_scope(None)
+                self.assertEqual(result, "production-ns")
+
+    def test_resolve_scope_explicit_overrides_default(self) -> None:
+        mock_manifest = _make_manifest()
+        with patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest") as mock_retrieve:
+            mock_retrieve.return_value = mock_manifest
+            handler = OpenHandler()
+            result = handler._resolve_scope("custom-ns")
+            self.assertEqual(result, "custom-ns")

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
@@ -33,6 +33,7 @@ class TestHostHandler(unittest.TestCase):
         mock_get_command.return_value = Mock()
         mock_manifest.get_command = mock_get_command
         mock_manifest.get_engine = mock_get_engine
+        mock_manifest.multi_host = False
         return mock_manifest, {"get_command": mock_get_command, "get_engine": mock_get_engine}
 
     def get_mock_outputs_handler_and_fns(self) -> tuple[Mock, dict[str, Mock]]:
@@ -118,7 +119,13 @@ class TestHostHandler(unittest.TestCase):
         handler = HostHandler(display_manager=NullDisplay())
 
         with self.assertRaises(NotImplementedError):
+            handler.list_hosts("")
+
+        with self.assertRaises(NotImplementedError):
             handler.get_host_status()
+
+        with self.assertRaises(NotImplementedError):
+            handler.show_host("node-1")
 
         with self.assertRaises(NotImplementedError):
             handler.start_host()
@@ -257,6 +264,185 @@ class TestHostHandler(unittest.TestCase):
         # add only commands that return a result here
         with self.assertRaises(KeyError):
             handler.get_host_status()
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_list_hosts_calls_run_command_and_return_result(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        # Setup
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_output_handler, _ = self.get_mock_outputs_handler_and_fns()
+
+        mock_tf_outputs_handler.return_value = mock_output_handler
+        mock_variable_handler = Mock()
+        mock_tf_variables_handler.return_value = mock_variable_handler
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].return_value = ["node-1", "node-2"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = ""
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        # Act
+        handler = HostHandler(display_manager=NullDisplay())
+        result, next_token = handler.list_hosts(query="")
+
+        # Verify
+        self.assertEqual(result, ["node-1", "node-2"])
+        self.assertIsNone(next_token)
+        mock_manifest_fns["get_command"].assert_called_once_with("host.list")
+        mock_cmd_runner_fns["run_command_sequence"].assert_called_once()
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("query", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["query"].value, "")
+        mock_cmd_runner_fns["get_result_value"].assert_called_once_with(mock_cmd, "host.list", list)
+        mock_cmd_runner_fns["get_result_value_with_fallback"].assert_called_once_with(
+            mock_cmd, "host.list.next_token", str, ""
+        )
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_list_hosts_passes_pagination_params(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].return_value = ["node-1"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = "abc123"
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = HostHandler(display_manager=NullDisplay())
+        result, next_token = handler.list_hosts(query="", limit=10, continue_from="token-xyz")
+
+        self.assertEqual(result, ["node-1"])
+        self.assertEqual(next_token, "abc123")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("limit", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["limit"].value, "10")
+        self.assertIn("continue_from", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["continue_from"].value, "token-xyz")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_list_hosts_defaults_pagination_params_when_not_provided(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].return_value = "node-1"
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = ""
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = HostHandler(display_manager=NullDisplay())
+        handler.list_hosts(query="")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["limit"].value, "")
+        self.assertEqual(cli_paramdefs["continue_from"].value, "")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_show_host_calls_run_command_and_return_details(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        # Setup — use the real manifest so _collect_results iterates actual result defs
+        mock_retrieve_manifest.return_value = self.mock_full_manifest
+        mock_output_handler, _ = self.get_mock_outputs_handler_and_fns()
+
+        mock_tf_outputs_handler.return_value = mock_output_handler
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value_with_fallback"].side_effect = [
+            "node-1",
+            "Ready",
+            '{"metadata": {"name": "node-1"}}',
+        ]
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        # Act
+        handler = HostHandler(display_manager=NullDisplay())
+        result = handler.show_host(name="node-1")
+
+        # Verify — keys come from manifest result-name with "host.show." prefix stripped
+        self.assertEqual(result["name"], "node-1")
+        self.assertEqual(result["status"], "Ready")
+        self.assertEqual(result["resource"], {"metadata": {"name": "node-1"}})
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "node-1")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_get_host_status_with_name_passes_cli_param(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        # Setup
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        # Act
+        handler = HostHandler(display_manager=NullDisplay())
+        handler.get_host_status(name="node-1")
+
+        # Verify
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "node-1")
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
@@ -549,6 +735,117 @@ class TestHostHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value_with_fallback"].assert_called_once_with(
             mock_cmd, "host.exec.returncode", int, 0
         )
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_start_host_passes_name(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = HostHandler(display_manager=NullDisplay())
+        handler.start_host(name="node-1")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "node-1")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_stop_host_passes_name(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = HostHandler(display_manager=NullDisplay())
+        handler.stop_host(name="node-1")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "node-1")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_connect_passes_name(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = HostHandler(display_manager=NullDisplay())
+        handler.connect(name="node-1")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "node-1")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_exec_command_passes_name(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].side_effect = ["stdout", "stderr"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 0
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = HostHandler(display_manager=NullDisplay())
+        handler.exec_command(["pwd"], name="node-1")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "node-1")
+        self.assertIn("commands", cli_paramdefs)
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_resource_utils.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_resource_utils.py
@@ -1,0 +1,183 @@
+import json
+import unittest
+from unittest.mock import Mock
+
+from jupyter_deploy.handlers.resource.resource_utils import collect_results, evaluate_status_rules, resolve_path
+from jupyter_deploy.manifest import JupyterDeployStatusRuleMatchV1, JupyterDeployStatusRuleV1
+
+
+class TestResolvePath(unittest.TestCase):
+    def test_simple_dot_access(self) -> None:
+        resource = {"spec": {"desiredStatus": "Running"}}
+        self.assertEqual(resolve_path(resource, ".spec.desiredStatus"), "Running")
+
+    def test_array_filter(self) -> None:
+        resource = {"status": {"conditions": [{"type": "Available", "status": "True"}]}}
+        self.assertEqual(resolve_path(resource, ".status.conditions[type=Available].status"), "True")
+
+    def test_array_filter_no_match(self) -> None:
+        resource = {"status": {"conditions": [{"type": "Available", "status": "True"}]}}
+        self.assertIsNone(resolve_path(resource, ".status.conditions[type=Degraded].status"))
+
+    def test_missing_key(self) -> None:
+        self.assertIsNone(resolve_path({}, ".spec.desiredStatus"))
+
+    def test_non_string_leaf(self) -> None:
+        resource = {"spec": {"replicas": 3}}
+        self.assertIsNone(resolve_path(resource, ".spec.replicas"))
+
+    def test_non_dict_root(self) -> None:
+        self.assertIsNone(resolve_path({"status": "a string"}, ".status.field"))
+
+
+class TestEvaluateStatusRules(unittest.TestCase):
+    RULES = [
+        JupyterDeployStatusRuleV1(
+            display="Degraded",
+            all=[JupyterDeployStatusRuleMatchV1(path=".status.conditions[type=Degraded].status", equals="True")],
+        ),
+        JupyterDeployStatusRuleV1(
+            display="Starting",
+            all=[
+                JupyterDeployStatusRuleMatchV1(path=".status.conditions[type=Progressing].status", equals="True"),
+                JupyterDeployStatusRuleMatchV1(path=".spec.desiredStatus", equals="Running"),
+            ],
+        ),
+        JupyterDeployStatusRuleV1(
+            display="Stopping",
+            all=[
+                JupyterDeployStatusRuleMatchV1(path=".status.conditions[type=Progressing].status", equals="True"),
+                JupyterDeployStatusRuleMatchV1(path=".spec.desiredStatus", equals="Stopped"),
+            ],
+        ),
+        JupyterDeployStatusRuleV1(
+            display="Stopped",
+            all=[JupyterDeployStatusRuleMatchV1(path=".status.conditions[type=Stopped].status", equals="True")],
+        ),
+        JupyterDeployStatusRuleV1(
+            display="Running",
+            all=[JupyterDeployStatusRuleMatchV1(path=".status.conditions[type=Available].status", equals="True")],
+        ),
+    ]
+
+    def test_running(self) -> None:
+        resource = json.dumps(
+            {
+                "status": {
+                    "conditions": [{"type": "Available", "status": "True"}, {"type": "Stopped", "status": "False"}]
+                }
+            }
+        )
+        self.assertEqual(evaluate_status_rules(resource, self.RULES), "Running")
+
+    def test_stopped(self) -> None:
+        resource = json.dumps(
+            {
+                "status": {
+                    "conditions": [{"type": "Available", "status": "False"}, {"type": "Stopped", "status": "True"}]
+                }
+            }
+        )
+        self.assertEqual(evaluate_status_rules(resource, self.RULES), "Stopped")
+
+    def test_starting(self) -> None:
+        resource = json.dumps(
+            {
+                "spec": {"desiredStatus": "Running"},
+                "status": {
+                    "conditions": [{"type": "Progressing", "status": "True"}, {"type": "Stopped", "status": "False"}]
+                },
+            }
+        )
+        self.assertEqual(evaluate_status_rules(resource, self.RULES), "Starting")
+
+    def test_stopping(self) -> None:
+        resource = json.dumps(
+            {
+                "spec": {"desiredStatus": "Stopped"},
+                "status": {
+                    "conditions": [{"type": "Progressing", "status": "True"}, {"type": "Available", "status": "False"}]
+                },
+            }
+        )
+        self.assertEqual(evaluate_status_rules(resource, self.RULES), "Stopping")
+
+    def test_degraded(self) -> None:
+        resource = json.dumps(
+            {
+                "status": {
+                    "conditions": [{"type": "Available", "status": "True"}, {"type": "Degraded", "status": "True"}]
+                }
+            }
+        )
+        self.assertEqual(evaluate_status_rules(resource, self.RULES), "Degraded")
+
+    def test_unknown_on_no_match(self) -> None:
+        resource = json.dumps({"status": {"conditions": []}})
+        self.assertEqual(evaluate_status_rules(resource, self.RULES), "Unknown")
+
+    def test_unknown_on_invalid_json(self) -> None:
+        self.assertEqual(evaluate_status_rules("not-json", self.RULES), "Unknown")
+
+    def test_unknown_on_empty_string(self) -> None:
+        self.assertEqual(evaluate_status_rules("", self.RULES), "Unknown")
+
+
+class TestCollectResults(unittest.TestCase):
+    def test_collects_and_strips_prefix(self) -> None:
+        mock_runner = Mock()
+        mock_runner.get_result_value_with_fallback.side_effect = ["my-ws", '{"spec": {}}']
+
+        mock_result_def_1 = Mock()
+        mock_result_def_1.result_name = "server.show.name"
+        mock_result_def_2 = Mock()
+        mock_result_def_2.result_name = "server.show.resource"
+
+        mock_command = Mock()
+        mock_command.cmd = "server.show"
+        mock_command.results = [mock_result_def_1, mock_result_def_2]
+
+        result = collect_results(mock_runner, mock_command)
+
+        self.assertEqual(result["name"], "my-ws")
+        self.assertEqual(result["resource"], {"spec": {}})
+
+    def test_returns_empty_dict_when_no_results(self) -> None:
+        mock_runner = Mock()
+        mock_command = Mock()
+        mock_command.cmd = "server.show"
+        mock_command.results = None
+
+        result = collect_results(mock_runner, mock_command)
+
+        self.assertEqual(result, {})
+
+    def test_non_json_values_returned_as_strings(self) -> None:
+        mock_runner = Mock()
+        mock_runner.get_result_value_with_fallback.return_value = "plain-text"
+
+        mock_result_def = Mock()
+        mock_result_def.result_name = "host.show.status"
+
+        mock_command = Mock()
+        mock_command.cmd = "host.show"
+        mock_command.results = [mock_result_def]
+
+        result = collect_results(mock_runner, mock_command)
+
+        self.assertEqual(result["status"], "plain-text")
+
+    def test_json_list_values_are_parsed(self) -> None:
+        mock_runner = Mock()
+        mock_runner.get_result_value_with_fallback.return_value = '["a", "b"]'
+
+        mock_result_def = Mock()
+        mock_result_def.result_name = "host.show.items"
+
+        mock_command = Mock()
+        mock_command.cmd = "host.show"
+        mock_command.results = [mock_result_def]
+
+        result = collect_results(mock_runner, mock_command)
+
+        self.assertEqual(result["items"], ["a", "b"])

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_server_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_server_handler.py
@@ -8,7 +8,10 @@ import yaml
 from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.handlers.resource.server_handler import ServerHandler
-from jupyter_deploy.manifest import JupyterDeployManifest, JupyterDeployManifestV1
+from jupyter_deploy.manifest import (
+    JupyterDeployManifest,
+    JupyterDeployManifestV1,
+)
 
 
 class TestServerHandler(unittest.TestCase):
@@ -36,6 +39,8 @@ class TestServerHandler(unittest.TestCase):
         mock_manifest.get_command = mock_get_command
         mock_manifest.get_engine = mock_get_engine
         mock_manifest.get_validated_service = mock_get_validated_service
+        mock_manifest.server_status_rules = None
+        mock_manifest.multi_server = False
         return mock_manifest, {
             "get_command": mock_get_command,
             "get_engine": mock_get_engine,
@@ -43,8 +48,13 @@ class TestServerHandler(unittest.TestCase):
         }
 
     def get_mock_outputs_handler_and_fns(self) -> tuple[Mock, dict[str, Mock]]:
-        """Return mock output handler with functions defined as mock."""
+        """Return mock output handler with functions defined as mock.
+
+        get_declared_output_def raises NotImplementedError so _resolve_scope
+        falls back to "default" when no scope is provided.
+        """
         mock_output_handler = Mock()
+        mock_output_handler.get_declared_output_def.side_effect = NotImplementedError
         return mock_output_handler, {}
 
     def get_mock_manifest_cmd_runner_and_fns(self) -> tuple[Mock, dict[str, Mock]]:
@@ -125,7 +135,13 @@ class TestServerHandler(unittest.TestCase):
         handler = ServerHandler(display_manager=NullDisplay())
 
         with self.assertRaises(NotImplementedError):
+            handler.list_servers("default")
+
+        with self.assertRaises(NotImplementedError):
             handler.get_server_status()
+
+        with self.assertRaises(NotImplementedError):
+            handler.show_server("my-ws", "default")
 
         with self.assertRaises(NotImplementedError):
             handler.start_server("all")
@@ -164,7 +180,9 @@ class TestServerHandler(unittest.TestCase):
         # Test get_server_status
         status = handler.get_server_status()
         self.assertEqual(status, "IN_SERVICE")
-        mock_cmd_runner_fns["run_command_sequence"].assert_called_with(mock.ANY, cli_paramdefs={})
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
         mock_cmd_runner_fns["get_result_value"].assert_called_with(mock.ANY, "server.status", str)
 
         # Test start_server
@@ -268,6 +286,187 @@ class TestServerHandler(unittest.TestCase):
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
     @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_list_servers_calls_run_command_and_return_result(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        # Setup
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_output_handler, _ = self.get_mock_outputs_handler_and_fns()
+
+        mock_tf_outputs_handler.return_value = mock_output_handler
+        mock_variable_handler = Mock()
+        mock_tf_variables_handler.return_value = mock_variable_handler
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].return_value = ["ws-1", "ws-2"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = ""
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        # Act
+        handler = ServerHandler(display_manager=NullDisplay())
+        result, next_token = handler.list_servers(scope="default")
+
+        # Verify
+        self.assertEqual(result, ["ws-1", "ws-2"])
+        self.assertIsNone(next_token)
+        mock_manifest_fns["get_command"].assert_called_once_with("server.list")
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
+        mock_cmd_runner_fns["get_result_value"].assert_called_once_with(mock_cmd, "server.list", list)
+        mock_cmd_runner_fns["get_result_value_with_fallback"].assert_called_once_with(
+            mock_cmd, "server.list.next_token", str, ""
+        )
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_list_servers_passes_pagination_params(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].return_value = ["ws-1"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = "next-abc"
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ServerHandler(display_manager=NullDisplay())
+        result, next_token = handler.list_servers(scope="default", limit=5, continue_from="token-xyz")
+
+        self.assertEqual(result, ["ws-1"])
+        self.assertEqual(next_token, "next-abc")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("limit", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["limit"].value, "5")
+        self.assertIn("continue_from", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["continue_from"].value, "token-xyz")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_list_servers_defaults_pagination_params_when_not_provided(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].return_value = "ws-1"
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = ""
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ServerHandler(display_manager=NullDisplay())
+        handler.list_servers(scope="default")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["limit"].value, "")
+        self.assertEqual(cli_paramdefs["continue_from"].value, "")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_show_server_calls_run_command_and_return_details(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        # Setup — use the real manifest so _collect_results iterates actual result defs
+        mock_retrieve_manifest.return_value = self.mock_full_manifest
+        mock_output_handler, _ = self.get_mock_outputs_handler_and_fns()
+
+        mock_tf_outputs_handler.return_value = mock_output_handler
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value_with_fallback"].side_effect = [
+            "my-ws",
+            '{"spec": {}}',
+        ]
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        # Act
+        handler = ServerHandler(display_manager=NullDisplay())
+        result = handler.show_server(name="my-ws", scope="default")
+
+        # Verify — keys come from manifest result-name with "server.show." prefix stripped
+        self.assertEqual(result["name"], "my-ws")
+        self.assertEqual(result["resource"], {"spec": {}})
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "my-ws")
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_get_server_status_with_name_and_scope(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        # Setup
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        # Act
+        handler = ServerHandler(display_manager=NullDisplay())
+        handler.get_server_status(name="my-ws", scope="team-a")
+
+        # Verify
+        mock_manifest_fns["get_command"].assert_called_once_with("server.status")
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "my-ws")
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "team-a")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
     def test_get_status_calls_run_command_and_return_result(
         self,
         mock_cmd_runner_class: Mock,
@@ -300,7 +499,9 @@ class TestServerHandler(unittest.TestCase):
         mock_manifest_fns["get_command"].assert_called_once_with("server.status")
         self.assertEqual(mock_cmd_runner_class.call_args[1]["output_handler"], mock_output_handler)
         self.assertEqual(mock_cmd_runner_class.call_args[1]["variable_handler"], mock_variable_handler)
-        mock_cmd_runner_fns["run_command_sequence"].assert_called_once_with(mock_cmd, cli_paramdefs={})
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
         mock_cmd_runner_fns["get_result_value"].assert_called_once_with(mock_cmd, "server.status", str)
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
@@ -343,13 +544,46 @@ class TestServerHandler(unittest.TestCase):
 
         # Check that StrResolvedCliParameter objects are created correctly
         cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
-        self.assertEqual(len(cli_paramdefs), 2)
         self.assertIn("action", cli_paramdefs)
         self.assertIn("service", cli_paramdefs)
+        self.assertIn("scope", cli_paramdefs)
         self.assertEqual(cli_paramdefs["action"].parameter_name, "action")
         self.assertEqual(cli_paramdefs["action"].value, "start")
         self.assertEqual(cli_paramdefs["service"].parameter_name, "service")
         self.assertEqual(cli_paramdefs["service"].value, "all")
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_start_server_passes_name_and_scope(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_manifest_fns["get_validated_service"].return_value = "jupyter"
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ServerHandler(display_manager=NullDisplay())
+        handler.start_server("jupyter", name="my-ws", scope="team-a")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "my-ws")
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "team-a")
+        self.assertIn("service", cli_paramdefs)
+        self.assertIn("action", cli_paramdefs)
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
@@ -391,13 +625,14 @@ class TestServerHandler(unittest.TestCase):
 
         # Check CLI parameters
         cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
-        self.assertEqual(len(cli_paramdefs), 2)
         self.assertIn("action", cli_paramdefs)
         self.assertIn("service", cli_paramdefs)
+        self.assertIn("scope", cli_paramdefs)
         self.assertEqual(cli_paramdefs["action"].parameter_name, "action")
         self.assertEqual(cli_paramdefs["action"].value, "stop")
         self.assertEqual(cli_paramdefs["service"].parameter_name, "service")
         self.assertEqual(cli_paramdefs["service"].value, "jupyter")
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
@@ -439,13 +674,14 @@ class TestServerHandler(unittest.TestCase):
 
         # Check CLI parameters
         cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
-        self.assertEqual(len(cli_paramdefs), 2)
         self.assertIn("action", cli_paramdefs)
         self.assertIn("service", cli_paramdefs)
+        self.assertIn("scope", cli_paramdefs)
         self.assertEqual(cli_paramdefs["action"].parameter_name, "action")
         self.assertEqual(cli_paramdefs["action"].value, "restart")
         self.assertEqual(cli_paramdefs["service"].parameter_name, "service")
         self.assertEqual(cli_paramdefs["service"].value, "sidecars")
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
@@ -498,13 +734,46 @@ class TestServerHandler(unittest.TestCase):
 
         # Check CLI parameters
         cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
-        self.assertEqual(len(cli_paramdefs), 2)
         self.assertIn("extra", cli_paramdefs)
         self.assertIn("service", cli_paramdefs)
+        self.assertIn("scope", cli_paramdefs)
         self.assertEqual(cli_paramdefs["extra"].parameter_name, "extra")
         self.assertEqual(cli_paramdefs["extra"].value, "-n 200")
         self.assertEqual(cli_paramdefs["service"].parameter_name, "service")
         self.assertEqual(cli_paramdefs["service"].value, "oauth")
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_get_server_logs_passes_name_and_scope(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_manifest_fns["get_validated_service"].return_value = "jupyter"
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].side_effect = ["logs", "errors"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 0
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ServerHandler(display_manager=NullDisplay())
+        handler.get_server_logs("jupyter", [], name="my-ws", scope="team-a")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "my-ws")
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "team-a")
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
@@ -554,13 +823,14 @@ class TestServerHandler(unittest.TestCase):
 
         # Check CLI parameters
         cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
-        self.assertEqual(len(cli_paramdefs), 2)
         self.assertIn("commands", cli_paramdefs)
         self.assertIn("service", cli_paramdefs)
+        self.assertIn("scope", cli_paramdefs)
         self.assertEqual(cli_paramdefs["commands"].parameter_name, "commands")
         self.assertEqual(cli_paramdefs["commands"].value, "whoami")
         self.assertEqual(cli_paramdefs["service"].parameter_name, "service")
         self.assertEqual(cli_paramdefs["service"].value, "jupyter")
+        self.assertEqual(cli_paramdefs["scope"].value, "default")
 
         # Verify get_result_value was called for stdout and stderr
         self.assertEqual(mock_cmd_runner_fns["get_result_value"].call_count, 2)
@@ -621,3 +891,65 @@ class TestServerHandler(unittest.TestCase):
         mock_cmd_runner_fns["get_result_value_with_fallback"].assert_called_once_with(
             mock_cmd, "server.exec.returncode", int, 0
         )
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_exec_command_passes_name_and_scope(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_manifest_fns["get_validated_service"].return_value = "jupyter"
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].side_effect = ["stdout", "stderr"]
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = 0
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ServerHandler(display_manager=NullDisplay())
+        handler.exec_command(service="jupyter", command_args=["pwd"], name="my-ws", scope="team-a")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "my-ws")
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "team-a")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_connect_passes_name_and_scope(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_manifest_fns["get_command"].return_value = Mock()
+        mock_manifest_fns["get_validated_service"].return_value = "jupyter"
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ServerHandler(display_manager=NullDisplay())
+        handler.connect(service="jupyter", name="my-ws", scope="team-a")
+
+        cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
+        self.assertIn("name", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "my-ws")
+        self.assertIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["scope"].value, "team-a")

--- a/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
+++ b/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
@@ -13,6 +13,9 @@ values:
   - name: "aws_region"
     source: "output"
     source-key: "region"
+  - name: "server_default_scope"
+    source: "output"
+    source-key: "server_default_scope"
 services:
   - jupyter
   - traefik
@@ -103,6 +106,80 @@ commands:
       - result-name: "host.exec.returncode"
         source: "result"
         source-key: "[0].ResponseCode"
+  - cmd: "host.list"
+    sequence:
+      - api-name: "aws.ec2.describe-instances"
+        arguments:
+          - api-attribute: "query"
+            source: "cli"
+            source-key: "query"
+          - api-attribute: "page_size"
+            source: "cli"
+            source-key: "limit"
+          - api-attribute: "pagination_token"
+            source: "cli"
+            source-key: "continue_from"
+    results:
+      - result-name: "host.list"
+        source: "result"
+        source-key: "[0].InstanceIds"
+      - result-name: "host.list.next_token"
+        source: "result"
+        source-key: "[0].NextToken"
+  - cmd: "host.show"
+    sequence:
+      - api-name: "aws.ec2.describe-instance"
+        arguments:
+          - api-attribute: "name"
+            source: "cli"
+            source-key: "name"
+    results:
+      - result-name: "host.show.name"
+        source: "result"
+        source-key: "[0].Name"
+      - result-name: "host.show.status"
+        source: "result"
+        source-key: "[0].Status"
+      - result-name: "host.show.resource"
+        source: "result"
+        source-key: "[0].Resource"
+  - cmd: "server.show"
+    sequence:
+      - api-name: "aws.ssm.wait-command-sync"
+        arguments:
+          - api-attribute: "name"
+            source: "cli"
+            source-key: "name"
+          - api-attribute: "scope"
+            source: "cli"
+            source-key: "scope"
+    results:
+      - result-name: "server.show.name"
+        source: "result"
+        source-key: "[0].Name"
+      - result-name: "server.show.resource"
+        source: "result"
+        source-key: "[0].Resource"
+  - cmd: "server.list"
+    sequence:
+      - api-name: "aws.ssm.wait-command-sync"
+        arguments:
+          - api-attribute: "scope"
+            source: "cli"
+            source-key: "scope"
+          - api-attribute: "page_size"
+            source: "cli"
+            source-key: "limit"
+          - api-attribute: "pagination_token"
+            source: "cli"
+            source-key: "continue_from"
+    results:
+      - result-name: "server.list"
+        source: "result"
+        source-key: "[0].Names"
+      - result-name: "server.list.next_token"
+        source: "result"
+        source-key: "[0].NextToken"
   - cmd: "server.status"
     sequence:
       - api-name: "aws.ssm.wait-command-sync"
@@ -491,6 +568,30 @@ commands:
       - result-name: "organization.get"
         source: "result"
         source-key: "[0].StandardOutputContent"
+  - cmd: "open.server"
+    sequence:
+      - api-name: "k8s.custom.get"
+        arguments:
+          - api-attribute: "group"
+            source: "output"
+            source-key: "workspace_crd_group"
+          - api-attribute: "version"
+            source: "output"
+            source-key: "workspace_crd_version"
+          - api-attribute: "plural"
+            source: "output"
+            source-key: "workspace_crd_plural"
+          - api-attribute: "scope"
+            source: "cli"
+            source-key: "scope"
+          - api-attribute: "name"
+            source: "cli"
+            source-key: "name"
+    results:
+      - result-name: "open.server.url"
+        source: "result"
+        source-key: "[0].Resource"
+        extract: "status.accessURL"
 secrets:
   - name: oauth_app_client_secret
     source: output

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_client_factory.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_client_factory.py
@@ -1,3 +1,5 @@
+import base64
+import os
 import unittest
 from unittest.mock import Mock, patch
 
@@ -24,3 +26,82 @@ class TestK8sClientFactory(unittest.TestCase):
 
         self.assertEqual(result, mock_api_client)
         mock_config.new_client_from_config.assert_called_once_with(config_file=None)
+
+
+class TestK8sClientFactoryFromEks(unittest.TestCase):
+    @patch("jupyter_deploy.api.aws.sts.eks_token.get_eks_bearer_token")
+    @patch("jupyter_deploy.provider.k8s.k8s_client_factory.client")
+    def test_from_eks_cluster_configures_endpoint_and_auth(self, mock_client_mod: Mock, mock_get_token: Mock) -> None:
+        mock_get_token.return_value = "k8s-aws-v1.test-token"
+        mock_configuration: Mock = Mock()
+        mock_configuration.api_key = {}
+        mock_configuration.api_key_prefix = {}
+        mock_client_mod.Configuration.return_value = mock_configuration
+        mock_api_client: Mock = Mock()
+        mock_client_mod.ApiClient.return_value = mock_api_client
+
+        ca_data = base64.b64encode(b"FAKE-CA-CERT").decode()
+
+        result = K8sClientFactory.from_eks_cluster(
+            endpoint="https://example.eks.amazonaws.com",
+            ca_data_b64=ca_data,
+            cluster_name="my-cluster",
+            region="us-west-2",
+        )
+
+        self.assertEqual(result, mock_api_client)
+        self.assertEqual(mock_configuration.host, "https://example.eks.amazonaws.com")
+        self.assertEqual(mock_configuration.api_key_prefix["authorization"], "Bearer")
+        self.assertEqual(mock_configuration.api_key["authorization"], "k8s-aws-v1.test-token")
+        mock_get_token.assert_called_once_with("my-cluster", "us-west-2")
+
+    @patch("jupyter_deploy.api.aws.sts.eks_token.get_eks_bearer_token")
+    @patch("jupyter_deploy.provider.k8s.k8s_client_factory.client")
+    def test_from_eks_cluster_writes_ca_cert_to_temp_file(self, mock_client_mod: Mock, mock_get_token: Mock) -> None:
+        mock_get_token.return_value = "k8s-aws-v1.test-token"
+        mock_configuration: Mock = Mock()
+        mock_configuration.api_key = {}
+        mock_configuration.api_key_prefix = {}
+        mock_client_mod.Configuration.return_value = mock_configuration
+        mock_client_mod.ApiClient.return_value = Mock()
+
+        ca_content = b"-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----"
+        ca_data = base64.b64encode(ca_content).decode()
+
+        K8sClientFactory.from_eks_cluster(
+            endpoint="https://example.eks.amazonaws.com",
+            ca_data_b64=ca_data,
+            cluster_name="my-cluster",
+            region="us-west-2",
+        )
+
+        ca_path = mock_configuration.ssl_ca_cert
+        self.assertTrue(os.path.exists(ca_path))
+        with open(ca_path, "rb") as f:
+            self.assertEqual(f.read(), ca_content)
+        os.unlink(ca_path)
+
+    @patch("jupyter_deploy.api.aws.sts.eks_token.get_eks_bearer_token")
+    @patch("jupyter_deploy.provider.k8s.k8s_client_factory.client")
+    def test_from_eks_cluster_sets_refresh_hook(self, mock_client_mod: Mock, mock_get_token: Mock) -> None:
+        mock_get_token.return_value = "k8s-aws-v1.initial-token"
+        mock_configuration: Mock = Mock()
+        mock_configuration.api_key = {}
+        mock_configuration.api_key_prefix = {}
+        mock_client_mod.Configuration.return_value = mock_configuration
+        mock_client_mod.ApiClient.return_value = Mock()
+
+        ca_data = base64.b64encode(b"FAKE").decode()
+
+        K8sClientFactory.from_eks_cluster(
+            endpoint="https://example.eks.amazonaws.com",
+            ca_data_b64=ca_data,
+            cluster_name="my-cluster",
+            region="us-west-2",
+        )
+
+        self.assertIsNotNone(mock_configuration.refresh_api_key_hook)
+
+        mock_get_token.return_value = "k8s-aws-v1.refreshed-token"
+        mock_configuration.refresh_api_key_hook(mock_configuration)
+        self.assertEqual(mock_configuration.api_key["authorization"], "k8s-aws-v1.refreshed-token")

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_core_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_core_runner.py
@@ -1,19 +1,20 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from jupyter_deploy.api.k8s.core import NodeConditionStatus, NodeInfo, PodInfo, PodPhase
+from jupyter_deploy.api.k8s.core import ExecResult, NodeConditionStatus, NodeInfo, PodInfo, PodPhase
 from jupyter_deploy.engine.supervised_execution import NullDisplay
-from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.exceptions import InstructionNotFoundError, InteractiveSessionError, InteractiveSessionTimeoutError
 from jupyter_deploy.provider.k8s.k8s_core_runner import K8sCoreRunner
 from jupyter_deploy.provider.resolved_argdefs import StrResolvedInstructionArgument
 
 
 class TestK8sCoreRunner(unittest.TestCase):
-    def _make_runner(self) -> K8sCoreRunner:
+    def _make_runner(self, kubeconfig_path: str | None = None) -> K8sCoreRunner:
         mock_api_client: Mock = Mock()
         with patch("jupyter_deploy.provider.k8s.k8s_core_runner.client") as mock_client_mod:
             mock_client_mod.CoreV1Api.return_value = Mock()
-            return K8sCoreRunner(NullDisplay(), api_client=mock_api_client)
+            mock_client_mod.AppsV1Api.return_value = Mock()
+            return K8sCoreRunner(NullDisplay(), api_client=mock_api_client, kubeconfig_path=kubeconfig_path)
 
     @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
     def test_list_nodes_returns_names_and_count(self, mock_k8s_core: Mock) -> None:
@@ -28,7 +29,7 @@ class TestK8sCoreRunner(unittest.TestCase):
 
         result = runner.execute_instruction(instruction_name="list-nodes", resolved_arguments={})
 
-        self.assertEqual(result["NodeNames"].value, "node-1,node-2")
+        self.assertEqual(result["NodeNames"].value, ["node-1", "node-2"])
         self.assertEqual(result["NextToken"].value, "")
         mock_k8s_core.list_nodes.assert_called_once_with(
             runner.core_api, label_selector=None, limit=None, _continue=None
@@ -87,7 +88,9 @@ class TestK8sCoreRunner(unittest.TestCase):
     @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
     def test_get_node_ready(self, mock_k8s_core: Mock) -> None:
         runner = self._make_runner()
-        mock_k8s_core.get_node.return_value = NodeInfo(name="node-1", status=NodeConditionStatus.READY)
+        mock_k8s_core.get_node.return_value = NodeInfo(
+            name="node-1", status=NodeConditionStatus.READY, resource={"metadata": {"name": "node-1"}}
+        )
 
         result = runner.execute_instruction(
             instruction_name="get-node",
@@ -98,6 +101,7 @@ class TestK8sCoreRunner(unittest.TestCase):
 
         self.assertEqual(result["Name"].value, "node-1")
         self.assertEqual(result["Status"].value, "Ready")
+        self.assertEqual(result["Resource"].value, '{"metadata": {"name": "node-1"}}')
 
     @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
     def test_get_node_not_ready(self, mock_k8s_core: Mock) -> None:
@@ -112,6 +116,7 @@ class TestK8sCoreRunner(unittest.TestCase):
         )
 
         self.assertEqual(result["Status"].value, "NotReady")
+        self.assertEqual(result["Resource"].value, "{}")
 
     @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
     def test_list_pods_returns_names_and_count(self, mock_k8s_core: Mock) -> None:
@@ -190,6 +195,250 @@ class TestK8sCoreRunner(unittest.TestCase):
 
         self.assertEqual(result["Name"].value, "pod-1")
         self.assertEqual(result["Phase"].value, "Running")
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_deployment_logs_returns_logs(self, mock_k8s_core: Mock) -> None:
+        runner = self._make_runner()
+        mock_k8s_core.get_deployment_logs.return_value = "log output"
+
+        result = runner.execute_instruction(
+            instruction_name="deployment-logs",
+            resolved_arguments={
+                "name": StrResolvedInstructionArgument(argument_name="name", value="my-deploy"),
+                "scope": StrResolvedInstructionArgument(argument_name="scope", value="default"),
+            },
+        )
+
+        self.assertEqual(result["Logs"].value, "log output")
+        mock_k8s_core.get_deployment_logs.assert_called_once_with(
+            runner.core_api,
+            runner.apps_api,
+            name="my-deploy",
+            namespace="default",
+            container=None,
+            tail_lines=None,
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_deployment_logs_passes_container_and_tail_lines(self, mock_k8s_core: Mock) -> None:
+        runner = self._make_runner()
+        mock_k8s_core.get_deployment_logs.return_value = "log"
+
+        runner.execute_instruction(
+            instruction_name="deployment-logs",
+            resolved_arguments={
+                "name": StrResolvedInstructionArgument(argument_name="name", value="my-deploy"),
+                "scope": StrResolvedInstructionArgument(argument_name="scope", value="ns"),
+                "container": StrResolvedInstructionArgument(argument_name="container", value="main"),
+                "tail_lines": StrResolvedInstructionArgument(argument_name="tail_lines", value="50"),
+            },
+        )
+
+        mock_k8s_core.get_deployment_logs.assert_called_once_with(
+            runner.core_api,
+            runner.apps_api,
+            name="my-deploy",
+            namespace="ns",
+            container="main",
+            tail_lines=50,
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_exec_pod_with_deployment_name_resolves_pod(self, mock_k8s_core: Mock) -> None:
+        runner = self._make_runner()
+        mock_deployment: Mock = Mock()
+        mock_deployment.spec.selector.match_labels = {"app": "ws"}
+        mock_apps_api: Mock = runner.apps_api  # type: ignore[assignment]
+        mock_apps_api.read_namespaced_deployment.return_value = mock_deployment
+        mock_k8s_core.list_pods.return_value = (
+            [PodInfo(name="ws-pod-abc", phase=PodPhase.RUNNING)],
+            None,
+        )
+        mock_k8s_core.exec_pod.return_value = ExecResult(stdout="ok", stderr="", returncode=0)
+
+        result = runner.execute_instruction(
+            instruction_name="exec-pod",
+            resolved_arguments={
+                "deployment_name": StrResolvedInstructionArgument(argument_name="deployment_name", value="my-deploy"),
+                "scope": StrResolvedInstructionArgument(argument_name="scope", value="default"),
+                "command": StrResolvedInstructionArgument(argument_name="command", value="echo hello"),
+            },
+        )
+
+        self.assertEqual(result["Stdout"].value, "ok")
+        self.assertEqual(result["Stderr"].value, "")
+        self.assertEqual(result["ReturnCode"].value, "0")
+        mock_apps_api.read_namespaced_deployment.assert_called_once_with(name="my-deploy", namespace="default")
+        mock_k8s_core.list_pods.assert_called_once_with(
+            runner.core_api,
+            namespace="default",
+            label_selector="app=ws",
+            limit=1,
+        )
+        mock_k8s_core.exec_pod.assert_called_once_with(
+            runner.core_api,
+            name="ws-pod-abc",
+            namespace="default",
+            command=["echo", "hello"],
+            container=None,
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_exec_pod_with_name_uses_pod_directly(self, mock_k8s_core: Mock) -> None:
+        runner = self._make_runner()
+        mock_apps_api: Mock = runner.apps_api  # type: ignore[assignment]
+        mock_k8s_core.exec_pod.return_value = ExecResult(stdout="ok", stderr="", returncode=0)
+
+        result = runner.execute_instruction(
+            instruction_name="exec-pod",
+            resolved_arguments={
+                "name": StrResolvedInstructionArgument(argument_name="name", value="pod-1"),
+                "scope": StrResolvedInstructionArgument(argument_name="scope", value="default"),
+                "command": StrResolvedInstructionArgument(argument_name="command", value="ls"),
+            },
+        )
+
+        self.assertEqual(result["Stdout"].value, "ok")
+        mock_apps_api.read_namespaced_deployment.assert_not_called()
+        mock_k8s_core.exec_pod.assert_called_once_with(
+            runner.core_api, name="pod-1", namespace="default", command=["ls"], container=None
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_exec_pod_raises_when_neither_name_nor_deployment(self, mock_k8s_core: Mock) -> None:
+        runner = self._make_runner()
+
+        with self.assertRaises(ValueError):
+            runner.execute_instruction(
+                instruction_name="exec-pod",
+                resolved_arguments={
+                    "scope": StrResolvedInstructionArgument(argument_name="scope", value="ns"),
+                    "command": StrResolvedInstructionArgument(argument_name="command", value="ls"),
+                },
+            )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_exec_pod_passes_container(self, mock_k8s_core: Mock) -> None:
+        runner = self._make_runner()
+        mock_k8s_core.exec_pod.return_value = ExecResult(stdout="", stderr="", returncode=0)
+
+        runner.execute_instruction(
+            instruction_name="exec-pod",
+            resolved_arguments={
+                "name": StrResolvedInstructionArgument(argument_name="name", value="pod-1"),
+                "scope": StrResolvedInstructionArgument(argument_name="scope", value="ns"),
+                "command": StrResolvedInstructionArgument(argument_name="command", value="ls"),
+                "container": StrResolvedInstructionArgument(argument_name="container", value="app"),
+            },
+        )
+
+        mock_k8s_core.exec_pod.assert_called_once_with(
+            runner.core_api, name="pod-1", namespace="ns", command=["ls"], container="app"
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_exec_pod_interactive_with_deployment_name(self, mock_k8s_core: Mock, mock_cmd_utils: Mock) -> None:
+        runner = self._make_runner(kubeconfig_path="/tmp/kubeconfig")
+        mock_deployment: Mock = Mock()
+        mock_deployment.spec.selector.match_labels = {"app": "ws"}
+        mock_apps_api: Mock = runner.apps_api  # type: ignore[assignment]
+        mock_apps_api.read_namespaced_deployment.return_value = mock_deployment
+        mock_k8s_core.list_pods.return_value = (
+            [PodInfo(name="ws-pod-abc", phase=PodPhase.RUNNING)],
+            None,
+        )
+        mock_cmd_utils.run_cmd_and_pipe_to_terminal.return_value = (0, False)
+
+        result = runner.execute_instruction(
+            instruction_name="exec-pod-interactive",
+            resolved_arguments={
+                "deployment_name": StrResolvedInstructionArgument(argument_name="deployment_name", value="my-deploy"),
+                "scope": StrResolvedInstructionArgument(argument_name="scope", value="default"),
+            },
+        )
+
+        self.assertEqual(result, {})
+        mock_cmd_utils.run_cmd_and_pipe_to_terminal.assert_called_once_with(
+            [
+                "kubectl",
+                "exec",
+                "-it",
+                "ws-pod-abc",
+                "-n",
+                "default",
+                "--kubeconfig",
+                "/tmp/kubeconfig",
+                "--",
+                "/bin/bash",
+            ]
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
+    def test_exec_pod_interactive_with_pod_name_and_container(self, mock_cmd_utils: Mock) -> None:
+        runner = self._make_runner()
+        mock_cmd_utils.run_cmd_and_pipe_to_terminal.return_value = (0, False)
+
+        result = runner.execute_instruction(
+            instruction_name="exec-pod-interactive",
+            resolved_arguments={
+                "name": StrResolvedInstructionArgument(argument_name="name", value="pod-1"),
+                "scope": StrResolvedInstructionArgument(argument_name="scope", value="ns"),
+                "container": StrResolvedInstructionArgument(argument_name="container", value="app"),
+                "command": StrResolvedInstructionArgument(argument_name="command", value="sh"),
+            },
+        )
+
+        self.assertEqual(result, {})
+        mock_cmd_utils.run_cmd_and_pipe_to_terminal.assert_called_once_with(
+            ["kubectl", "exec", "-it", "pod-1", "-n", "ns", "-c", "app", "--", "sh"]
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
+    def test_exec_pod_interactive_timeout_raises(self, mock_cmd_utils: Mock) -> None:
+        runner = self._make_runner()
+        mock_cmd_utils.run_cmd_and_pipe_to_terminal.return_value = (0, True)
+
+        with self.assertRaises(InteractiveSessionTimeoutError):
+            runner.execute_instruction(
+                instruction_name="exec-pod-interactive",
+                resolved_arguments={
+                    "name": StrResolvedInstructionArgument(argument_name="name", value="pod-1"),
+                    "scope": StrResolvedInstructionArgument(argument_name="scope", value="ns"),
+                },
+            )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
+    def test_exec_pod_interactive_nonzero_retcode_raises(self, mock_cmd_utils: Mock) -> None:
+        runner = self._make_runner()
+        mock_cmd_utils.run_cmd_and_pipe_to_terminal.return_value = (1, False)
+
+        with self.assertRaises(InteractiveSessionError):
+            runner.execute_instruction(
+                instruction_name="exec-pod-interactive",
+                resolved_arguments={
+                    "name": StrResolvedInstructionArgument(argument_name="name", value="pod-1"),
+                    "scope": StrResolvedInstructionArgument(argument_name="scope", value="ns"),
+                },
+            )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
+    def test_exec_pod_interactive_filters_default_container(self, mock_cmd_utils: Mock) -> None:
+        runner = self._make_runner()
+        mock_cmd_utils.run_cmd_and_pipe_to_terminal.return_value = (0, False)
+
+        runner.execute_instruction(
+            instruction_name="exec-pod-interactive",
+            resolved_arguments={
+                "name": StrResolvedInstructionArgument(argument_name="name", value="pod-1"),
+                "scope": StrResolvedInstructionArgument(argument_name="scope", value="ns"),
+                "container": StrResolvedInstructionArgument(argument_name="container", value="default"),
+            },
+        )
+
+        mock_cmd_utils.run_cmd_and_pipe_to_terminal.assert_called_once_with(
+            ["kubectl", "exec", "-it", "pod-1", "-n", "ns", "--", "/bin/bash"]
+        )
 
     def test_unknown_instruction_raises_error(self) -> None:
         runner = self._make_runner()

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_custom_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_custom_runner.py
@@ -40,7 +40,7 @@ class TestK8sCustomRunner(unittest.TestCase):
 
         result = runner.execute_instruction(instruction_name="list", resolved_arguments=_crd_args())
 
-        self.assertEqual(result["Names"].value, "ws-1,ws-2")
+        self.assertEqual(result["Names"].value, ["ws-1", "ws-2"])
         self.assertEqual(json.loads(result["Items"].value), items)
         self.assertEqual(result["NextToken"].value, "")
         mock_k8s_custom.list_namespaced.assert_called_once_with(
@@ -92,7 +92,7 @@ class TestK8sCustomRunner(unittest.TestCase):
 
         result = runner.execute_instruction(instruction_name="list-cluster", resolved_arguments=args)
 
-        self.assertEqual(result["Names"].value, "cr-1")
+        self.assertEqual(result["Names"].value, ["cr-1"])
         self.assertEqual(result["NextToken"].value, "")
         mock_k8s_custom.list_cluster.assert_called_once_with(
             runner.custom_api, ref=WORKSPACE_REF, limit=None, _continue=None

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_error_handler.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_error_handler.py
@@ -1,0 +1,97 @@
+import json
+import unittest
+
+from kubernetes.client.exceptions import ApiException
+
+from jupyter_deploy.exceptions import (
+    InvalidProviderCredentialsError,
+    ProviderPermissionError,
+    ResourceNotFoundError,
+)
+from jupyter_deploy.provider.k8s.k8s_error_handler import k8s_error_context_manager
+
+
+def _api_exception(status: int, reason: str, body: dict | None = None) -> ApiException:
+    e = ApiException(status=status, reason=reason)
+    if body is not None:
+        e.body = json.dumps(body)
+    return e
+
+
+def _not_found_body(kind: str, name: str) -> dict:
+    return {
+        "kind": "Status",
+        "message": f'{kind} "{name}" not found',
+        "reason": "NotFound",
+        "details": {"name": name, "kind": kind},
+        "code": 404,
+    }
+
+
+class TestK8sErrorContextManager(unittest.TestCase):
+    def test_401_raises_invalid_provider_credentials(self) -> None:
+        with self.assertRaises(InvalidProviderCredentialsError) as ctx, k8s_error_context_manager():
+            raise _api_exception(401, "Unauthorized", {"message": "token expired"})
+
+        self.assertEqual(ctx.exception.provider_name.value, "Kubernetes")
+
+    def test_403_raises_provider_permission_error(self) -> None:
+        with self.assertRaises(ProviderPermissionError) as ctx, k8s_error_context_manager():
+            raise _api_exception(403, "Forbidden", {"message": "forbidden: User cannot get nodes"})
+
+        self.assertEqual(ctx.exception.provider_name.value, "Kubernetes")
+        self.assertIn("forbidden", ctx.exception.original_message)
+
+    def test_404_raises_resource_not_found(self) -> None:
+        body = _not_found_body("nodes", "i-do-not-exist")
+        with self.assertRaises(ResourceNotFoundError) as ctx, k8s_error_context_manager():
+            raise _api_exception(404, "Not Found", body)
+
+        self.assertEqual(ctx.exception.resource_kind, "nodes")
+        self.assertEqual(ctx.exception.resource_name, "i-do-not-exist")
+        self.assertIn("i-do-not-exist", str(ctx.exception))
+
+    def test_404_with_scope_includes_scope_in_message(self) -> None:
+        body = _not_found_body("workspaces", "my-ws")
+        with self.assertRaises(ResourceNotFoundError) as ctx, k8s_error_context_manager(scope="my-namespace"):
+            raise _api_exception(404, "Not Found", body)
+
+        self.assertEqual(ctx.exception.scope, "my-namespace")
+        self.assertIn("in 'my-namespace'", str(ctx.exception))
+
+    def test_404_without_scope_omits_scope_in_message(self) -> None:
+        body = _not_found_body("nodes", "node-1")
+        with self.assertRaises(ResourceNotFoundError) as ctx, k8s_error_context_manager():
+            raise _api_exception(404, "Not Found", body)
+
+        self.assertIsNone(ctx.exception.scope)
+        self.assertNotIn("in '", str(ctx.exception))
+
+    def test_404_with_no_body_uses_defaults(self) -> None:
+        with self.assertRaises(ResourceNotFoundError) as ctx, k8s_error_context_manager():
+            raise _api_exception(404, "Not Found")
+
+        self.assertEqual(ctx.exception.resource_kind, "resource")
+        self.assertEqual(ctx.exception.resource_name, "")
+
+    def test_404_with_malformed_body(self) -> None:
+        e = ApiException(status=404, reason="Not Found")
+        e.body = "not json"
+        with self.assertRaises(ResourceNotFoundError) as ctx, k8s_error_context_manager():
+            raise e
+
+        self.assertEqual(ctx.exception.resource_kind, "resource")
+
+    def test_other_status_reraises(self) -> None:
+        with self.assertRaises(ApiException), k8s_error_context_manager():
+            raise _api_exception(409, "Conflict")
+
+    def test_no_exception_passes_through(self) -> None:
+        with k8s_error_context_manager():
+            result = 1 + 1
+
+        self.assertEqual(result, 2)
+
+    def test_non_api_exception_passes_through(self) -> None:
+        with self.assertRaises(ValueError), k8s_error_context_manager():
+            raise ValueError("unrelated")

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_runner.py
@@ -30,10 +30,12 @@ class TestK8sApiRunner(unittest.TestCase):
         runner = K8sApiRunner(NullDisplay(), kubeconfig_path="/tmp/kubeconfig")
         resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
 
-        result = runner.execute_instruction(instruction_name="core.list-nodes", resolved_arguments=resolved_args)
+        result = runner.execute_instruction(instruction_name="k8s.core.list-nodes", resolved_arguments=resolved_args)
 
         mock_factory.from_kubeconfig.assert_called_once_with(kubeconfig_path="/tmp/kubeconfig")
-        mock_core_runner_class.assert_called_once_with(ANY, api_client=mock_api_client)
+        mock_core_runner_class.assert_called_once_with(
+            ANY, api_client=mock_api_client, kubeconfig_path="/tmp/kubeconfig"
+        )
         mock_core_runner.execute_instruction.assert_called_once_with(
             instruction_name="list-nodes", resolved_arguments=resolved_args
         )
@@ -55,7 +57,7 @@ class TestK8sApiRunner(unittest.TestCase):
         runner = K8sApiRunner(NullDisplay(), kubeconfig_path="/tmp/kubeconfig")
         resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
 
-        result = runner.execute_instruction(instruction_name="custom.list", resolved_arguments=resolved_args)
+        result = runner.execute_instruction(instruction_name="k8s.custom.list", resolved_arguments=resolved_args)
 
         mock_factory.from_kubeconfig.assert_called_once_with(kubeconfig_path="/tmp/kubeconfig")
         mock_custom_runner_class.assert_called_once_with(ANY, api_client=mock_api_client)
@@ -76,8 +78,8 @@ class TestK8sApiRunner(unittest.TestCase):
         runner = K8sApiRunner(NullDisplay(), kubeconfig_path="/tmp/kubeconfig")
         resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
 
-        runner.execute_instruction(instruction_name="core.list-nodes", resolved_arguments=resolved_args)
-        runner.execute_instruction(instruction_name="core.get-node", resolved_arguments=resolved_args)
+        runner.execute_instruction(instruction_name="k8s.core.list-nodes", resolved_arguments=resolved_args)
+        runner.execute_instruction(instruction_name="k8s.core.get-node", resolved_arguments=resolved_args)
 
         mock_core_runner_class.assert_called_once()
         self.assertEqual(mock_core_runner.execute_instruction.call_count, 2)
@@ -90,16 +92,59 @@ class TestK8sApiRunner(unittest.TestCase):
         runner = K8sApiRunner(NullDisplay(), kubeconfig_path="/tmp/kubeconfig")
 
         with self.assertRaises(InstructionNotFoundError) as context:
-            runner.execute_instruction(instruction_name="unknown.command", resolved_arguments={})
+            runner.execute_instruction(instruction_name="k8s.unknown.command", resolved_arguments={})
 
         self.assertIn("unknown", str(context.exception))
 
     def test_execute_raises_on_invalid_instruction_name(self) -> None:
         runner = K8sApiRunner(NullDisplay(), kubeconfig_path="/tmp/kubeconfig")
 
-        invalid_instructions = ["", ".", "core", "core."]
+        invalid_instructions = ["", ".", "k8s", "k8s.", "k8s.core", "k8s.core."]
         for invalid_instruction in invalid_instructions:
             with self.subTest(invalid_instruction=invalid_instruction):
                 with self.assertRaises(ValueError) as context:
                     runner.execute_instruction(instruction_name=invalid_instruction, resolved_arguments={})
                 self.assertIn(invalid_instruction, str(context.exception))
+
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sCoreRunner")
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sClientFactory")
+    def test_uses_eks_cluster_when_all_params_provided(self, mock_factory: Mock, mock_core_runner_class: Mock) -> None:
+        mock_api_client: Mock = Mock()
+        mock_factory.from_eks_cluster.return_value = mock_api_client
+        mock_core_runner_class.return_value = Mock()
+
+        runner = K8sApiRunner(
+            NullDisplay(),
+            cluster_endpoint="https://example.eks.amazonaws.com",
+            cluster_ca_data="Y2VydA==",
+            cluster_name="my-cluster",
+            region="us-west-2",
+        )
+        runner.execute_instruction(instruction_name="k8s.core.list-nodes", resolved_arguments={})
+
+        mock_factory.from_eks_cluster.assert_called_once_with(
+            endpoint="https://example.eks.amazonaws.com",
+            ca_data_b64="Y2VydA==",
+            cluster_name="my-cluster",
+            region="us-west-2",
+        )
+        mock_factory.from_kubeconfig.assert_not_called()
+
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sCoreRunner")
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sClientFactory")
+    def test_falls_back_to_kubeconfig_when_eks_params_incomplete(
+        self, mock_factory: Mock, mock_core_runner_class: Mock
+    ) -> None:
+        mock_api_client: Mock = Mock()
+        mock_factory.from_kubeconfig.return_value = mock_api_client
+        mock_core_runner_class.return_value = Mock()
+
+        runner = K8sApiRunner(
+            NullDisplay(),
+            kubeconfig_path="/tmp/kubeconfig",
+            cluster_endpoint="https://example.eks.amazonaws.com",
+        )
+        runner.execute_instruction(instruction_name="k8s.core.list-nodes", resolved_arguments={})
+
+        mock_factory.from_kubeconfig.assert_called_once_with(kubeconfig_path="/tmp/kubeconfig")
+        mock_factory.from_eks_cluster.assert_not_called()

--- a/libs/jupyter-deploy/tests/unit/provider/test_instruction_runner_factory.py
+++ b/libs/jupyter-deploy/tests/unit/provider/test_instruction_runner_factory.py
@@ -172,11 +172,21 @@ class TestInstructionRunnerFactory(unittest.TestCase):
             self.assertEqual({ApiGroup.AWS: self.mock_aws_api_runner}, InstructionRunnerFactory._api_group_runner_map)
             self.mock_aws_api_runner_cls.assert_called_once()
 
-    def test_imports_k8s_provider_at_runtime_only_and_return_it(self) -> None:
+    def test_imports_k8s_provider_with_eks_outputs_and_return_it(self) -> None:
         mock_outputs_handler = Mock(spec=EngineOutputsHandler)
-        mock_kubeconfig_def = Mock(spec=StrTemplateOutputDefinition)
-        mock_kubeconfig_def.value = "/tmp/kubeconfig"
-        mock_outputs_handler.get_declared_output_def.return_value = mock_kubeconfig_def
+
+        def _mock_get_declared(name: str, value_type: type) -> Mock:
+            values = {
+                "cluster_endpoint": "https://example.eks.amazonaws.com",
+                "cluster_ca_certificate": "Y2VydA==",
+                "cluster_name": "my-cluster",
+                "aws_region": "us-west-2",
+            }
+            mock_def = Mock(spec=StrTemplateOutputDefinition)
+            mock_def.value = values[name]
+            return mock_def
+
+        mock_outputs_handler.get_declared_output_def.side_effect = _mock_get_declared
 
         with self.patch_provider_runner_modules():
             importlib.reload(instruction_runner_factory)
@@ -187,12 +197,46 @@ class TestInstructionRunnerFactory(unittest.TestCase):
                 "k8s", mock_outputs_handler, NullDisplay()
             )
 
-            mock_outputs_handler.get_declared_output_def.assert_called_once_with(
-                "kubeconfig_path", StrTemplateOutputDefinition
-            )
             self.assertEqual(self.mock_k8s_api_runner, runner)
-            self.assertEqual({ApiGroup.K8S: self.mock_k8s_api_runner}, InstructionRunnerFactory._api_group_runner_map)
-            self.mock_k8s_api_runner_cls.assert_called_once_with(display_manager=ANY, kubeconfig_path="/tmp/kubeconfig")
+            self.mock_k8s_api_runner_cls.assert_called_once_with(
+                display_manager=ANY,
+                kubeconfig_path=None,
+                cluster_endpoint="https://example.eks.amazonaws.com",
+                cluster_ca_data="Y2VydA==",
+                cluster_name="my-cluster",
+                region="us-west-2",
+            )
+
+    def test_imports_k8s_provider_falls_back_to_kubeconfig(self) -> None:
+        mock_outputs_handler = Mock(spec=EngineOutputsHandler)
+
+        def _mock_get_declared(name: str, value_type: type) -> Mock:
+            if name == "kubeconfig_path":
+                mock_def = Mock(spec=StrTemplateOutputDefinition)
+                mock_def.value = "/tmp/kubeconfig"
+                return mock_def
+            raise NotImplementedError(f"No value: {name}")
+
+        mock_outputs_handler.get_declared_output_def.side_effect = _mock_get_declared
+
+        with self.patch_provider_runner_modules():
+            importlib.reload(instruction_runner_factory)
+            InstructionRunnerFactory = instruction_runner_factory.InstructionRunnerFactory
+            InstructionRunnerFactory._api_group_runner_map = {}
+
+            runner = InstructionRunnerFactory.get_provider_instruction_runner(
+                "k8s", mock_outputs_handler, NullDisplay()
+            )
+
+            self.assertEqual(self.mock_k8s_api_runner, runner)
+            self.mock_k8s_api_runner_cls.assert_called_once_with(
+                display_manager=ANY,
+                kubeconfig_path="/tmp/kubeconfig",
+                cluster_endpoint=None,
+                cluster_ca_data=None,
+                cluster_name=None,
+                region=None,
+            )
 
     def test_raise_not_value_error_on_unmatched_provider(self) -> None:
         mock_outputs_handler = Mock(spec=EngineOutputsHandler)

--- a/libs/jupyter-deploy/tests/unit/provider/test_manifest_command_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/test_manifest_command_runner.py
@@ -313,6 +313,10 @@ class TestManifestCommandRunner(unittest.TestCase):
         winners = runner.get_result_value(cmd, "karaoke-winners", list[str])
         self.assertEqual(winners, ["Ross", "Rachel"])
 
+        # Test str→int coercion for integer-like strings
+        hours_as_int = runner.get_result_value(cmd, "hours-of-hangover", int)
+        self.assertEqual(hours_as_int, 24)
+
         # Test with different expected type
         with self.assertRaises(TypeError):
             runner.get_result_value(cmd, "hours-of-hangover", list)
@@ -320,6 +324,33 @@ class TestManifestCommandRunner(unittest.TestCase):
             runner.get_result_value(cmd, "party", dict)
         with self.assertRaises(TypeError):
             runner.get_result_value(cmd, "karaoke-winners", int)
+
+    @patch("jupyter_deploy.provider.manifest_command_runner.InstructionRunnerFactory.get_provider_instruction_runner")
+    def test_get_result_value_str_to_int_rejects_non_integer(self, mock_get_provider_instruction_runner: Mock) -> None:
+        cmd = JupyterDeployCommandV1.model_validate(
+            {
+                "cmd": "test",
+                "sequence": [{"api-name": "mock.api", "arguments": []}],
+                "results": [{"result-name": "price", "source": "result", "source-key": "[0].Price"}],
+            }
+        )
+
+        mock_runner = Mock()
+        mock_runner.execute_instruction.return_value = {
+            "Price": StrResolvedInstructionResult(result_name="Price", value="1.25"),
+        }
+        mock_get_provider_instruction_runner.return_value = mock_runner
+
+        output_handler_mock = Mock()
+        output_handler_mock.get_full_project_outputs.return_value = {}
+
+        runner = ManifestCommandRunner(
+            display_manager=Mock(), output_handler=output_handler_mock, variable_handler=Mock()
+        )
+        runner.run_command_sequence(cmd, {})
+
+        with self.assertRaises(TypeError):
+            runner.get_result_value(cmd, "price", int)
 
     @patch("jupyter_deploy.provider.manifest_command_runner.InstructionRunnerFactory.get_provider_instruction_runner")
     def test_get_result_value_raises_error_for_invalid_result(self, mock_get_provider_instruction_runner: Mock) -> None:

--- a/libs/jupyter-deploy/tests/unit/provider/test_resolved_argdefs.py
+++ b/libs/jupyter-deploy/tests/unit/provider/test_resolved_argdefs.py
@@ -156,6 +156,55 @@ class TestResolveResultArgDef(unittest.TestCase):
         self.assertIn(CustomResolvedInstructionResult.__name__, str(context.exception))
 
 
+class TestResolveResultArgDefExtract(unittest.TestCase):
+    def test_extracts_nested_string_value(self) -> None:
+        resultdefs: dict[str, ResolvedInstructionResult] = {
+            "resource": StrResolvedInstructionResult(
+                result_name="resource", value='{"status": {"deploymentName": "my-deploy"}}'
+            ),
+        }
+
+        result = resolve_result_argdef(
+            resultdefs=resultdefs, arg_name="name", source_key="resource", extract="status.deploymentName"
+        )
+
+        self.assertIsInstance(result, StrResolvedInstructionArgument)
+        self.assertEqual(result.value, "my-deploy")
+
+    def test_extracts_nested_object_as_json(self) -> None:
+        resultdefs: dict[str, ResolvedInstructionResult] = {
+            "resource": StrResolvedInstructionResult(
+                result_name="resource", value='{"spec": {"template": {"containers": []}}}'
+            ),
+        }
+
+        result = resolve_result_argdef(
+            resultdefs=resultdefs, arg_name="tmpl", source_key="resource", extract="spec.template"
+        )
+
+        self.assertIsInstance(result, StrResolvedInstructionArgument)
+        self.assertEqual(result.value, '{"containers": []}')
+
+    def test_raises_key_error_for_missing_path_segment(self) -> None:
+        resultdefs: dict[str, ResolvedInstructionResult] = {
+            "resource": StrResolvedInstructionResult(result_name="resource", value='{"status": {}}'),
+        }
+
+        with self.assertRaises(KeyError):
+            resolve_result_argdef(
+                resultdefs=resultdefs, arg_name="name", source_key="resource", extract="status.deploymentName"
+            )
+
+    def test_no_extract_returns_original_value(self) -> None:
+        resultdefs: dict[str, ResolvedInstructionResult] = {
+            "resource": StrResolvedInstructionResult(result_name="resource", value='{"status": "ok"}'),
+        }
+
+        result = resolve_result_argdef(resultdefs=resultdefs, arg_name="val", source_key="resource", extract=None)
+
+        self.assertEqual(result.value, '{"status": "ok"}')
+
+
 class TestResolveCliParamArgDef(unittest.TestCase):
     def test_resolves_all_cli_parameter_types(self) -> None:
         # Arrange


### PR DESCRIPTION
This PR a/ updates `host`, `server` and `open` commands in the CLI to support multi-host, multi-server templates, b/ wire these changes to the `eks-oidc` template.

Also in this PR:
- fix instruction in `/getting-started` page

### User experience
- list the hosts: `jd host list`
- list the servers (==workspaces): `jd server list`
- target a specific scope: `jd server list --scope workspace-ns`
- list the hosts w/ label filter: `jd host list --query jupyter-deploy/role=components`
- paginate: `jd host list --continue-from TOKEN`
- show status of a specific host: `jd host status --name HOST-NAME`
- show details of a specific host `jd host show --name HOST-NAME`
- show status of a specific server: `jd server status --name SERVER-NAME`
- show details of a specific server `jd server show --name SERVER-NAME  --scope NAMESPACE`
- also update `server`: `status`, `start`, `stop`, `logs`, `exec`, `connect` to support --name SERVER-NAME and `--scope NAMESPACE`
- open getting-started page: `jd open`
- open specific workspace: `jd open --name SERVER-NAME --scope NAMESPACE` or simply `jd open --name SERVER-NAME`

### Implementation
- update cli to add attributes
- update `ServerHandler`, `HostHandler`, OpenHandler`
- add `api/k8s` API
- update `provider/k8s/k8s_client_factory` w/ `from_eks_cluster()` method that lazy imports `aws` to generate the token from `EKS:GetToken`
- add error handler for k8s error in `provider/k8s/k8s_error_handler`, and wrap in `k8s_runner`
- add `ResourceNotFoundError` as standard error
- add `server-status-rules` to manifest to convert `workspace.status.conditions` into a single status (in a template agnostic way) - use it in `jd server status`
- add `multi-host` and `multi-server` flags in manifest - use it to raise exception if `HOST-NAME` or `SERVER-NAME` positional argument is _not_ passed for such templates
- update eks-oidc template `manifest.yaml` to reference new commands, incl. new `server.list`, `host.list`, `open.server` 

### Testing
- added unit tests
- tested manually against a deployed `eks-oidc` template
- added E2E tests for `jd host` commands

### Screenshots
**list hosts**
<img width="324" height="59" alt="Screenshot 2026-05-13 at 12 15 14 PM" src="https://github.com/user-attachments/assets/becb2d70-60d7-40e5-9013-8e3c98baba60" />

**paginate hosts**
<img width="435" height="74" alt="Screenshot 2026-05-13 at 12 15 49 PM" src="https://github.com/user-attachments/assets/ffe264a4-5ea5-4c7d-bdb1-f157e0405949" />

**host status**
<img width="606" height="29" alt="Screenshot 2026-05-13 at 12 16 19 PM" src="https://github.com/user-attachments/assets/4744c2d6-3560-42d9-95f9-265f7868ca93" />

**host show**
<img width="659" height="355" alt="Screenshot 2026-05-13 at 12 16 49 PM" src="https://github.com/user-attachments/assets/4a234524-f7de-4365-9baf-54b8cb498cb2" />

**list servers**
<img width="364" height="47" alt="Screenshot 2026-05-13 at 12 17 32 PM" src="https://github.com/user-attachments/assets/d6785e6c-4b26-47c7-9f6e-70ba5c963b54" />

**server status**
<img width="414" height="30" alt="Screenshot 2026-05-13 at 12 17 59 PM" src="https://github.com/user-attachments/assets/b33185f2-dac2-40a8-8f27-9d795204304e" />

**server show**
<img width="1130" height="351" alt="Screenshot 2026-05-13 at 12 18 34 PM" src="https://github.com/user-attachments/assets/4d0627f8-be84-4ece-b3b8-2e08172235e8" />

**not found**
<img width="412" height="31" alt="Screenshot 2026-05-13 at 12 19 10 PM" src="https://github.com/user-attachments/assets/2196cefd-3f4d-4a68-85df-e19d36b8752b" />

**not found - ns**
<img width="596" height="30" alt="Screenshot 2026-05-13 at 12 19 54 PM" src="https://github.com/user-attachments/assets/d88a3b70-92a4-4a76-8982-beebf9ad6497" />




