### PR TITLE
feat: component cmds

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -44,6 +44,12 @@ values:
 - name: server_default_scope
   source: output
   source-key: server_default_scope
+- name: workspace_router_namespace
+  source: output
+  source-key: workspace_router_namespace
+- name: workspace_operator_namespace
+  source: output
+  source-key: workspace_operator_namespace
 project-store:
   store-type: s3-only
 multi-host: true
@@ -297,7 +303,7 @@ commands:
     - api-attribute: container
       source: cli
       source-key: service
-    - api-attribute: tail_lines
+    - api-attribute: extra
       source: cli
       source-key: extra
   results:
@@ -406,6 +412,244 @@ commands:
     - api-attribute: container
       source: cli
       source-key: service
+- cmd: component.deployment.status
+  sequence:
+  - api-name: k8s.apps.get-deployment-status
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+  results:
+  - result-name: component.deployment.status.status
+    source: result
+    source-key: '[0].Status'
+  - result-name: component.deployment.status.status_category
+    source: result
+    source-key: '[0].StatusCategory'
+  - result-name: component.deployment.status.details
+    source: result
+    source-key: '[0].Details'
+  - result-name: component.deployment.status.sub_component
+    source: result
+    source-key: '[0].SubComponent'
+- cmd: component.deployment.show
+  sequence:
+  - api-name: k8s.apps.get-deployment
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+  results:
+  - result-name: component.deployment.show.name
+    source: result
+    source-key: '[0].Name'
+  - result-name: component.deployment.show.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: component.deployment.logs
+  sequence:
+  - api-name: k8s.core.deployment-logs
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: extra
+      source: cli
+      source-key: extra
+  results:
+  - result-name: component.deployment.logs.logs
+    source: result
+    source-key: '[0].Logs'
+- cmd: component.deployment.restart
+  sequence:
+  - api-name: k8s.apps.rollout-restart
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+- cmd: component.cronjob.status
+  sequence:
+  - api-name: k8s.batch.get-cronjob-status
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: query
+      source: cli
+      source-key: query
+  results:
+  - result-name: component.cronjob.status.status
+    source: result
+    source-key: '[0].Status'
+  - result-name: component.cronjob.status.status_category
+    source: result
+    source-key: '[0].StatusCategory'
+  - result-name: component.cronjob.status.details
+    source: result
+    source-key: '[0].Details'
+  - result-name: component.cronjob.status.sub_component
+    source: result
+    source-key: '[0].SubComponent'
+- cmd: component.cronjob.show
+  sequence:
+  - api-name: k8s.batch.get-cronjob
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+  results:
+  - result-name: component.cronjob.show.name
+    source: result
+    source-key: '[0].Name'
+  - result-name: component.cronjob.show.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: component.cronjob.logs
+  sequence:
+  - api-name: k8s.batch.get-job-logs
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: query
+      source: cli
+      source-key: query
+    - api-attribute: extra
+      source: cli
+      source-key: extra
+  results:
+  - result-name: component.cronjob.logs.logs
+    source: result
+    source-key: '[0].Logs'
+- cmd: component.cronjob.trigger
+  sequence:
+  - api-name: k8s.batch.create-job-from-cronjob
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+  results:
+  - result-name: component.cronjob.trigger.job_name
+    source: result
+    source-key: '[0].JobName'
+components:
+  traefik:
+    type: Deployment
+    description: Ingress controller and reverse proxy
+    scope: workspace_router_namespace
+    verbs:
+      status:
+        method: k8s.apps.get-deployment-status
+      show:
+        method: k8s.apps.get-deployment
+      logs:
+        method: k8s.core.deployment-logs
+      restart:
+        method: k8s.apps.rollout-restart
+  dex:
+    type: Deployment
+    description: OIDC identity provider
+    scope: workspace_router_namespace
+    verbs:
+      status:
+        method: k8s.apps.get-deployment-status
+      show:
+        method: k8s.apps.get-deployment
+      logs:
+        method: k8s.core.deployment-logs
+      restart:
+        method: k8s.apps.rollout-restart
+  oauth2-proxy:
+    type: Deployment
+    description: OAuth2 authentication proxy
+    scope: workspace_router_namespace
+    verbs:
+      status:
+        method: k8s.apps.get-deployment-status
+      show:
+        method: k8s.apps.get-deployment
+      logs:
+        method: k8s.core.deployment-logs
+      restart:
+        method: k8s.apps.rollout-restart
+  authmiddleware:
+    type: Deployment
+    description: JWT validation and session management
+    scope: workspace_router_namespace
+    verbs:
+      status:
+        method: k8s.apps.get-deployment-status
+      show:
+        method: k8s.apps.get-deployment
+      logs:
+        method: k8s.core.deployment-logs
+      restart:
+        method: k8s.apps.rollout-restart
+  console:
+    type: Deployment
+    description: Web console for workspace management
+    scope: workspace_router_namespace
+    verbs:
+      status:
+        method: k8s.apps.get-deployment-status
+      show:
+        method: k8s.apps.get-deployment
+      logs:
+        method: k8s.core.deployment-logs
+      restart:
+        method: k8s.apps.rollout-restart
+  workspace-operator:
+    type: Deployment
+    description: Workspace lifecycle controller
+    resource-name: jupyter-k8s-controller-manager
+    scope: workspace_operator_namespace
+    verbs:
+      status:
+        method: k8s.apps.get-deployment-status
+      show:
+        method: k8s.apps.get-deployment
+      logs:
+        method: k8s.core.deployment-logs
+      restart:
+        method: k8s.apps.rollout-restart
+  jwt-rotator:
+    type: CronJob
+    description: Periodic JWT signing key rotation
+    scope: workspace_router_namespace
+    query: "app=jwt-rotator"
+    verbs:
+      status:
+        method: k8s.batch.get-cronjob-status
+      show:
+        method: k8s.batch.get-cronjob
+      logs:
+        method: k8s.batch.get-job-logs
+      trigger:
+        method: k8s.batch.create-job-from-cronjob
 supervised-execution:
   config:
     config.terraform-plan:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
@@ -1,0 +1,360 @@
+"""E2E tests for component commands on the EKS OIDC template."""
+
+import json
+import time
+from datetime import UTC, datetime
+
+import pytest
+from pytest_jupyter_deploy.cli import JDCliError
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+
+
+def _get_manifest_components(e2e_deployment: EndToEndDeployment) -> dict:
+    """Read component definitions from the project manifest."""
+    manifest = e2e_deployment.get_manifest()
+    return manifest.get_components()
+
+
+def _get_all_names(e2e_deployment: EndToEndDeployment) -> list[str]:
+    return list(_get_manifest_components(e2e_deployment).keys())
+
+
+def _get_deployment_names(e2e_deployment: EndToEndDeployment) -> list[str]:
+    return [name for name, comp in _get_manifest_components(e2e_deployment).items() if comp.type == "Deployment"]
+
+
+def _get_cronjob_names(e2e_deployment: EndToEndDeployment) -> list[str]:
+    return [name for name, comp in _get_manifest_components(e2e_deployment).items() if comp.type == "CronJob"]
+
+
+def _poll_component_status(
+    e2e_deployment: EndToEndDeployment, name: str, target_status: str, timeout_s: int = 120, interval_s: int = 5
+) -> None:
+    """Poll component status until it matches target_status or timeout is reached."""
+    deadline = time.time() + timeout_s
+    last_status = ""
+    while time.time() < deadline:
+        result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "status", "--name", name])
+        last_status = result.stdout.strip().split(":")[-1].strip()
+        if last_status == target_status:
+            return
+        time.sleep(interval_s)
+    raise TimeoutError(
+        f"Component '{name}' did not reach status '{target_status}' within {timeout_s}s (last: {last_status})"
+    )
+
+
+def _get_component_last_updated(e2e_deployment: EndToEndDeployment, name: str) -> datetime | None:
+    """Get the last_updated timestamp of the sub_component from health JSON."""
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "health", "--json"])
+    data = json.loads(result.stdout)
+    for comp in data["components"]:
+        if comp["name"] == name and comp.get("sub_component"):
+            sub = json.loads(comp["sub_component"])
+            if sub.get("last_updated"):
+                dt = datetime.fromisoformat(sub["last_updated"])
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=UTC)
+                return dt
+    return None
+
+
+# ── component health ────────────────────────────────────────────────────────
+
+
+def test_component_health(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify health dashboard shows all components with populated fields."""
+    e2e_deployment.ensure_deployed()
+
+    components = _get_manifest_components(e2e_deployment)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "health"])
+    output = result.stdout
+
+    for name in components:
+        assert name in output, f"Expected component '{name}' in health output"
+
+    types = {comp.type for comp in components.values()}
+    for comp_type in types:
+        assert comp_type in output, f"Expected type '{comp_type}' in health output"
+
+
+def test_component_health_json(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify health --json returns valid JSON with all components and expected keys."""
+    e2e_deployment.ensure_deployed()
+
+    manifest_components = _get_manifest_components(e2e_deployment)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "health", "--json"])
+    data = json.loads(result.stdout)
+
+    assert "components" in data, f"Expected 'components' key, got: {list(data.keys())}"
+    components = data["components"]
+    assert len(components) == len(manifest_components), (
+        f"Expected {len(manifest_components)} components, got {len(components)}"
+    )
+
+    names = [c["name"] for c in components]
+    for name in manifest_components:
+        assert name in names, f"Expected component '{name}' in JSON output"
+
+    expected_types = {comp.type for comp in manifest_components.values()}
+    for comp in components:
+        assert comp["status"], f"Component '{comp['name']}' has empty status"
+        assert comp["type"] in expected_types, f"Component '{comp['name']}' has unexpected type: {comp['type']}"
+        assert comp["status_category"] in ("healthy", "in-progress", "degraded"), (
+            f"Component '{comp['name']}' has unexpected status_category: {comp['status_category']}"
+        )
+        assert comp["details"], f"Component '{comp['name']}' has empty details"
+
+
+# ── component list ──────────────────────────────────────────────────────────
+
+
+def test_component_list(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify list shows table with all components."""
+    e2e_deployment.ensure_deployed()
+
+    manifest_components = _get_manifest_components(e2e_deployment)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "list"])
+    output = result.stdout
+
+    for name in manifest_components:
+        assert name in output, f"Expected component '{name}' in list output"
+
+    for comp_type in {comp.type for comp in manifest_components.values()}:
+        assert comp_type in output, f"Expected type '{comp_type}' in list output"
+
+
+def test_component_list_json(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify list --json returns valid JSON with all components and descriptions match manifest."""
+    e2e_deployment.ensure_deployed()
+
+    manifest_components = _get_manifest_components(e2e_deployment)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "list", "--json"])
+    components = json.loads(result.stdout)
+
+    assert isinstance(components, list), f"Expected list, got {type(components)}"
+    assert len(components) == len(manifest_components), (
+        f"Expected {len(manifest_components)} components, got {len(components)}"
+    )
+
+    by_name = {c["name"]: c for c in components}
+    for name, comp_def in manifest_components.items():
+        assert name in by_name, f"Expected component '{name}' in JSON output"
+        assert by_name[name]["type"] == comp_def.type, (
+            f"Type mismatch for '{name}': expected '{comp_def.type}', got '{by_name[name]['type']}'"
+        )
+        actual_desc = by_name[name]["description"]
+        assert actual_desc == comp_def.description, (
+            f"Description mismatch for '{name}': expected '{comp_def.description}', got '{actual_desc}'"
+        )
+
+
+def test_component_list_text(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify list --text returns comma-separated component names matching manifest."""
+    e2e_deployment.ensure_deployed()
+
+    manifest_components = _get_manifest_components(e2e_deployment)
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "list", "--text"])
+    names = result.stdout.strip().split(",")
+
+    assert len(names) == len(manifest_components), (
+        f"Expected {len(manifest_components)} names, got {len(names)}: {names}"
+    )
+    for name in manifest_components:
+        assert name in names, f"Expected component '{name}' in text output"
+
+
+# ── component status ────────────────────────────────────────────────────────
+
+
+def test_component_status_happy_case(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify status returns a non-empty result for each component."""
+    e2e_deployment.ensure_deployed()
+
+    for name in _get_all_names(e2e_deployment):
+        result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "status", "--name", name])
+        assert f"{name} status:" in result.stdout, f"Expected '{name} status:' in output:\n{result.stdout}"
+
+
+def test_component_status_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify status for a non-existent component fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "status", "--name", "i-do-not-exist"])
+
+
+# ── component show ──────────────────────────────────────────────────────────
+
+
+def test_component_show_deployment(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify show returns output for a Deployment component."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_deployment_names(e2e_deployment)[0]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", name])
+    assert result.stdout.strip(), "Expected non-empty output for component show"
+
+
+def test_component_show_deployment_json(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify show --json returns valid JSON with expected fields for a Deployment."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_deployment_names(e2e_deployment)[0]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", name, "--json"])
+    data = json.loads(result.stdout)
+    assert "name" in data, f"Expected 'name' in JSON response, got: {list(data.keys())}"
+    assert "resource" in data, f"Expected 'resource' in JSON response, got: {list(data.keys())}"
+    assert data["name"] == name
+
+
+def test_component_show_job(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify show returns output for a CronJob component."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_cronjob_names(e2e_deployment)[0]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", name, "--json"])
+    data = json.loads(result.stdout)
+    assert "name" in data, f"Expected 'name' in JSON response, got: {list(data.keys())}"
+    assert "resource" in data, f"Expected 'resource' in JSON response, got: {list(data.keys())}"
+    assert data["name"] == name
+
+
+def test_component_show_description(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify show --description returns the manifest description."""
+    e2e_deployment.ensure_deployed()
+
+    manifest_components = _get_manifest_components(e2e_deployment)
+    first_name = next(iter(manifest_components))
+    expected_desc = manifest_components[first_name].description
+
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "component", "show", "--name", first_name, "--description"]
+    )
+    assert expected_desc in result.stdout, f"Expected description '{expected_desc}' in output:\n{result.stdout}"
+
+
+def test_component_show_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify show for a non-existent component fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", "i-do-not-exist"])
+
+
+# ── component logs ──────────────────────────────────────────────────────────
+
+
+def test_component_logs_no_args(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify logs returns output for a Deployment component with no extra args."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_deployment_names(e2e_deployment)[0]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "logs", "--name", name])
+    assert result.stdout.strip(), f"Expected non-empty log output for {name}"
+
+
+def test_component_logs_valid_flags(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify logs with valid kubectl flags (--tail) works and produces less output."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_deployment_names(e2e_deployment)[0]
+    full_result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "logs", "--name", name])
+    tail_result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "component", "logs", "--name", name, "--", "--tail=5"]
+    )
+    assert tail_result.stdout.strip(), "Expected non-empty output with --tail=5"
+    assert len(tail_result.stdout) <= len(full_result.stdout), "Expected --tail=5 to produce less or equal output"
+
+
+def test_component_logs_bad_flag(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify logs with an invalid kubectl flag fails with a clean error."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_deployment_names(e2e_deployment)[0]
+    with pytest.raises(JDCliError) as exc_info:
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "logs", "--name", name, "--", "--head=20"])
+    assert "unknown flag" in str(exc_info.value).lower(), (
+        f"Expected 'unknown flag' in error message, got: {exc_info.value}"
+    )
+
+
+def test_component_logs_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify logs for a non-existent component fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "logs", "--name", "i-do-not-exist"])
+
+
+# ── component restart ───────────────────────────────────────────────────────
+
+
+def test_component_restart(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify restart completes: polls until Ready, verifies pod age < 5 minutes."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_deployment_names(e2e_deployment)[-1]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "restart", "--name", name])
+    assert "Restarted" in result.stdout, f"Expected 'Restarted' in output:\n{result.stdout}"
+
+    _poll_component_status(e2e_deployment, name, "Ready", timeout_s=120)
+
+    last_updated = _get_component_last_updated(e2e_deployment, name)
+    assert last_updated is not None, f"Could not determine last_updated for '{name}'"
+    age_minutes = (datetime.now(UTC) - last_updated).total_seconds() / 60.0
+    assert age_minutes < 5, f"Expected pod last_updated < 5 minutes after restart, got {age_minutes:.1f}m"
+
+
+def test_component_restart_wrong_type(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify restart fails for a CronJob component (wrong type)."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_cronjob_names(e2e_deployment)[0]
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "restart", "--name", name])
+
+
+def test_component_restart_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify restart for a non-existent component fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "restart", "--name", "i-do-not-exist"])
+
+
+# ── component trigger ───────────────────────────────────────────────────────
+
+
+def test_component_trigger(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify trigger creates a Job, polls until Idle, verifies last run < 2 minutes."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_cronjob_names(e2e_deployment)[0]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "trigger", "--name", name])
+    assert name in result.stdout, f"Expected '{name}' in output:\n{result.stdout}"
+    assert "Created job" in result.stdout, f"Expected 'Created job' in output:\n{result.stdout}"
+
+    _poll_component_status(e2e_deployment, name, "Idle", timeout_s=120)
+
+    last_updated = _get_component_last_updated(e2e_deployment, name)
+    assert last_updated is not None, f"Could not determine last_updated for '{name}'"
+    age_minutes = (datetime.now(UTC) - last_updated).total_seconds() / 60.0
+    assert age_minutes < 2, f"Expected last run last_updated < 2 minutes after trigger, got {age_minutes:.1f}m"
+
+
+def test_component_trigger_wrong_type(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify trigger fails for a Deployment component (wrong type)."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_deployment_names(e2e_deployment)[0]
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "trigger", "--name", name])
+
+
+def test_component_trigger_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify trigger for a non-existent component fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "trigger", "--name", "i-do-not-exist"])

--- a/libs/jupyter-deploy/jupyter_deploy/api/k8s/apps.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/k8s/apps.py
@@ -1,0 +1,162 @@
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from kubernetes.client import ApiClient, AppsV1Api, CoreV1Api
+
+
+@dataclass(frozen=True)
+class DeploymentStatus:
+    name: str
+    available: bool
+    ready_replicas: int
+    total_replicas: int
+    conditions: list[dict[str, str]] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class DeploymentInfo:
+    name: str
+    image: str
+    replicas: int
+    ready_replicas: int
+    conditions: list[dict[str, str]]
+    resource: dict[str, Any] = field(default_factory=dict)
+
+
+def _parse_conditions(deployment: object) -> list[dict[str, str]]:
+    status = getattr(deployment, "status", None)
+    conditions = getattr(status, "conditions", None) if status else None
+    if not conditions:
+        return []
+    return [
+        {
+            "type": getattr(c, "type", ""),
+            "status": getattr(c, "status", ""),
+            "message": getattr(c, "message", "") or "",
+        }
+        for c in conditions
+    ]
+
+
+def _is_available(conditions: list[dict[str, str]]) -> bool:
+    for c in conditions:
+        if c["type"] == "Available":
+            return c["status"] == "True"
+    return False
+
+
+def get_deployment_status(apps_api: AppsV1Api, name: str, namespace: str) -> DeploymentStatus:
+    """Return replica counts and availability for a Deployment."""
+    deployment = apps_api.read_namespaced_deployment(name=name, namespace=namespace)
+    deploy_name = deployment.metadata.name if deployment.metadata else ""
+    status = deployment.status
+    ready = status.ready_replicas or 0 if status else 0
+    total = status.replicas or 0 if status else 0
+    conditions = _parse_conditions(deployment)
+    return DeploymentStatus(
+        name=deploy_name,
+        available=_is_available(conditions),
+        ready_replicas=ready,
+        total_replicas=total,
+        conditions=conditions,
+    )
+
+
+def get_deployment(apps_api: AppsV1Api, name: str, namespace: str) -> DeploymentInfo:
+    """Return detailed info including the full serialized resource."""
+    deployment = apps_api.read_namespaced_deployment(name=name, namespace=namespace)
+    deploy_name = deployment.metadata.name if deployment.metadata else ""
+    spec = deployment.spec
+    image = ""
+    if spec and spec.template and spec.template.spec and spec.template.spec.containers:
+        image = spec.template.spec.containers[0].image or ""
+    status = deployment.status
+    replicas = spec.replicas or 0 if spec else 0
+    ready = status.ready_replicas or 0 if status else 0
+    conditions = _parse_conditions(deployment)
+    resource: dict[str, Any] = ApiClient().sanitize_for_serialization(deployment)
+    return DeploymentInfo(
+        name=deploy_name,
+        image=image,
+        replicas=replicas,
+        ready_replicas=ready,
+        conditions=conditions,
+        resource=resource,
+    )
+
+
+@dataclass(frozen=True)
+class PodHealthInfo:
+    name: str
+    phase: str
+    reason: str
+    last_transition: str
+
+
+def get_deployment_oldest_pod(
+    apps_api: AppsV1Api, core_api: CoreV1Api, name: str, namespace: str
+) -> PodHealthInfo | None:
+    """Return health info for the oldest pod of a deployment."""
+    deployment = apps_api.read_namespaced_deployment(name=name, namespace=namespace)
+    match_labels = deployment.spec.selector.match_labels if deployment.spec and deployment.spec.selector else None
+    if not match_labels:
+        return None
+    label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
+    pods = core_api.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
+    if not pods.items:
+        return None
+
+    pods.items.sort(
+        key=lambda p: (
+            p.metadata.creation_timestamp
+            if p.metadata and p.metadata.creation_timestamp
+            else datetime.max.replace(tzinfo=UTC)
+        ),
+    )
+    oldest = pods.items[0]
+    pod_name = oldest.metadata.name if oldest.metadata else ""
+    status = oldest.status
+    phase = status.phase or "Unknown" if status else "Unknown"
+    reason = ""
+    last_transition = ""
+
+    if status and status.container_statuses:
+        for cs in status.container_statuses:
+            state = cs.state
+            if state and state.waiting:
+                reason = state.waiting.reason or ""
+                break
+            if state and state.terminated:
+                reason = state.terminated.reason or ""
+                break
+
+    if status and status.conditions:
+        transitions = [c.last_transition_time for c in status.conditions if c.last_transition_time]
+        if transitions:
+            latest = max(transitions)
+            last_transition = _format_time(latest)
+
+    return PodHealthInfo(name=pod_name, phase=phase, reason=reason, last_transition=last_transition)
+
+
+def _format_time(dt: object | None) -> str:
+    if dt is None:
+        return ""
+    if isinstance(dt, datetime):
+        return dt.isoformat()
+    return str(dt)
+
+
+def rollout_restart(apps_api: AppsV1Api, name: str, namespace: str) -> None:
+    """Trigger a rolling restart by changing the annotation that the deployment controller watches.
+
+    The K8s API has no rollout verb; this replicates what kubectl does."""
+    body = {
+        "spec": {
+            "template": {
+                "metadata": {"annotations": {"kubectl.kubernetes.io/restartedAt": datetime.now(UTC).isoformat()}}
+            }
+        }
+    }
+    apps_api.patch_namespaced_deployment(name=name, namespace=namespace, body=body)

--- a/libs/jupyter-deploy/jupyter_deploy/api/k8s/batch.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/k8s/batch.py
@@ -1,0 +1,146 @@
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+from kubernetes.client import ApiClient, BatchV1Api, V1Job, V1ObjectMeta
+
+
+@dataclass(frozen=True)
+class CronJobStatus:
+    name: str
+    schedule: str
+    last_schedule_time: str
+    active_count: int
+    suspended: bool
+
+
+@dataclass(frozen=True)
+class CronJobInfo:
+    name: str
+    schedule: str
+    last_schedule_time: str
+    last_successful_time: str
+    active_count: int
+    suspended: bool
+    resource: dict[str, Any] = field(default_factory=dict)
+
+
+def _format_time(dt: object | None) -> str:
+    if dt is None:
+        return ""
+    if isinstance(dt, datetime):
+        return dt.isoformat()
+    return str(dt)
+
+
+def get_cronjob_status(batch_api: BatchV1Api, name: str, namespace: str) -> CronJobStatus:
+    """Read and parse the cronJob resource, return a Status object."""
+    cj = batch_api.read_namespaced_cron_job(name=name, namespace=namespace)
+    cj_name = cj.metadata.name if cj.metadata else ""
+    spec = cj.spec
+    status = cj.status
+    schedule = spec.schedule if spec else ""
+    suspended = spec.suspend if spec else False
+    last_schedule = _format_time(status.last_schedule_time if status else None)
+    active = len(status.active) if status and status.active else 0
+    return CronJobStatus(
+        name=cj_name,
+        schedule=schedule,
+        last_schedule_time=last_schedule,
+        active_count=active,
+        suspended=suspended or False,
+    )
+
+
+def get_cronjob(batch_api: BatchV1Api, name: str, namespace: str) -> CronJobInfo:
+    """Read and parse the cronJob resource, return a full serialized object."""
+    cj = batch_api.read_namespaced_cron_job(name=name, namespace=namespace)
+    cj_name = cj.metadata.name if cj.metadata else ""
+    spec = cj.spec
+    status = cj.status
+    schedule = spec.schedule if spec else ""
+    suspended = spec.suspend if spec else False
+    last_schedule = _format_time(status.last_schedule_time if status else None)
+    last_success = _format_time(status.last_successful_time if status else None)
+    active = len(status.active) if status and status.active else 0
+    resource: dict[str, Any] = ApiClient().sanitize_for_serialization(cj)
+    return CronJobInfo(
+        name=cj_name,
+        schedule=schedule,
+        last_schedule_time=last_schedule,
+        last_successful_time=last_success,
+        active_count=active,
+        suspended=suspended or False,
+        resource=resource,
+    )
+
+
+@dataclass(frozen=True)
+class JobResultInfo:
+    name: str
+    status: str
+    completion_time: str
+
+
+def find_jobs(batch_api: BatchV1Api, namespace: str, label_selector: str) -> list:
+    """List Kubernetes Jobs in the namespace using a label selector."""
+    jobs = batch_api.list_namespaced_job(namespace=namespace, label_selector=label_selector)
+    return list(jobs.items)
+
+
+def get_last_job_result(batch_api: BatchV1Api, namespace: str, label_selector: str) -> JobResultInfo | None:
+    """Return the result of the most recent job matching a label selector."""
+    matching = find_jobs(batch_api, namespace, label_selector)
+
+    if not matching:
+        return None
+
+    matching.sort(
+        key=lambda j: j.status.start_time if j.status and j.status.start_time else datetime.min.replace(tzinfo=UTC),
+        reverse=True,
+    )
+
+    latest = matching[0]
+    job_name = latest.metadata.name if latest.metadata else ""
+    status = latest.status
+
+    if status and status.active and status.active > 0:
+        result_status = "Running"
+    elif status and status.succeeded and status.succeeded > 0:
+        result_status = "Succeeded"
+    elif status and status.failed and status.failed > 0:
+        result_status = "Failed"
+    else:
+        result_status = "Unknown"
+
+    completion = _format_time(status.completion_time if status else None)
+
+    return JobResultInfo(name=job_name, status=result_status, completion_time=completion)
+
+
+def create_job_from_cronjob(batch_api: BatchV1Api, name: str, namespace: str) -> str:
+    """Create a one-off Job from a CronJob's template, return the generated Job name."""
+    cj = batch_api.read_namespaced_cron_job(name=name, namespace=namespace)
+    job_template = cj.spec.job_template
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    job_name = f"{name}-manual-{timestamp}"
+
+    template_labels: dict[str, str] = {}
+    if job_template.metadata and job_template.metadata.labels:
+        template_labels = dict(job_template.metadata.labels)
+
+    job = V1Job(
+        api_version="batch/v1",
+        kind="Job",
+        metadata=V1ObjectMeta(
+            name=job_name,
+            namespace=namespace,
+            labels=template_labels,
+            annotations={"cronjob.kubernetes.io/instantiate": "manual"},
+        ),
+        spec=job_template.spec,
+    )
+
+    batch_api.create_namespaced_job(namespace=namespace, body=job)
+    return job_name

--- a/libs/jupyter-deploy/jupyter_deploy/api/k8s/core.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/k8s/core.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-from kubernetes.client import ApiClient, AppsV1Api, CoreV1Api
+from kubernetes.client import ApiClient, CoreV1Api
 from kubernetes.stream import stream as k8s_stream
 
 
@@ -114,38 +114,6 @@ def get_pod(api: CoreV1Api, name: str, namespace: str) -> PodInfo:
     pod = api.read_namespaced_pod(name=name, namespace=namespace)
     pod_name = pod.metadata.name if pod.metadata else ""
     return PodInfo(name=pod_name, phase=_parse_pod_phase(pod))
-
-
-def get_deployment_logs(
-    core_api: CoreV1Api,
-    apps_api: AppsV1Api,
-    name: str,
-    namespace: str,
-    container: str | None = None,
-    tail_lines: int | None = None,
-) -> str:
-    deployment = apps_api.read_namespaced_deployment(name=name, namespace=namespace)
-    match_labels = deployment.spec.selector.match_labels or {}
-    label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
-    if not label_selector:
-        return ""
-
-    pods = core_api.list_namespaced_pod(namespace=namespace, label_selector=label_selector)
-    if not pods.items:
-        return ""
-
-    pod_name = pods.items[0].metadata.name if pods.items[0].metadata else ""
-    if not pod_name:
-        return ""
-
-    kwargs: dict[str, str | int] = {"name": pod_name, "namespace": namespace}
-    if container:
-        kwargs["container"] = container
-    if tail_lines:
-        kwargs["tail_lines"] = tail_lines
-
-    result: str = core_api.read_namespaced_pod_log(**kwargs)
-    return result
 
 
 @dataclass(frozen=True)

--- a/libs/jupyter-deploy/jupyter_deploy/api/k8s/utils.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/k8s/utils.py
@@ -1,0 +1,26 @@
+from datetime import UTC, datetime
+
+
+def format_age(iso_timestamp: str) -> str:
+    """Convert an ISO timestamp, return a human-readable age string (e.g. '3h ago', '2d ago')."""
+    if not iso_timestamp:
+        return ""
+    try:
+        dt = datetime.fromisoformat(iso_timestamp)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        delta = datetime.now(UTC) - dt
+        total_seconds = int(delta.total_seconds())
+    except (ValueError, TypeError):
+        return iso_timestamp
+
+    if total_seconds < 60:
+        return f"{total_seconds}s ago"
+    minutes = total_seconds // 60
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}h ago"
+    days = hours // 24
+    return f"{days}d ago"

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.table import Table
 
 from jupyter_deploy import cmd_utils
+from jupyter_deploy.cli.component_app import component_app
 from jupyter_deploy.cli.error_decorator import handle_cli_errors
 from jupyter_deploy.cli.history_app import history_app
 from jupyter_deploy.cli.host_app import host_app
@@ -56,6 +57,7 @@ class JupyterDeployCliRunner:
         self.app.add_typer(teams_app, name="teams")
         self.app.add_typer(organization_app, name="organization")
         self.app.add_typer(host_app, name="host")
+        self.app.add_typer(component_app, name="component")
         self.app.add_typer(history_app, name="history")
         self.app.add_typer(projects_app, name="projects")
 

--- a/libs/jupyter-deploy/jupyter_deploy/cli/component_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/component_app.py
@@ -1,0 +1,273 @@
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from jupyter_deploy import cmd_utils
+from jupyter_deploy.cli.error_decorator import handle_cli_errors
+from jupyter_deploy.cli.simple_display import SimpleDisplayManager
+from jupyter_deploy.enum import StatusCategory
+from jupyter_deploy.handlers.resource import component_handler
+
+
+def _format_sub_component(raw: str) -> str:
+    if not raw:
+        return ""
+    try:
+        item = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if not item:
+        return ""
+    return f"{item['name']}: {item['status']}"
+
+
+component_app = typer.Typer(
+    help="Interact with the platform components supporting your apps.",
+    no_args_is_help=True,
+)
+
+
+@component_app.command()
+def health(
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+) -> None:
+    """Display a summary of all components and their status.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = component_handler.ComponentHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner("Checking component status..."):
+            results = handler.get_all_status()
+
+        if json_output:
+            console.print(json.dumps({"components": results}), highlight=False, markup=False, soft_wrap=True)
+            return
+
+        table = Table()
+        table.add_column("Name", style="bold cyan")
+        table.add_column("Type")
+        table.add_column("Status")
+        table.add_column("Details")
+        table.add_column("Sub-component")
+        for r in results:
+            status_text = r["status"]
+            category = r.get("status_category", "")
+            if category == StatusCategory.HEALTHY:
+                status_text = f"[green]{status_text}[/green]"
+            elif category == StatusCategory.IN_PROGRESS:
+                status_text = f"[dark_goldenrod]{status_text}[/dark_goldenrod]"
+            elif category == StatusCategory.DEGRADED:
+                status_text = f"[indian_red]{status_text}[/indian_red]"
+            sub_text = _format_sub_component(r.get("sub_component", ""))
+            table.add_row(r["name"], r["type"], status_text, r["details"], sub_text)
+        console.print(table)
+
+
+@component_app.command(name="list")
+def list_components(
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+    text_output: Annotated[bool, typer.Option("--text", help="Output as comma-separated names.")] = False,
+) -> None:
+    """List components declared in the manifest.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    err_console = Console(stderr=True)
+
+    if json_output and text_output:
+        err_console.print(":x: Cannot use both --json and --text.", style="red")
+        raise typer.Exit(code=1)
+
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = component_handler.ComponentHandler(display_manager=simple_display_manager)
+        components = handler.list_components()
+
+        if json_output:
+            console.print(json.dumps(components), highlight=False, markup=False, soft_wrap=True)
+            return
+        if text_output:
+            console.out(",".join(c["name"] for c in components))
+            return
+
+        table = Table()
+        table.add_column("Name", style="bold cyan")
+        table.add_column("Type")
+        table.add_column("Description")
+        for c in components:
+            table.add_row(c["name"], c["type"], c["description"])
+        console.print(table)
+
+
+@component_app.command()
+def status(
+    name: Annotated[str, typer.Option("--name", help="Name of the component to check.")],
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+) -> None:
+    """Check the status of a particular component.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = component_handler.ComponentHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner(f"Checking status of {name}..."):
+            result = handler.get_component_status(name=name)
+
+        console.print(f"{name} status: [bold cyan]{result}[/]")
+
+
+@component_app.command()
+def show(
+    name: Annotated[str, typer.Option("--name", help="Name of the component to show details for.")],
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+    description: Annotated[
+        bool, typer.Option("--description", "-d", help="Show description instead of full details.")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+) -> None:
+    """Display detailed information about a specific component.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+
+    Pass --description to display the component's description only.
+    """
+    console = Console()
+    err_console = Console(stderr=True)
+
+    if description and json_output:
+        err_console.print(":x: --description and --json cannot be used together.", style="red")
+        raise typer.Exit(code=1)
+
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = component_handler.ComponentHandler(display_manager=simple_display_manager)
+
+        if description:
+            desc = handler.get_component_description(name=name)
+            console.print(f"[bold cyan]{desc}[/]")
+            return
+
+        with simple_display_manager.spinner(f"Getting component details for {name}..."):
+            details = handler.show_component(name=name)
+
+        if json_output:
+            console.print(json.dumps(details), highlight=False, markup=False, soft_wrap=True)
+            return
+
+        console.print_json(json.dumps(details))
+
+
+@component_app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})
+def logs(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Option("--name", help="Name of the component whose logs to display.")],
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+) -> None:
+    """Print the logs of a component.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+
+    You can pass additional arguments after '--'.
+    """
+    extra = ctx.args
+
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = component_handler.ComponentHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner(f"Fetching logs for {name}..."):
+            log_output = handler.get_component_logs(name=name, extra=extra)
+
+        if log_output:
+            console.print(log_output)
+        else:
+            console.print(":warning: no logs were retrieved.", style="yellow")
+
+
+@component_app.command()
+def restart(
+    name: Annotated[str, typer.Option("--name", help="Name of the component to restart.")],
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+) -> None:
+    """Restart a persisting component.
+
+    Only supported for persisting components.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = component_handler.ComponentHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner(f"Restarting {name}..."):
+            handler.restart_component(name=name)
+
+        simple_display_manager.success(f"Restarted '{name}'.")
+
+
+@component_app.command()
+def trigger(
+    name: Annotated[str, typer.Option("--name", help="Name of the CronJob component to trigger.")],
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+) -> None:
+    """Trigger an ephemeral job from a job-generating component.
+
+    Only supported for job-generating components.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = component_handler.ComponentHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner(f"Triggering {name}..."):
+            job_name = handler.trigger_component(name=name)
+
+        simple_display_manager.success(f"Created job '{job_name}' from '{name}'.")

--- a/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
@@ -8,6 +8,7 @@ from rich.console import Console
 
 from jupyter_deploy.exceptions import (
     CommandNotImplementedError,
+    ComponentNotFoundError,
     ConfigurationError,
     DownAutoApproveRequiredError,
     HostCommandInstructionError,
@@ -15,6 +16,7 @@ from jupyter_deploy.exceptions import (
     InstructionNotFoundError,
     InteractiveSessionError,
     InteractiveSessionTimeoutError,
+    InvalidComponentVerbError,
     InvalidInstructionArgumentError,
     InvalidInstructionResultError,
     InvalidManifestError,
@@ -188,6 +190,19 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         console.print(f":x: {e}", style="bold red")
         console.line()
         console.print(f":bulb: Run [bold cyan]{e.list_command}[/] to see available {e.resource_type}s.")
+        raise typer.Exit(code=1) from None
+
+    except ComponentNotFoundError as e:
+        console.print(f":x: {e}", style="bold red")
+        console.line()
+        console.print(f"Available components: {', '.join(e.valid_components)}")
+        console.print(":bulb: Run [bold cyan]jd component list[/] to see all components.")
+        raise typer.Exit(code=1) from None
+
+    except InvalidComponentVerbError as e:
+        console.print(f":x: {e}", style="bold red")
+        console.line()
+        console.print(f"Available actions for '{e.component_name}': {', '.join(e.valid_verbs)}")
         raise typer.Exit(code=1) from None
 
     except ResourceNotFoundError as e:

--- a/libs/jupyter-deploy/jupyter_deploy/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/enum.py
@@ -1,6 +1,14 @@
 from enum import Enum
 
 
+class StatusCategory(str, Enum):
+    """Health category for component/resource status, used by the CLI to pick display colors."""
+
+    HEALTHY = "healthy"
+    IN_PROGRESS = "in-progress"
+    DEGRADED = "degraded"
+
+
 class HostStatusType(str, Enum):
     """Types of host status checks available via `jd host status --for`."""
 

--- a/libs/jupyter-deploy/jupyter_deploy/exceptions.py
+++ b/libs/jupyter-deploy/jupyter_deploy/exceptions.py
@@ -336,6 +336,38 @@ class ResourceNameRequiredError(JupyterDeployError, ValueError):
         )
 
 
+class ComponentNotFoundError(JupyterDeployError, ValueError):
+    """Raised when a component name is not found in the manifest.
+
+    Attributes:
+        component_name: The name that was looked up
+        valid_components: List of valid component names
+    """
+
+    def __init__(self, component_name: str, valid_components: list[str]) -> None:
+        self.component_name = component_name
+        self.valid_components = valid_components
+        super().__init__(f"Component '{component_name}' not found.")
+
+
+class InvalidComponentVerbError(JupyterDeployError, ValueError):
+    """Raised when a verb is not valid for the component's type.
+
+    Attributes:
+        component_name: The component name
+        verb: The verb that was attempted
+        component_type: The component type (e.g., Deployment, CronJob)
+        valid_verbs: List of valid verbs for this component
+    """
+
+    def __init__(self, component_name: str, verb: str, component_type: str, valid_verbs: list[str]) -> None:
+        self.component_name = component_name
+        self.verb = verb
+        self.component_type = component_type
+        self.valid_verbs = valid_verbs
+        super().__init__(f"'{verb}' is not supported for {component_type} component '{component_name}'.")
+
+
 class ResourceNotFoundError(InstructionError, RuntimeError):
     """Raised when a provider resource is not found (e.g., node, pod, deployment).
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/component_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/component_handler.py
@@ -1,0 +1,200 @@
+from typing import Any
+
+from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
+from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
+from jupyter_deploy.engine.supervised_execution import DisplayManager
+from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
+from jupyter_deploy.exceptions import InvalidComponentVerbError
+from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
+from jupyter_deploy.handlers.resource.resource_utils import collect_results
+from jupyter_deploy.manifest import JupyterDeployComponentDefinitionV1
+from jupyter_deploy.provider import manifest_command_runner as cmd_runner
+from jupyter_deploy.provider.resolved_clidefs import ResolvedCliParameter, StrResolvedCliParameter
+
+
+class ComponentHandler(BaseProjectHandler):
+    """Handler class to interact with platform components."""
+
+    _output_handler: EngineOutputsHandler
+
+    def __init__(self, display_manager: DisplayManager) -> None:
+        super().__init__(display_manager=display_manager)
+
+        if self.engine == EngineType.TERRAFORM:
+            self._output_handler = tf_outputs.TerraformOutputsHandler(
+                project_path=self.project_path, project_manifest=self.project_manifest
+            )
+            self._variable_handler = tf_variables.TerraformVariablesHandler(
+                project_path=self.project_path,
+                project_manifest=self.project_manifest,
+                display_manager=self.display_manager,
+            )
+        else:
+            raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
+
+    def _resolve_namespace(self, component: JupyterDeployComponentDefinitionV1) -> str:
+        output_defs = self._output_handler.get_full_project_outputs()
+        ns_key = component.scope
+        if ns_key not in output_defs:
+            raise KeyError(f"Output '{ns_key}' not found for component namespace resolution")
+        ns_def = output_defs[ns_key]
+        if isinstance(ns_def, StrTemplateOutputDefinition) and ns_def.value:
+            return ns_def.value
+        raise ValueError(f"Output '{ns_key}' is not resolved")
+
+    def _validate_verb(self, name: str, component: JupyterDeployComponentDefinitionV1, verb: str) -> None:
+        if verb not in component.verbs:
+            raise InvalidComponentVerbError(name, verb, component.type, list(component.verbs.keys()))
+
+    def _get_command_name(self, component: JupyterDeployComponentDefinitionV1, verb: str) -> str:
+        return f"component.{component.type.lower()}.{verb}"
+
+    def _get_resource_name(self, name: str, component: JupyterDeployComponentDefinitionV1) -> str:
+        return component.resource_name or name
+
+    def _build_cli_paramdefs(
+        self,
+        name: str,
+        component: JupyterDeployComponentDefinitionV1,
+        namespace: str,
+        extra: dict[str, str] | None = None,
+    ) -> dict[str, ResolvedCliParameter[Any]]:
+        cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {
+            "name": StrResolvedCliParameter(parameter_name="name", value=name),
+            "scope": StrResolvedCliParameter(parameter_name="scope", value=namespace),
+        }
+        if component.query:
+            cli_paramdefs["query"] = StrResolvedCliParameter(parameter_name="query", value=component.query)
+        if extra:
+            for k, v in extra.items():
+                cli_paramdefs[k] = StrResolvedCliParameter(parameter_name=k, value=v)
+        return cli_paramdefs
+
+    def list_components(self) -> list[dict[str, str]]:
+        """Return the list of components with name, type, and description."""
+        components = self.project_manifest.get_components()
+        return [{"name": name, "type": comp.type, "description": comp.description} for name, comp in components.items()]
+
+    def get_component_description(self, name: str) -> str:
+        """Return the description string for a single component."""
+        component = self.project_manifest.get_component(name)
+        return component.description
+
+    def get_all_status(self) -> list[dict[str, str]]:
+        """Return status of all components for dashboard display."""
+        components = self.project_manifest.get_components()
+        results: list[dict[str, str]] = []
+        for name, comp_def in components.items():
+            namespace = self._resolve_namespace(comp_def)
+            cmd_name = self._get_command_name(comp_def, "status")
+            command = self.project_manifest.get_command(cmd_name)
+            runner = cmd_runner.ManifestCommandRunner(
+                display_manager=self.display_manager,
+                output_handler=self._output_handler,
+                variable_handler=self._variable_handler,
+            )
+            resource_name = self._get_resource_name(name, comp_def)
+            cli_paramdefs = self._build_cli_paramdefs(resource_name, comp_def, namespace)
+            runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+            status = runner.get_result_value(command, f"{cmd_name}.status", str)
+            status_category = runner.get_result_value_with_fallback(command, f"{cmd_name}.status_category", str, "")
+            details = runner.get_result_value_with_fallback(command, f"{cmd_name}.details", str, "")
+            sub_component = runner.get_result_value_with_fallback(command, f"{cmd_name}.sub_component", str, "")
+            results.append(
+                {
+                    "name": name,
+                    "type": comp_def.type,
+                    "status": status,
+                    "status_category": status_category,
+                    "details": details,
+                    "sub_component": sub_component,
+                }
+            )
+        return results
+
+    def get_component_status(self, name: str) -> str:
+        """Return the status string for a single component."""
+        component = self.project_manifest.get_component(name)
+        self._validate_verb(name, component, "status")
+        namespace = self._resolve_namespace(component)
+        resource_name = self._get_resource_name(name, component)
+        cmd_name = self._get_command_name(component, "status")
+        command = self.project_manifest.get_command(cmd_name)
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        cli_paramdefs = self._build_cli_paramdefs(resource_name, component, namespace)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+        return runner.get_result_value(command, f"{cmd_name}.status", str)
+
+    def show_component(self, name: str) -> dict[str, Any]:
+        """Return detailed information about a component."""
+        component = self.project_manifest.get_component(name)
+        self._validate_verb(name, component, "show")
+        namespace = self._resolve_namespace(component)
+        resource_name = self._get_resource_name(name, component)
+        cmd_name = self._get_command_name(component, "show")
+        command = self.project_manifest.get_command(cmd_name)
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        cli_paramdefs = self._build_cli_paramdefs(resource_name, component, namespace)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+        return collect_results(runner, command)
+
+    def get_component_logs(self, name: str, extra: list[str] | None = None) -> str:
+        """Return logs for a component."""
+        component = self.project_manifest.get_component(name)
+        self._validate_verb(name, component, "logs")
+        namespace = self._resolve_namespace(component)
+        resource_name = self._get_resource_name(name, component)
+        cmd_name = self._get_command_name(component, "logs")
+        command = self.project_manifest.get_command(cmd_name)
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        extra_params: dict[str, str] = {"extra": " ".join(extra) if extra else ""}
+        runner.run_command_sequence(
+            command, cli_paramdefs=self._build_cli_paramdefs(resource_name, component, namespace, extra=extra_params)
+        )
+        return runner.get_result_value(command, f"{cmd_name}.logs", str)
+
+    def restart_component(self, name: str) -> None:
+        """Rolling restart a component (Deployment only)."""
+        component = self.project_manifest.get_component(name)
+        self._validate_verb(name, component, "restart")
+        namespace = self._resolve_namespace(component)
+        resource_name = self._get_resource_name(name, component)
+        cmd_name = self._get_command_name(component, "restart")
+        command = self.project_manifest.get_command(cmd_name)
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        cli_paramdefs = self._build_cli_paramdefs(resource_name, component, namespace)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+
+    def trigger_component(self, name: str) -> str:
+        """Trigger a Job from a CronJob component. Returns the Job name."""
+        component = self.project_manifest.get_component(name)
+        self._validate_verb(name, component, "trigger")
+        namespace = self._resolve_namespace(component)
+        resource_name = self._get_resource_name(name, component)
+        cmd_name = self._get_command_name(component, "trigger")
+        command = self.project_manifest.get_command(cmd_name)
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        cli_paramdefs = self._build_cli_paramdefs(resource_name, component, namespace)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+        return runner.get_result_value(command, f"{cmd_name}.job_name", str)

--- a/libs/jupyter-deploy/jupyter_deploy/manifest.py
+++ b/libs/jupyter-deploy/jupyter_deploy/manifest.py
@@ -14,6 +14,7 @@ from jupyter_deploy.enum import (
 )
 from jupyter_deploy.exceptions import (
     CommandNotImplementedError,
+    ComponentNotFoundError,
     InvalidServiceError,
     InvalidStoreTypeError,
     SecretNotFoundError,
@@ -264,6 +265,21 @@ class JupyterDeployProjectStoreV1(BaseModel):
             raise InvalidStoreTypeError(self.store_type, [t.value for t in StoreType]) from None
 
 
+class JupyterDeployComponentVerbV1(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    method: str
+
+
+class JupyterDeployComponentDefinitionV1(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    type: str
+    description: str = ""
+    resource_name: str | None = Field(alias="resource-name", default=None)
+    scope: str
+    query: str = ""
+    verbs: dict[str, JupyterDeployComponentVerbV1]
+
+
 class JupyterDeployManifestV1(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
     schema_version: Literal[1]
@@ -278,6 +294,7 @@ class JupyterDeployManifestV1(BaseModel):
     server_status_rules: list[JupyterDeployStatusRuleV1] | None = Field(alias="server-status-rules", default=None)
     supervised_execution: JupyterDeploySupervisedExecutionV1 | None = Field(alias="supervised-execution", default=None)
     project_store: JupyterDeployProjectStoreV1 | None = Field(alias="project-store", default=None)
+    components: dict[str, JupyterDeployComponentDefinitionV1] | None = None
 
     def get_engine(self) -> EngineType:
         """Return the engine type."""
@@ -368,6 +385,28 @@ class JupyterDeployManifestV1(BaseModel):
     def compute_project_id(self, deployment_id: str) -> str:
         """Return a project identifier for use in the project store."""
         return f"{self.template.name}-{deployment_id}"
+
+    def get_components(self) -> dict[str, JupyterDeployComponentDefinitionV1]:
+        """Return the components map.
+
+        Raises:
+            CommandNotImplementedError if no components are declared.
+        """
+        if not self.components:
+            raise CommandNotImplementedError("component")
+        return self.components
+
+    def get_component(self, name: str) -> JupyterDeployComponentDefinitionV1:
+        """Return a single component definition by name.
+
+        Raises:
+            CommandNotImplementedError if no components are declared.
+            ComponentNotFoundError if the named component does not exist.
+        """
+        components = self.get_components()
+        if name not in components:
+            raise ComponentNotFoundError(name, list(components.keys()))
+        return components[name]
 
 
 # Combined type using discriminated union

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_apps_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_apps_runner.py
@@ -1,0 +1,125 @@
+import json
+from enum import Enum
+
+from kubernetes import client
+
+from jupyter_deploy.api.k8s import apps as k8s_apps
+from jupyter_deploy.api.k8s.utils import format_age
+from jupyter_deploy.engine.supervised_execution import DisplayManager
+from jupyter_deploy.enum import StatusCategory
+from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.provider.instruction_runner import InstructionRunner
+from jupyter_deploy.provider.resolved_argdefs import (
+    ResolvedInstructionArgument,
+    StrResolvedInstructionArgument,
+    require_arg,
+)
+from jupyter_deploy.provider.resolved_resultdefs import (
+    ResolvedInstructionResult,
+    StrResolvedInstructionResult,
+)
+
+_EMPTY_SUB_COMPONENT = ""
+
+
+class K8sAppsInstruction(str, Enum):
+    """Instructions supported by the K8s Apps (AppsV1) runner."""
+
+    GET_DEPLOYMENT_STATUS = "get-deployment-status"
+    GET_DEPLOYMENT = "get-deployment"
+    ROLLOUT_RESTART = "rollout-restart"
+
+
+class K8sAppsRunner(InstructionRunner):
+    """Runner class for Kubernetes Apps API instructions."""
+
+    def __init__(self, display_manager: DisplayManager, api_client: client.ApiClient) -> None:
+        super().__init__(display_manager)
+        self.apps_api = client.AppsV1Api(api_client)
+        self.core_api = client.CoreV1Api(api_client)
+
+    def _get_deployment_status(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Getting deployment status: {name_arg.value}")
+        status = k8s_apps.get_deployment_status(self.apps_api, name=name_arg.value, namespace=scope_arg.value)
+
+        if not status.available:
+            status_display = "Degraded"
+            status_category = StatusCategory.DEGRADED
+        elif status.ready_replicas < status.total_replicas:
+            status_display = "Updating"
+            status_category = StatusCategory.IN_PROGRESS
+        else:
+            status_display = "Ready"
+            status_category = StatusCategory.HEALTHY
+        details = f"{status.ready_replicas}/{status.total_replicas} replicas"
+
+        pod_info = k8s_apps.get_deployment_oldest_pod(
+            self.apps_api, self.core_api, name=name_arg.value, namespace=scope_arg.value
+        )
+        if pod_info:
+            sub_display = pod_info.reason or pod_info.phase
+            age = format_age(pod_info.last_transition)
+            if age:
+                sub_display += f" ({age})"
+            sub_component = json.dumps(
+                {"name": "pod (oldest)", "status": sub_display, "last_updated": pod_info.last_transition}
+            )
+        else:
+            sub_component = _EMPTY_SUB_COMPONENT
+
+        return {
+            "Name": StrResolvedInstructionResult(result_name="Name", value=status.name),
+            "Status": StrResolvedInstructionResult(result_name="Status", value=status_display),
+            "StatusCategory": StrResolvedInstructionResult(result_name="StatusCategory", value=status_category),
+            "Details": StrResolvedInstructionResult(result_name="Details", value=details),
+            "SubComponent": StrResolvedInstructionResult(result_name="SubComponent", value=sub_component),
+        }
+
+    def _get_deployment(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Getting deployment details: {name_arg.value}")
+        info = k8s_apps.get_deployment(self.apps_api, name=name_arg.value, namespace=scope_arg.value)
+
+        return {
+            "Name": StrResolvedInstructionResult(result_name="Name", value=info.name),
+            "Resource": StrResolvedInstructionResult(result_name="Resource", value=json.dumps(info.resource)),
+        }
+
+    def _rollout_restart(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Restarting deployment: {name_arg.value}")
+        k8s_apps.rollout_restart(self.apps_api, name=name_arg.value, namespace=scope_arg.value)
+
+        return {}
+
+    def execute_instruction(
+        self,
+        instruction_name: str,
+        resolved_arguments: dict[str, ResolvedInstructionArgument],
+    ) -> dict[str, ResolvedInstructionResult]:
+        try:
+            instruction = K8sAppsInstruction(instruction_name)
+        except ValueError:
+            raise InstructionNotFoundError(f"Unknown K8s apps instruction: '{instruction_name}'") from None
+
+        if instruction == K8sAppsInstruction.GET_DEPLOYMENT_STATUS:
+            return self._get_deployment_status(resolved_arguments)
+        elif instruction == K8sAppsInstruction.GET_DEPLOYMENT:
+            return self._get_deployment(resolved_arguments)
+        elif instruction == K8sAppsInstruction.ROLLOUT_RESTART:
+            return self._rollout_restart(resolved_arguments)
+
+        raise InstructionNotFoundError(f"Unknown K8s apps instruction: '{instruction_name}'")

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_batch_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_batch_runner.py
@@ -1,0 +1,189 @@
+import json
+import subprocess
+from datetime import UTC, datetime
+from enum import Enum
+
+from kubernetes import client
+
+from jupyter_deploy import cmd_utils
+from jupyter_deploy.api.k8s import batch as k8s_batch
+from jupyter_deploy.api.k8s.utils import format_age
+from jupyter_deploy.engine.supervised_execution import DisplayManager
+from jupyter_deploy.enum import StatusCategory
+from jupyter_deploy.exceptions import InstructionError, InstructionNotFoundError
+from jupyter_deploy.provider.instruction_runner import InstructionRunner
+from jupyter_deploy.provider.resolved_argdefs import (
+    ResolvedInstructionArgument,
+    StrResolvedInstructionArgument,
+    require_arg,
+    retrieve_optional_arg,
+)
+from jupyter_deploy.provider.resolved_resultdefs import (
+    ResolvedInstructionResult,
+    StrResolvedInstructionResult,
+)
+
+_EMPTY_SUB_COMPONENT = ""
+
+
+class K8sBatchInstruction(str, Enum):
+    GET_CRONJOB_STATUS = "get-cronjob-status"
+    GET_CRONJOB = "get-cronjob"
+    CREATE_JOB_FROM_CRONJOB = "create-job-from-cronjob"
+    GET_JOB_LOGS = "get-job-logs"
+
+
+class K8sBatchRunner(InstructionRunner):
+    """Runner class for Kubernetes Batch API instructions."""
+
+    def __init__(self, display_manager: DisplayManager, api_client: client.ApiClient) -> None:
+        super().__init__(display_manager)
+        self.batch_api = client.BatchV1Api(api_client)
+        self.core_api = client.CoreV1Api(api_client)
+
+    def _get_cronjob_status(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+        query_arg = retrieve_optional_arg(resolved_arguments, "query", StrResolvedInstructionArgument, "")
+
+        self.display_manager.info(f"Getting cronjob status: {name_arg.value}")
+        status = k8s_batch.get_cronjob_status(self.batch_api, name=name_arg.value, namespace=scope_arg.value)
+
+        details = status.schedule
+
+        job_result = None
+        if query_arg.value:
+            job_result = k8s_batch.get_last_job_result(
+                self.batch_api, namespace=scope_arg.value, label_selector=query_arg.value
+            )
+
+        if status.suspended:
+            status_display = "Suspended"
+            status_category = StatusCategory.DEGRADED
+        elif status.active_count > 0 or (job_result and job_result.status == "Running"):
+            status_display = "Active"
+            status_category = StatusCategory.IN_PROGRESS
+        else:
+            status_display = "Idle"
+            status_category = StatusCategory.HEALTHY
+
+        if job_result:
+            sub_display = job_result.status
+            age = format_age(job_result.completion_time)
+            if age:
+                sub_display += f" ({age})"
+            sub_component = json.dumps(
+                {"name": "run (latest)", "status": sub_display, "last_updated": job_result.completion_time}
+            )
+        else:
+            sub_component = _EMPTY_SUB_COMPONENT
+
+        return {
+            "Name": StrResolvedInstructionResult(result_name="Name", value=status.name),
+            "Status": StrResolvedInstructionResult(result_name="Status", value=status_display),
+            "StatusCategory": StrResolvedInstructionResult(result_name="StatusCategory", value=status_category),
+            "Details": StrResolvedInstructionResult(result_name="Details", value=details),
+            "SubComponent": StrResolvedInstructionResult(result_name="SubComponent", value=sub_component),
+        }
+
+    def _get_cronjob(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Getting cronjob details: {name_arg.value}")
+        info = k8s_batch.get_cronjob(self.batch_api, name=name_arg.value, namespace=scope_arg.value)
+
+        return {
+            "Name": StrResolvedInstructionResult(result_name="Name", value=info.name),
+            "Resource": StrResolvedInstructionResult(result_name="Resource", value=json.dumps(info.resource)),
+        }
+
+    def _create_job_from_cronjob(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Triggering job from cronjob: {name_arg.value}")
+        job_name = k8s_batch.create_job_from_cronjob(self.batch_api, name=name_arg.value, namespace=scope_arg.value)
+
+        return {
+            "JobName": StrResolvedInstructionResult(result_name="JobName", value=job_name),
+        }
+
+    def _resolve_cronjob_pod_name(self, cronjob_name: str, namespace: str, label_selector: str) -> str:
+        matching = k8s_batch.find_jobs(self.batch_api, namespace=namespace, label_selector=label_selector)
+
+        if not matching:
+            raise ValueError(f"No jobs found for cronjob {cronjob_name} in namespace {namespace}")
+
+        matching.sort(
+            key=lambda j: j.status.start_time if j.status and j.status.start_time else datetime.min.replace(tzinfo=UTC),
+            reverse=True,
+        )
+
+        latest_job = matching[0]
+        job_name = latest_job.metadata.name if latest_job.metadata else ""
+        if not job_name:
+            raise ValueError(f"No jobs found for cronjob {cronjob_name} in namespace {namespace}")
+
+        pods = self.core_api.list_namespaced_pod(namespace=namespace, label_selector=f"job-name={job_name}")
+        if not pods.items:
+            raise ValueError(f"No pods found for job {job_name} in namespace {namespace}")
+
+        pod_name = pods.items[0].metadata.name if pods.items[0].metadata else ""
+        if not pod_name:
+            raise ValueError(f"No pods found for job {job_name} in namespace {namespace}")
+        return pod_name
+
+    def _get_job_logs(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+        query_arg = require_arg(resolved_arguments, "query", StrResolvedInstructionArgument)
+        extra_arg = retrieve_optional_arg(resolved_arguments, "extra", StrResolvedInstructionArgument, "")
+
+        self.display_manager.info(f"Getting logs for cronjob: {name_arg.value}")
+
+        pod_name = self._resolve_cronjob_pod_name(name_arg.value, scope_arg.value, query_arg.value)
+
+        kubectl_cmd = ["kubectl", "logs", pod_name, "--namespace", scope_arg.value]
+        if extra_arg.value:
+            kubectl_cmd.extend(extra_arg.value.split())
+
+        try:
+            logs = cmd_utils.run_cmd_and_capture_output(kubectl_cmd)
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.strip() if e.stderr else ""
+            if "unknown flag" in stderr or "unknown shorthand flag" in stderr or "invalid argument" in stderr:
+                raise InstructionError(stderr) from None
+            raise
+        return {
+            "Logs": StrResolvedInstructionResult(result_name="Logs", value=logs),
+        }
+
+    def execute_instruction(
+        self,
+        instruction_name: str,
+        resolved_arguments: dict[str, ResolvedInstructionArgument],
+    ) -> dict[str, ResolvedInstructionResult]:
+        try:
+            instruction = K8sBatchInstruction(instruction_name)
+        except ValueError:
+            raise InstructionNotFoundError(f"Unknown K8s batch instruction: '{instruction_name}'") from None
+
+        if instruction == K8sBatchInstruction.GET_CRONJOB_STATUS:
+            return self._get_cronjob_status(resolved_arguments)
+        elif instruction == K8sBatchInstruction.GET_CRONJOB:
+            return self._get_cronjob(resolved_arguments)
+        elif instruction == K8sBatchInstruction.CREATE_JOB_FROM_CRONJOB:
+            return self._create_job_from_cronjob(resolved_arguments)
+        elif instruction == K8sBatchInstruction.GET_JOB_LOGS:
+            return self._get_job_logs(resolved_arguments)
+
+        raise InstructionNotFoundError(f"Unknown K8s batch instruction: '{instruction_name}'")

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_core_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_core_runner.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from enum import Enum
 
 from kubernetes import client
@@ -6,7 +7,12 @@ from kubernetes import client
 from jupyter_deploy import cmd_utils
 from jupyter_deploy.api.k8s import core as k8s_core
 from jupyter_deploy.engine.supervised_execution import DisplayManager
-from jupyter_deploy.exceptions import InstructionNotFoundError, InteractiveSessionError, InteractiveSessionTimeoutError
+from jupyter_deploy.exceptions import (
+    InstructionError,
+    InstructionNotFoundError,
+    InteractiveSessionError,
+    InteractiveSessionTimeoutError,
+)
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
 from jupyter_deploy.provider.resolved_argdefs import (
     ResolvedInstructionArgument,
@@ -126,19 +132,28 @@ class K8sCoreRunner(InstructionRunner):
         name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
         scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
         container_arg = retrieve_optional_arg(resolved_arguments, "container", StrResolvedInstructionArgument, "")
-        tail_lines_arg = retrieve_optional_arg(resolved_arguments, "tail_lines", StrResolvedInstructionArgument, "")
+        extra_arg = retrieve_optional_arg(resolved_arguments, "extra", StrResolvedInstructionArgument, "")
 
-        container = container_arg.value if container_arg.value and container_arg.value != "default" else None
         self.display_manager.info(f"Getting logs for deployment {name_arg.value} in namespace: {scope_arg.value}")
-        logs = k8s_core.get_deployment_logs(
-            self.core_api,
-            self.apps_api,
-            name=name_arg.value,
-            namespace=scope_arg.value,
-            container=container,
-            tail_lines=int(tail_lines_arg.value) if tail_lines_arg.value else None,
-        )
 
+        pod_name = self._resolve_pod_name(name_arg.value, scope_arg.value)
+        container = container_arg.value if container_arg.value and container_arg.value != "default" else None
+
+        kubectl_cmd = ["kubectl", "logs", pod_name, "--namespace", scope_arg.value]
+        if self._kubeconfig_path:
+            kubectl_cmd.extend(["--kubeconfig", self._kubeconfig_path])
+        if container:
+            kubectl_cmd.extend(["-c", container])
+        if extra_arg.value:
+            kubectl_cmd.extend(extra_arg.value.split())
+
+        try:
+            logs = cmd_utils.run_cmd_and_capture_output(kubectl_cmd)
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.strip() if e.stderr else ""
+            if "unknown flag" in stderr or "unknown shorthand flag" in stderr or "invalid argument" in stderr:
+                raise InstructionError(stderr) from None
+            raise
         return {
             "Logs": StrResolvedInstructionResult(result_name="Logs", value=logs),
         }

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_runner.py
@@ -5,6 +5,8 @@ from kubernetes import client
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.exceptions import InstructionNotFoundError
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
+from jupyter_deploy.provider.k8s.k8s_apps_runner import K8sAppsRunner
+from jupyter_deploy.provider.k8s.k8s_batch_runner import K8sBatchRunner
 from jupyter_deploy.provider.k8s.k8s_client_factory import K8sClientFactory
 from jupyter_deploy.provider.k8s.k8s_core_runner import K8sCoreRunner
 from jupyter_deploy.provider.k8s.k8s_custom_runner import K8sCustomRunner
@@ -18,6 +20,8 @@ class K8sService(str, Enum):
 
     CORE = "core"
     CUSTOM = "custom"
+    APPS = "apps"
+    BATCH = "batch"
 
 
 class K8sApiRunner(InstructionRunner):
@@ -79,6 +83,14 @@ class K8sApiRunner(InstructionRunner):
             return service_runner
         elif service_name == K8sService.CUSTOM:
             service_runner = K8sCustomRunner(self.display_manager, api_client=api_client)
+            self._service_runners[service_name] = service_runner
+            return service_runner
+        elif service_name == K8sService.APPS:
+            service_runner = K8sAppsRunner(self.display_manager, api_client=api_client)
+            self._service_runners[service_name] = service_runner
+            return service_runner
+        elif service_name == K8sService.BATCH:
+            service_runner = K8sBatchRunner(self.display_manager, api_client=api_client)
             self._service_runners[service_name] = service_runner
             return service_runner
 

--- a/libs/jupyter-deploy/tests/unit/api/k8s/test_apps.py
+++ b/libs/jupyter-deploy/tests/unit/api/k8s/test_apps.py
@@ -1,0 +1,121 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from kubernetes.client import AppsV1Api
+from kubernetes.client.exceptions import ApiException
+
+from jupyter_deploy.api.k8s.apps import (
+    DeploymentInfo,
+    DeploymentStatus,
+    get_deployment,
+    get_deployment_status,
+    rollout_restart,
+)
+
+
+def _mock_deployment(
+    name: str = "traefik",
+    ready: int = 1,
+    total: int = 1,
+    image: str = "traefik:v2.10",
+    available: bool = True,
+) -> Mock:
+    deployment: Mock = Mock()
+    deployment.metadata.name = name
+    deployment.spec.replicas = total
+    deployment.spec.template.spec.containers = [Mock(image=image)]
+    deployment.spec.selector.match_labels = {"app": name}
+    deployment.status.replicas = total
+    deployment.status.ready_replicas = ready
+
+    condition: Mock = Mock()
+    condition.type = "Available"
+    condition.status = "True" if available else "False"
+    condition.message = "Deployment has minimum availability."
+    deployment.status.conditions = [condition]
+
+    return deployment
+
+
+class TestGetDeploymentStatus(unittest.TestCase):
+    def test_returns_ready_when_available(self) -> None:
+        mock_api: Mock = Mock(spec=AppsV1Api)
+        mock_api.read_namespaced_deployment.return_value = _mock_deployment()
+
+        result = get_deployment_status(mock_api, name="traefik", namespace="kube-system")
+
+        self.assertIsInstance(result, DeploymentStatus)
+        self.assertEqual(result.name, "traefik")
+        self.assertTrue(result.available)
+        self.assertEqual(result.ready_replicas, 1)
+        self.assertEqual(result.total_replicas, 1)
+
+    def test_returns_not_available_when_degraded(self) -> None:
+        mock_api: Mock = Mock(spec=AppsV1Api)
+        mock_api.read_namespaced_deployment.return_value = _mock_deployment(ready=0, available=False)
+
+        result = get_deployment_status(mock_api, name="traefik", namespace="kube-system")
+
+        self.assertFalse(result.available)
+        self.assertEqual(result.ready_replicas, 0)
+
+    def test_passes_name_and_namespace(self) -> None:
+        mock_api: Mock = Mock(spec=AppsV1Api)
+        mock_api.read_namespaced_deployment.return_value = _mock_deployment()
+
+        get_deployment_status(mock_api, name="dex", namespace="auth")
+
+        mock_api.read_namespaced_deployment.assert_called_once_with(name="dex", namespace="auth")
+
+    def test_raises_on_not_found(self) -> None:
+        mock_api: Mock = Mock(spec=AppsV1Api)
+        mock_api.read_namespaced_deployment.side_effect = ApiException(status=404, reason="Not Found")
+
+        with self.assertRaises(ApiException):
+            get_deployment_status(mock_api, name="missing", namespace="default")
+
+
+class TestGetDeployment(unittest.TestCase):
+    @patch("jupyter_deploy.api.k8s.apps.ApiClient")
+    def test_returns_deployment_info(self, mock_api_client_cls: Mock) -> None:
+        mock_api_client_cls.return_value.sanitize_for_serialization.return_value = {"kind": "Deployment"}
+        mock_api: Mock = Mock(spec=AppsV1Api)
+        mock_api.read_namespaced_deployment.return_value = _mock_deployment(image="dex:v2.36")
+
+        result = get_deployment(mock_api, name="dex", namespace="auth")
+
+        self.assertIsInstance(result, DeploymentInfo)
+        self.assertEqual(result.name, "traefik")
+        self.assertEqual(result.image, "dex:v2.36")
+        self.assertEqual(result.replicas, 1)
+        self.assertEqual(result.ready_replicas, 1)
+        self.assertIsInstance(result.resource, dict)
+
+    def test_raises_on_not_found(self) -> None:
+        mock_api: Mock = Mock(spec=AppsV1Api)
+        mock_api.read_namespaced_deployment.side_effect = ApiException(status=404, reason="Not Found")
+
+        with self.assertRaises(ApiException):
+            get_deployment(mock_api, name="missing", namespace="default")
+
+
+class TestRolloutRestart(unittest.TestCase):
+    def test_patches_deployment_with_annotation(self) -> None:
+        mock_api: Mock = Mock(spec=AppsV1Api)
+
+        rollout_restart(mock_api, name="traefik", namespace="kube-system")
+
+        mock_api.patch_namespaced_deployment.assert_called_once()
+        call_kwargs = mock_api.patch_namespaced_deployment.call_args
+        self.assertEqual(call_kwargs.kwargs["name"], "traefik")
+        self.assertEqual(call_kwargs.kwargs["namespace"], "kube-system")
+        body = call_kwargs.kwargs["body"]
+        annotations = body["spec"]["template"]["metadata"]["annotations"]
+        self.assertIn("kubectl.kubernetes.io/restartedAt", annotations)
+
+    def test_raises_on_api_error(self) -> None:
+        mock_api: Mock = Mock(spec=AppsV1Api)
+        mock_api.patch_namespaced_deployment.side_effect = ApiException(status=403, reason="Forbidden")
+
+        with self.assertRaises(ApiException):
+            rollout_restart(mock_api, name="traefik", namespace="kube-system")

--- a/libs/jupyter-deploy/tests/unit/api/k8s/test_batch.py
+++ b/libs/jupyter-deploy/tests/unit/api/k8s/test_batch.py
@@ -1,0 +1,191 @@
+import unittest
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+from kubernetes.client import BatchV1Api
+
+from jupyter_deploy.api.k8s.batch import (
+    CronJobInfo,
+    CronJobStatus,
+    JobResultInfo,
+    create_job_from_cronjob,
+    find_jobs,
+    get_cronjob,
+    get_cronjob_status,
+    get_last_job_result,
+)
+
+
+def _mock_cronjob(
+    name: str = "jwt-rotator",
+    schedule: str = "0 */6 * * *",
+    suspended: bool = False,
+    active_count: int = 0,
+) -> Mock:
+    cj: Mock = Mock()
+    cj.metadata.name = name
+    cj.spec.schedule = schedule
+    cj.spec.suspend = suspended
+    cj.spec.job_template.spec = Mock()
+    cj.spec.job_template.metadata = Mock()
+    cj.spec.job_template.metadata.labels = {"app": name}
+    cj.status.last_schedule_time = datetime(2025, 5, 14, 6, 0, 0, tzinfo=UTC)
+    cj.status.last_successful_time = datetime(2025, 5, 14, 6, 0, 30, tzinfo=UTC)
+    cj.status.active = [Mock()] * active_count if active_count else None
+    return cj
+
+
+class TestGetCronjobStatus(unittest.TestCase):
+    def test_returns_idle_when_no_active_jobs(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        mock_api.read_namespaced_cron_job.return_value = _mock_cronjob()
+
+        result = get_cronjob_status(mock_api, name="jwt-rotator", namespace="router")
+
+        self.assertIsInstance(result, CronJobStatus)
+        self.assertEqual(result.name, "jwt-rotator")
+        self.assertEqual(result.schedule, "0 */6 * * *")
+        self.assertFalse(result.suspended)
+        self.assertEqual(result.active_count, 0)
+
+    def test_returns_suspended_status(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        mock_api.read_namespaced_cron_job.return_value = _mock_cronjob(suspended=True)
+
+        result = get_cronjob_status(mock_api, name="jwt-rotator", namespace="router")
+
+        self.assertTrue(result.suspended)
+
+    def test_returns_active_count(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        mock_api.read_namespaced_cron_job.return_value = _mock_cronjob(active_count=2)
+
+        result = get_cronjob_status(mock_api, name="jwt-rotator", namespace="router")
+
+        self.assertEqual(result.active_count, 2)
+
+
+class TestGetCronjob(unittest.TestCase):
+    @patch("jupyter_deploy.api.k8s.batch.ApiClient")
+    def test_returns_cronjob_info(self, mock_api_client_cls: Mock) -> None:
+        mock_api_client_cls.return_value.sanitize_for_serialization.return_value = {"kind": "CronJob"}
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        mock_api.read_namespaced_cron_job.return_value = _mock_cronjob()
+
+        result = get_cronjob(mock_api, name="jwt-rotator", namespace="router")
+
+        self.assertIsInstance(result, CronJobInfo)
+        self.assertEqual(result.name, "jwt-rotator")
+        self.assertEqual(result.schedule, "0 */6 * * *")
+        self.assertIsInstance(result.resource, dict)
+
+
+class TestCreateJobFromCronjob(unittest.TestCase):
+    def test_creates_job_with_manual_prefix(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        mock_api.read_namespaced_cron_job.return_value = _mock_cronjob()
+
+        job_name = create_job_from_cronjob(mock_api, name="jwt-rotator", namespace="router")
+
+        self.assertTrue(job_name.startswith("jwt-rotator-manual-"))
+        mock_api.create_namespaced_job.assert_called_once()
+
+    def test_created_job_copies_template_labels(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        mock_api.read_namespaced_cron_job.return_value = _mock_cronjob()
+
+        create_job_from_cronjob(mock_api, name="jwt-rotator", namespace="router")
+
+        call_kwargs = mock_api.create_namespaced_job.call_args
+        job_body = call_kwargs.kwargs.get("body") or call_kwargs[1]["body"]
+        labels = job_body.metadata.labels
+        self.assertEqual(labels["app"], "jwt-rotator")
+
+
+def _mock_job(name: str, start_time: datetime, succeeded: int = 0, failed: int = 0, active: int = 0) -> Mock:
+    job: Mock = Mock()
+    job.metadata.name = name
+    job.status.start_time = start_time
+    job.status.succeeded = succeeded
+    job.status.failed = failed
+    job.status.active = active
+    job.status.completion_time = datetime(2025, 5, 14, 6, 1, 0, tzinfo=UTC) if succeeded else None
+    return job
+
+
+class TestFindJobs(unittest.TestCase):
+    def test_returns_matching_jobs(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        job = _mock_job("jwt-rotator-123", datetime(2025, 5, 14, 6, 0, 0, tzinfo=UTC), succeeded=1)
+        mock_api.list_namespaced_job.return_value = Mock(items=[job])
+
+        result = find_jobs(mock_api, namespace="router", label_selector="app=jwt-rotator")
+
+        self.assertEqual(len(result), 1)
+        mock_api.list_namespaced_job.assert_called_once_with(namespace="router", label_selector="app=jwt-rotator")
+
+    def test_returns_empty_when_no_jobs(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        mock_api.list_namespaced_job.return_value = Mock(items=[])
+
+        result = find_jobs(mock_api, namespace="router", label_selector="app=jwt-rotator")
+
+        self.assertEqual(result, [])
+
+
+class TestGetLastJobResult(unittest.TestCase):
+    def test_returns_none_when_no_jobs(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        mock_api.list_namespaced_job.return_value = Mock(items=[])
+
+        result = get_last_job_result(mock_api, namespace="router", label_selector="app=jwt-rotator")
+
+        self.assertIsNone(result)
+
+    def test_returns_succeeded_for_completed_job(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        job = _mock_job("jwt-rotator-123", datetime(2025, 5, 14, 6, 0, 0, tzinfo=UTC), succeeded=1)
+        mock_api.list_namespaced_job.return_value = Mock(items=[job])
+
+        result = get_last_job_result(mock_api, namespace="router", label_selector="app=jwt-rotator")
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertIsInstance(result, JobResultInfo)
+        self.assertEqual(result.status, "Succeeded")
+        self.assertEqual(result.name, "jwt-rotator-123")
+
+    def test_returns_running_for_active_job(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        job = _mock_job("jwt-rotator-manual-456", datetime(2025, 5, 14, 6, 0, 0, tzinfo=UTC), active=1)
+        mock_api.list_namespaced_job.return_value = Mock(items=[job])
+
+        result = get_last_job_result(mock_api, namespace="router", label_selector="app=jwt-rotator")
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.status, "Running")
+
+    def test_returns_failed_for_failed_job(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        job = _mock_job("jwt-rotator-789", datetime(2025, 5, 14, 6, 0, 0, tzinfo=UTC), failed=1)
+        mock_api.list_namespaced_job.return_value = Mock(items=[job])
+
+        result = get_last_job_result(mock_api, namespace="router", label_selector="app=jwt-rotator")
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.status, "Failed")
+
+    def test_picks_most_recent_job(self) -> None:
+        mock_api: Mock = Mock(spec=BatchV1Api)
+        older = _mock_job("jwt-rotator-old", datetime(2025, 5, 14, 3, 0, 0, tzinfo=UTC), succeeded=1)
+        newer = _mock_job("jwt-rotator-new", datetime(2025, 5, 14, 6, 0, 0, tzinfo=UTC), failed=1)
+        mock_api.list_namespaced_job.return_value = Mock(items=[older, newer])
+
+        result = get_last_job_result(mock_api, namespace="router", label_selector="app=jwt-rotator")
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result.name, "jwt-rotator-new")
+        self.assertEqual(result.status, "Failed")

--- a/libs/jupyter-deploy/tests/unit/api/k8s/test_core.py
+++ b/libs/jupyter-deploy/tests/unit/api/k8s/test_core.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from kubernetes.client import AppsV1Api, CoreV1Api
+from kubernetes.client import CoreV1Api
 from kubernetes.client.exceptions import ApiException
 
 from jupyter_deploy.api.k8s.core import (
@@ -9,7 +9,6 @@ from jupyter_deploy.api.k8s.core import (
     NodeConditionStatus,
     PodPhase,
     exec_pod,
-    get_deployment_logs,
     get_node,
     get_pod,
     list_nodes,
@@ -190,70 +189,6 @@ class TestGetPod(unittest.TestCase):
 
         with self.assertRaises(ApiException):
             get_pod(mock_api, name="nonexistent", namespace="default")
-
-
-def _mock_deployment(match_labels: dict[str, str] | None = None) -> Mock:
-    deployment: Mock = Mock()
-    deployment.spec.selector.match_labels = match_labels
-    return deployment
-
-
-class TestGetDeploymentLogs(unittest.TestCase):
-    def test_returns_logs_from_first_pod(self) -> None:
-        mock_core: Mock = Mock(spec=CoreV1Api)
-        mock_apps: Mock = Mock(spec=AppsV1Api)
-        mock_apps.read_namespaced_deployment.return_value = _mock_deployment({"app": "web"})
-        mock_core.list_namespaced_pod.return_value = _mock_pod_list([_mock_pod("pod-1")])
-        mock_core.read_namespaced_pod_log.return_value = "log line 1\nlog line 2"
-
-        result = get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="default")
-
-        self.assertEqual(result, "log line 1\nlog line 2")
-        mock_apps.read_namespaced_deployment.assert_called_once_with(name="my-deploy", namespace="default")
-        mock_core.list_namespaced_pod.assert_called_once_with(namespace="default", label_selector="app=web")
-        mock_core.read_namespaced_pod_log.assert_called_once_with(name="pod-1", namespace="default")
-
-    def test_returns_empty_when_no_pods(self) -> None:
-        mock_core: Mock = Mock(spec=CoreV1Api)
-        mock_apps: Mock = Mock(spec=AppsV1Api)
-        mock_apps.read_namespaced_deployment.return_value = _mock_deployment({"app": "web"})
-        mock_core.list_namespaced_pod.return_value = _mock_pod_list([])
-
-        result = get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="default")
-
-        self.assertEqual(result, "")
-        mock_core.read_namespaced_pod_log.assert_not_called()
-
-    def test_returns_empty_when_no_match_labels(self) -> None:
-        mock_core: Mock = Mock(spec=CoreV1Api)
-        mock_apps: Mock = Mock(spec=AppsV1Api)
-        mock_apps.read_namespaced_deployment.return_value = _mock_deployment(None)
-
-        result = get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="default")
-
-        self.assertEqual(result, "")
-        mock_core.list_namespaced_pod.assert_not_called()
-
-    def test_passes_container_and_tail_lines(self) -> None:
-        mock_core: Mock = Mock(spec=CoreV1Api)
-        mock_apps: Mock = Mock(spec=AppsV1Api)
-        mock_apps.read_namespaced_deployment.return_value = _mock_deployment({"app": "web"})
-        mock_core.list_namespaced_pod.return_value = _mock_pod_list([_mock_pod("pod-1")])
-        mock_core.read_namespaced_pod_log.return_value = "last line"
-
-        get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="ns", container="main", tail_lines=10)
-
-        mock_core.read_namespaced_pod_log.assert_called_once_with(
-            name="pod-1", namespace="ns", container="main", tail_lines=10
-        )
-
-    def test_raises_on_api_error(self) -> None:
-        mock_core: Mock = Mock(spec=CoreV1Api)
-        mock_apps: Mock = Mock(spec=AppsV1Api)
-        mock_apps.read_namespaced_deployment.side_effect = _NOT_FOUND
-
-        with self.assertRaises(ApiException):
-            get_deployment_logs(mock_core, mock_apps, name="my-deploy", namespace="default")
 
 
 class TestExecPod(unittest.TestCase):

--- a/libs/jupyter-deploy/tests/unit/api/k8s/test_utils.py
+++ b/libs/jupyter-deploy/tests/unit/api/k8s/test_utils.py
@@ -1,0 +1,123 @@
+import unittest
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from jupyter_deploy.api.k8s.utils import format_age
+
+
+class TestFormatAge(unittest.TestCase):
+    def test_returns_empty_for_empty_string(self) -> None:
+        self.assertEqual(format_age(""), "")
+
+    def test_returns_seconds_ago(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 30, tzinfo=UTC)
+        timestamp = (now - timedelta(seconds=45)).isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "45s ago")
+
+    def test_returns_minutes_ago(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = (now - timedelta(minutes=15)).isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "15m ago")
+
+    def test_returns_hours_ago(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = (now - timedelta(hours=3)).isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "3h ago")
+
+    def test_returns_days_ago(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = (now - timedelta(days=5)).isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "5d ago")
+
+    def test_boundary_59_seconds_shows_seconds(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = (now - timedelta(seconds=59)).isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "59s ago")
+
+    def test_boundary_60_seconds_shows_minutes(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = (now - timedelta(seconds=60)).isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "1m ago")
+
+    def test_boundary_23_hours_shows_hours(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = (now - timedelta(hours=23)).isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "23h ago")
+
+    def test_boundary_24_hours_shows_days(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = (now - timedelta(hours=24)).isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "1d ago")
+
+    def test_naive_timestamp_treated_as_utc(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = "2025-05-14T10:00:00"
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "2h ago")
+
+    def test_invalid_timestamp_returns_original(self) -> None:
+        self.assertEqual(format_age("not-a-date"), "not-a-date")
+
+    def test_zero_seconds_shows_zero(self) -> None:
+        now = datetime(2025, 5, 14, 12, 0, 0, tzinfo=UTC)
+        timestamp = now.isoformat()
+
+        with patch("jupyter_deploy.api.k8s.utils.datetime") as mock_dt:
+            mock_dt.now.return_value = now
+            mock_dt.fromisoformat = datetime.fromisoformat
+            result = format_age(timestamp)
+
+        self.assertEqual(result, "0s ago")

--- a/libs/jupyter-deploy/tests/unit/cli/test_component_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_component_app.py
@@ -1,0 +1,419 @@
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from typer.testing import CliRunner
+
+from jupyter_deploy.cli.component_app import component_app
+
+
+class TestComponentApp(unittest.TestCase):
+    def test_help_command(self) -> None:
+        self.assertTrue(len(component_app.info.help or "") > 0, "help should not be empty")
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        for cmd in ["health", "list", "status", "show", "logs", "restart", "trigger"]:
+            self.assertTrue(result.stdout.index(cmd) > 0, f"missing command: {cmd}")
+
+    def test_no_arg_defaults_to_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(component_app, [])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(len(result.stdout) > 0)
+
+
+class TestComponentHealthCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_health_shows_dashboard(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_all_status.return_value = [
+            {
+                "name": "traefik",
+                "type": "Deployment",
+                "status": "Ready",
+                "details": "1/1 replicas",
+                "sub_component": '{"name": "traefik-abc", "status": "Running"}',
+            },
+        ]
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["health"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.get_all_status.assert_called_once()
+        self.assertIn("traefik", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_health_json_output(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_all_status.return_value = [
+            {
+                "name": "traefik",
+                "type": "Deployment",
+                "status": "Ready",
+                "details": "1/1 replicas",
+                "sub_component": '{"name": "traefik-abc", "status": "Running"}',
+            },
+        ]
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["health", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('"components"', result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_health_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_all_status.return_value = []
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["health", "--path", "/test/dir"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/test/dir"))
+
+
+class TestComponentListCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_list_shows_table(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.list_components.return_value = [
+            {"name": "traefik", "type": "Deployment", "description": "Ingress controller"},
+            {"name": "dex", "type": "Deployment", "description": "Identity provider"},
+            {"name": "jwt-rotator", "type": "CronJob", "description": "Rotates JWT keys"},
+        ]
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["list"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.list_components.assert_called_once()
+        self.assertIn("traefik", result.stdout)
+        self.assertIn("Deployment", result.stdout)
+        self.assertIn("Ingress controller", result.stdout)
+        self.assertIn("jwt-rotator", result.stdout)
+        self.assertIn("CronJob", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_list_json_output(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.list_components.return_value = [
+            {"name": "traefik", "type": "Deployment", "description": "Ingress controller"},
+            {"name": "dex", "type": "Deployment", "description": "Identity provider"},
+        ]
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["list", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('"name"', result.stdout)
+        self.assertIn('"type"', result.stdout)
+        self.assertIn('"description"', result.stdout)
+        self.assertIn("traefik", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_list_text_output(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.list_components.return_value = [
+            {"name": "traefik", "type": "Deployment", "description": "Ingress controller"},
+            {"name": "dex", "type": "Deployment", "description": "Identity provider"},
+        ]
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["list", "--text"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("traefik,dex", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_list_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.list_components.return_value = []
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["list", "--path", "/my/project"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/my/project"))
+
+    def test_list_rejects_json_and_text_together(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["list", "--json", "--text"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestComponentStatusCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_status_prints_result(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_component_status.return_value = "Ready"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["status", "--name", "traefik"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.get_component_status.assert_called_once_with(name="traefik")
+        self.assertIn("Ready", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_status_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_component_status.return_value = "Ready"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["status", "--name", "traefik", "--path", "/my/project"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/my/project"))
+
+    def test_status_requires_name(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["status"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestComponentShowCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_calls_show_component(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.show_component.return_value = {"name": "traefik", "image": "traefik:v2.10"}
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["show", "--name", "traefik"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.show_component.assert_called_once_with(name="traefik")
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_description_outputs_text(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_component_description.return_value = "Ingress controller and reverse proxy"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["show", "--name", "traefik", "--description"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.get_component_description.assert_called_once_with(name="traefik")
+        self.assertIn("Ingress controller and reverse proxy", result.stdout)
+        mock_handler.show_component.assert_not_called()
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_json_output(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.show_component.return_value = {"name": "traefik", "image": "traefik:v2.10", "replicas": 1}
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["show", "--name", "traefik", "--json"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('"name"', result.stdout)
+        self.assertIn('"traefik"', result.stdout)
+        self.assertIn('"replicas"', result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_show_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.show_component.return_value = {"name": "traefik"}
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["show", "--name", "traefik", "--path", "/my/project"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/my/project"))
+
+    def test_show_rejects_description_and_json_together(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["show", "--name", "dex", "--description", "--json"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+
+class TestComponentLogsCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_logs_calls_get_component_logs(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_component_logs.return_value = "log line 1\nlog line 2"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["logs", "--name", "traefik"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.get_component_logs.assert_called_once_with(name="traefik", extra=[])
+        self.assertIn("log line 1", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_logs_passes_extra_args(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_component_logs.return_value = "filtered"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["logs", "--name", "traefik", "--", "--tail=50"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.get_component_logs.assert_called_once_with(name="traefik", extra=["--tail=50"])
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_logs_prints_warning_when_empty(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_component_logs.return_value = ""
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["logs", "--name", "traefik"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.get_component_logs.assert_called_once_with(name="traefik", extra=[])
+        self.assertIn("no logs", result.stdout)
+
+
+class TestComponentLogsPathCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_logs_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.get_component_logs.return_value = "log"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["logs", "--name", "traefik", "--path", "/my/project"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/my/project"))
+
+
+class TestComponentRestartCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_restart_calls_restart_component(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["restart", "--name", "traefik"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.restart_component.assert_called_once_with(name="traefik")
+        self.assertIn("Restarted", result.stdout)
+
+
+class TestComponentRestartPathCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_restart_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["restart", "--name", "traefik", "--path", "/my/project"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/my/project"))
+
+
+class TestComponentTriggerCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_trigger_calls_trigger_component(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.trigger_component.return_value = "jwt-rotator-manual-20250514"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["trigger", "--name", "jwt-rotator"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.trigger_component.assert_called_once_with(name="jwt-rotator")
+        self.assertIn("jwt-rotator-manual-20250514", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_trigger_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.trigger_component.return_value = "jwt-rotator-manual-20250514"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["trigger", "--name", "jwt-rotator", "--path", "/my/project"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/my/project"))

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_component_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_component_handler.py
@@ -1,0 +1,465 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
+from jupyter_deploy.exceptions import ComponentNotFoundError, InvalidComponentVerbError
+from jupyter_deploy.handlers.resource.component_handler import ComponentHandler
+from jupyter_deploy.manifest import JupyterDeployComponentDefinitionV1, JupyterDeployComponentVerbV1
+
+
+def _mock_component_deployment() -> JupyterDeployComponentDefinitionV1:
+    return JupyterDeployComponentDefinitionV1(
+        type="Deployment",
+        scope="workspace_router_namespace",
+        verbs={
+            "status": JupyterDeployComponentVerbV1(method="k8s.apps.get-deployment-status"),
+            "show": JupyterDeployComponentVerbV1(method="k8s.apps.get-deployment"),
+            "logs": JupyterDeployComponentVerbV1(method="k8s.core.deployment-logs"),
+            "restart": JupyterDeployComponentVerbV1(method="k8s.apps.rollout-restart"),
+        },
+    )
+
+
+def _mock_component_cronjob() -> JupyterDeployComponentDefinitionV1:
+    return JupyterDeployComponentDefinitionV1(
+        type="CronJob",
+        scope="workspace_router_namespace",
+        query="app=jwt-rotator",
+        verbs={
+            "status": JupyterDeployComponentVerbV1(method="k8s.batch.get-cronjob-status"),
+            "show": JupyterDeployComponentVerbV1(method="k8s.batch.get-cronjob"),
+            "logs": JupyterDeployComponentVerbV1(method="k8s.batch.get-job-logs"),
+            "trigger": JupyterDeployComponentVerbV1(method="k8s.batch.create-job-from-cronjob"),
+        },
+    )
+
+
+_NS_OUTPUTS = {
+    "workspace_router_namespace": StrTemplateOutputDefinition(
+        output_name="workspace_router_namespace", value="router-ns"
+    )
+}
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerGetComponentStatus(unittest.TestCase):
+    def test_returns_status_for_deployment(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value.return_value = "Ready"
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            mock_command: Mock = Mock()
+            manifest.get_command.return_value = mock_command
+
+            handler = ComponentHandler(display_manager=Mock())
+            result = handler.get_component_status("traefik")
+
+        self.assertEqual(result, "Ready")
+        manifest.get_command.assert_called_once_with("component.deployment.status")
+        mock_runner.run_command_sequence.assert_called_once()
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["name"].value, "traefik")
+        self.assertEqual(cli_paramdefs["scope"].value, "router-ns")
+
+    def test_passes_query_for_cronjob(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_cronjob()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value.return_value = "Idle"
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            handler.get_component_status("jwt-rotator")
+
+        manifest.get_command.assert_called_once_with("component.cronjob.status")
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["query"].value, "app=jwt-rotator")
+
+    def test_error_bubbles_up(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = RuntimeError("API failure")
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            with self.assertRaises(RuntimeError):
+                handler.get_component_status("traefik")
+
+    def test_raises_component_not_found(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.side_effect = ComponentNotFoundError("unknown", ["traefik", "dex"])
+        mock_manifest_fn.return_value = manifest
+
+        handler = ComponentHandler(display_manager=Mock())
+
+        with self.assertRaises(ComponentNotFoundError) as ctx:
+            handler.get_component_status("unknown")
+
+        self.assertEqual(ctx.exception.component_name, "unknown")
+        self.assertIn("traefik", ctx.exception.valid_components)
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerVerbValidation(unittest.TestCase):
+    def test_raises_invalid_verb_for_restart_on_cronjob(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_cronjob()
+        mock_manifest_fn.return_value = manifest
+
+        handler = ComponentHandler(display_manager=Mock())
+
+        with self.assertRaises(InvalidComponentVerbError) as ctx:
+            handler.restart_component("jwt-rotator")
+
+        self.assertEqual(ctx.exception.verb, "restart")
+        self.assertEqual(ctx.exception.component_type, "CronJob")
+        self.assertIn("trigger", ctx.exception.valid_verbs)
+
+    def test_raises_invalid_verb_for_trigger_on_deployment(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        handler = ComponentHandler(display_manager=Mock())
+
+        with self.assertRaises(InvalidComponentVerbError) as ctx:
+            handler.trigger_component("traefik")
+
+        self.assertEqual(ctx.exception.verb, "trigger")
+        self.assertEqual(ctx.exception.component_type, "Deployment")
+        self.assertIn("restart", ctx.exception.valid_verbs)
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerGetAllStatus(unittest.TestCase):
+    def test_returns_status_for_all_components(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_components.return_value = {
+            "traefik": _mock_component_deployment(),
+            "jwt-rotator": _mock_component_cronjob(),
+        }
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value.return_value = "Ready"
+        mock_runner.get_result_value_with_fallback.return_value = "1/1 replicas"
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            results = handler.get_all_status()
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]["name"], "traefik")
+        self.assertEqual(results[0]["status"], "Ready")
+        self.assertEqual(results[1]["name"], "jwt-rotator")
+        manifest.get_command.assert_any_call("component.deployment.status")
+        manifest.get_command.assert_any_call("component.cronjob.status")
+
+    def test_error_bubbles_up(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_components.return_value = {
+            "traefik": _mock_component_deployment(),
+        }
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        with patch(
+            "jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner"
+        ) as mock_runner_cls:
+            mock_runner_cls.return_value.run_command_sequence.side_effect = RuntimeError("API failure")
+            manifest.get_command.return_value = Mock()
+            handler = ComponentHandler(display_manager=Mock())
+
+            with self.assertRaises(RuntimeError):
+                handler.get_all_status()
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerShowComponent(unittest.TestCase):
+    def test_calls_show_command_with_correct_args(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value.return_value = ""
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            mock_command: Mock = Mock()
+            mock_command.results = []
+            manifest.get_command.return_value = mock_command
+
+            handler = ComponentHandler(display_manager=Mock())
+            handler.show_component("traefik")
+
+        manifest.get_command.assert_called_once_with("component.deployment.show")
+        mock_runner.run_command_sequence.assert_called_once()
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["name"].value, "traefik")
+        self.assertEqual(cli_paramdefs["scope"].value, "router-ns")
+
+    def test_error_bubbles_up(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = RuntimeError("API failure")
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            with self.assertRaises(RuntimeError):
+                handler.show_component("traefik")
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerGetComponentLogs(unittest.TestCase):
+    def test_calls_logs_command_with_extra(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value.return_value = "log line"
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            result = handler.get_component_logs("traefik", extra=["--tail=50", "--since=1h"])
+
+        self.assertEqual(result, "log line")
+        manifest.get_command.assert_called_once_with("component.deployment.logs")
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["name"].value, "traefik")
+        self.assertEqual(cli_paramdefs["scope"].value, "router-ns")
+        self.assertEqual(cli_paramdefs["extra"].value, "--tail=50 --since=1h")
+
+    def test_passes_empty_extra_when_none(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value.return_value = ""
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            handler.get_component_logs("traefik")
+
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["extra"].value, "")
+
+    def test_error_bubbles_up(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = RuntimeError("API failure")
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            with self.assertRaises(RuntimeError):
+                handler.get_component_logs("traefik")
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerRestartComponent(unittest.TestCase):
+    def test_calls_restart_command(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            handler.restart_component("traefik")
+
+        manifest.get_command.assert_called_once_with("component.deployment.restart")
+        mock_runner.run_command_sequence.assert_called_once()
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["name"].value, "traefik")
+        self.assertEqual(cli_paramdefs["scope"].value, "router-ns")
+
+    def test_error_bubbles_up(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = RuntimeError("API failure")
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            with self.assertRaises(RuntimeError):
+                handler.restart_component("traefik")
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerTriggerComponent(unittest.TestCase):
+    def test_calls_trigger_command_and_returns_job_name(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_cronjob()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value.return_value = "jwt-rotator-manual-20250514"
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            result = handler.trigger_component("jwt-rotator")
+
+        self.assertEqual(result, "jwt-rotator-manual-20250514")
+        manifest.get_command.assert_called_once_with("component.cronjob.trigger")
+        mock_runner.run_command_sequence.assert_called_once()
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["name"].value, "jwt-rotator")
+        self.assertEqual(cli_paramdefs["scope"].value, "router-ns")
+        self.assertEqual(cli_paramdefs["query"].value, "app=jwt-rotator")
+
+    def test_error_bubbles_up(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_cronjob()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = RuntimeError("API failure")
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            with self.assertRaises(RuntimeError):
+                handler.trigger_component("jwt-rotator")

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_apps_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_apps_runner.py
@@ -1,0 +1,120 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from kubernetes.client.exceptions import ApiException
+
+from jupyter_deploy.api.k8s.apps import DeploymentInfo, DeploymentStatus
+from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.provider.k8s.k8s_apps_runner import K8sAppsRunner
+from jupyter_deploy.provider.resolved_argdefs import StrResolvedInstructionArgument
+
+
+def _build_args(name: str = "traefik", scope: str = "kube-system") -> dict:
+    return {
+        "name": StrResolvedInstructionArgument(argument_name="name", value=name),
+        "scope": StrResolvedInstructionArgument(argument_name="scope", value=scope),
+    }
+
+
+class TestK8sAppsRunnerGetDeploymentStatus(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_deployment_oldest_pod")
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_deployment_status")
+    def test_returns_ready_status(self, mock_get_status: Mock, mock_oldest_pod: Mock) -> None:
+        mock_get_status.return_value = DeploymentStatus(
+            name="traefik", available=True, ready_replicas=1, total_replicas=1, conditions=[]
+        )
+        mock_oldest_pod.return_value = None
+        display_manager: Mock = Mock()
+        runner = K8sAppsRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("get-deployment-status", _build_args())
+
+        self.assertEqual(result["Status"].value, "Ready")
+        self.assertEqual(result["Details"].value, "1/1 replicas")
+        self.assertIn("SubComponent", result)
+
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_deployment_oldest_pod")
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_deployment_status")
+    def test_returns_degraded_status(self, mock_get_status: Mock, mock_oldest_pod: Mock) -> None:
+        mock_get_status.return_value = DeploymentStatus(
+            name="traefik", available=False, ready_replicas=0, total_replicas=1, conditions=[]
+        )
+        mock_oldest_pod.return_value = None
+        display_manager: Mock = Mock()
+        runner = K8sAppsRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("get-deployment-status", _build_args())
+
+        self.assertEqual(result["Status"].value, "Degraded")
+        self.assertEqual(result["Details"].value, "0/1 replicas")
+
+
+class TestK8sAppsRunnerGetDeploymentStatusApiError(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_deployment_status")
+    def test_api_exception_bubbles_up(self, mock_get_status: Mock) -> None:
+        mock_get_status.side_effect = ApiException(status=404, reason="Not Found")
+        runner = K8sAppsRunner(display_manager=Mock(), api_client=Mock())
+
+        with self.assertRaises(ApiException):
+            runner.execute_instruction("get-deployment-status", _build_args())
+
+
+class TestK8sAppsRunnerGetDeployment(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_deployment")
+    def test_returns_resource_json(self, mock_get: Mock) -> None:
+        mock_get.return_value = DeploymentInfo(
+            name="traefik",
+            image="traefik:v2.10",
+            replicas=1,
+            ready_replicas=1,
+            conditions=[],
+            resource={"kind": "Deployment"},
+        )
+        display_manager: Mock = Mock()
+        runner = K8sAppsRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("get-deployment", _build_args())
+
+        self.assertEqual(result["Name"].value, "traefik")
+        self.assertIn("Deployment", result["Resource"].value)
+
+
+class TestK8sAppsRunnerGetDeploymentApiError(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_deployment")
+    def test_api_exception_bubbles_up(self, mock_get: Mock) -> None:
+        mock_get.side_effect = ApiException(status=404, reason="Not Found")
+        runner = K8sAppsRunner(display_manager=Mock(), api_client=Mock())
+
+        with self.assertRaises(ApiException):
+            runner.execute_instruction("get-deployment", _build_args())
+
+
+class TestK8sAppsRunnerRolloutRestart(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.rollout_restart")
+    def test_calls_rollout_restart(self, mock_restart: Mock) -> None:
+        display_manager: Mock = Mock()
+        runner = K8sAppsRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("rollout-restart", _build_args())
+
+        mock_restart.assert_called_once()
+        self.assertEqual(result, {})
+
+
+class TestK8sAppsRunnerRolloutRestartApiError(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.rollout_restart")
+    def test_api_exception_bubbles_up(self, mock_restart: Mock) -> None:
+        mock_restart.side_effect = ApiException(status=403, reason="Forbidden")
+        runner = K8sAppsRunner(display_manager=Mock(), api_client=Mock())
+
+        with self.assertRaises(ApiException):
+            runner.execute_instruction("rollout-restart", _build_args())
+
+
+class TestK8sAppsRunnerUnknownInstruction(unittest.TestCase):
+    def test_raises_instruction_not_found(self) -> None:
+        display_manager: Mock = Mock()
+        runner = K8sAppsRunner(display_manager=display_manager, api_client=Mock())
+
+        with self.assertRaises(InstructionNotFoundError):
+            runner.execute_instruction("unknown-instruction", _build_args())

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_batch_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_batch_runner.py
@@ -1,0 +1,179 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from kubernetes.client.exceptions import ApiException
+
+from jupyter_deploy.api.k8s.batch import CronJobStatus, JobResultInfo
+from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.provider.k8s.k8s_batch_runner import K8sBatchRunner
+from jupyter_deploy.provider.resolved_argdefs import StrResolvedInstructionArgument
+
+
+def _build_args(name: str = "jwt-rotator", scope: str = "router", query: str = "app=jwt-rotator") -> dict:
+    return {
+        "name": StrResolvedInstructionArgument(argument_name="name", value=name),
+        "scope": StrResolvedInstructionArgument(argument_name="scope", value=scope),
+        "query": StrResolvedInstructionArgument(argument_name="query", value=query),
+    }
+
+
+class TestK8sBatchRunnerGetCronjobStatus(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_last_job_result")
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_cronjob_status")
+    def test_returns_idle_status(self, mock_get_status: Mock, mock_last_job: Mock) -> None:
+        mock_get_status.return_value = CronJobStatus(
+            name="jwt-rotator",
+            schedule="0 */6 * * *",
+            last_schedule_time="2025-05-14T06:00:00",
+            active_count=0,
+            suspended=False,
+        )
+        mock_last_job.return_value = None
+        display_manager: Mock = Mock()
+        runner = K8sBatchRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("get-cronjob-status", _build_args())
+
+        self.assertEqual(result["Status"].value, "Idle")
+        self.assertEqual(result["Details"].value, "0 */6 * * *")
+        self.assertIn("SubComponent", result)
+
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_last_job_result")
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_cronjob_status")
+    def test_returns_suspended_status(self, mock_get_status: Mock, mock_last_job: Mock) -> None:
+        mock_get_status.return_value = CronJobStatus(
+            name="jwt-rotator", schedule="0 */6 * * *", last_schedule_time="", active_count=0, suspended=True
+        )
+        mock_last_job.return_value = None
+        display_manager: Mock = Mock()
+        runner = K8sBatchRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("get-cronjob-status", _build_args())
+
+        self.assertEqual(result["Status"].value, "Suspended")
+
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_last_job_result")
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_cronjob_status")
+    def test_returns_active_status(self, mock_get_status: Mock, mock_last_job: Mock) -> None:
+        mock_get_status.return_value = CronJobStatus(
+            name="jwt-rotator", schedule="0 */6 * * *", last_schedule_time="", active_count=1, suspended=False
+        )
+        mock_last_job.return_value = None
+        display_manager: Mock = Mock()
+        runner = K8sBatchRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("get-cronjob-status", _build_args())
+
+        self.assertEqual(result["Status"].value, "Active")
+
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_last_job_result")
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_cronjob_status")
+    def test_returns_active_when_manual_job_running(self, mock_get_status: Mock, mock_last_job: Mock) -> None:
+        mock_get_status.return_value = CronJobStatus(
+            name="jwt-rotator", schedule="0 */6 * * *", last_schedule_time="", active_count=0, suspended=False
+        )
+        mock_last_job.return_value = JobResultInfo(name="jwt-rotator-manual-123", status="Running", completion_time="")
+        display_manager: Mock = Mock()
+        runner = K8sBatchRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("get-cronjob-status", _build_args())
+
+        self.assertEqual(result["Status"].value, "Active")
+        self.assertEqual(result["StatusCategory"].value, "in-progress")
+
+
+class TestK8sBatchRunnerGetCronjobStatusApiError(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.get_cronjob_status")
+    def test_api_exception_bubbles_up(self, mock_get_status: Mock) -> None:
+        mock_get_status.side_effect = ApiException(status=404, reason="Not Found")
+        runner = K8sBatchRunner(display_manager=Mock(), api_client=Mock())
+
+        with self.assertRaises(ApiException):
+            runner.execute_instruction("get-cronjob-status", _build_args())
+
+
+class TestK8sBatchRunnerCreateJobFromCronjob(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.create_job_from_cronjob")
+    def test_returns_job_name(self, mock_create: Mock) -> None:
+        mock_create.return_value = "jwt-rotator-manual-20250514"
+        display_manager: Mock = Mock()
+        runner = K8sBatchRunner(display_manager=display_manager, api_client=Mock())
+
+        result = runner.execute_instruction("create-job-from-cronjob", _build_args())
+
+        self.assertEqual(result["JobName"].value, "jwt-rotator-manual-20250514")
+
+
+class TestK8sBatchRunnerCreateJobFromCronjobApiError(unittest.TestCase):
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.create_job_from_cronjob")
+    def test_api_exception_bubbles_up(self, mock_create: Mock) -> None:
+        mock_create.side_effect = ApiException(status=403, reason="Forbidden")
+        runner = K8sBatchRunner(display_manager=Mock(), api_client=Mock())
+
+        with self.assertRaises(ApiException):
+            runner.execute_instruction("create-job-from-cronjob", _build_args())
+
+
+class TestK8sBatchRunnerGetJobLogs(unittest.TestCase):
+    def _make_runner(self) -> K8sBatchRunner:
+        with patch("jupyter_deploy.provider.k8s.k8s_batch_runner.client") as mock_client_mod:
+            mock_client_mod.BatchV1Api.return_value = Mock()
+            mock_client_mod.CoreV1Api.return_value = Mock()
+            return K8sBatchRunner(display_manager=Mock(), api_client=Mock())
+
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.find_jobs")
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.cmd_utils")
+    def test_returns_logs(self, mock_cmd_utils: Mock, mock_find_jobs: Mock) -> None:
+        runner = self._make_runner()
+        mock_core_api: Mock = runner.core_api  # type: ignore[assignment]
+
+        job: Mock = Mock()
+        job.metadata.name = "jwt-rotator-123"
+        job.status.start_time = None
+        mock_find_jobs.return_value = [job]
+
+        pod: Mock = Mock()
+        pod.metadata.name = "jwt-rotator-123-abc"
+        mock_core_api.list_namespaced_pod.return_value = Mock(items=[pod])
+        mock_cmd_utils.run_cmd_and_capture_output.return_value = "key rotated"
+
+        result = runner.execute_instruction("get-job-logs", _build_args())
+
+        self.assertEqual(result["Logs"].value, "key rotated")
+        mock_cmd_utils.run_cmd_and_capture_output.assert_called_once_with(
+            ["kubectl", "logs", "jwt-rotator-123-abc", "--namespace", "router"]
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.k8s_batch.find_jobs")
+    @patch("jupyter_deploy.provider.k8s.k8s_batch_runner.cmd_utils")
+    def test_passes_extra_args(self, mock_cmd_utils: Mock, mock_find_jobs: Mock) -> None:
+        runner = self._make_runner()
+        mock_core_api: Mock = runner.core_api  # type: ignore[assignment]
+
+        job: Mock = Mock()
+        job.metadata.name = "jwt-rotator-123"
+        job.status.start_time = None
+        mock_find_jobs.return_value = [job]
+
+        pod: Mock = Mock()
+        pod.metadata.name = "jwt-rotator-123-abc"
+        mock_core_api.list_namespaced_pod.return_value = Mock(items=[pod])
+        mock_cmd_utils.run_cmd_and_capture_output.return_value = "last 20 lines"
+
+        args = _build_args()
+        args["extra"] = StrResolvedInstructionArgument(argument_name="extra", value="--tail=20 --since=1h")
+        result = runner.execute_instruction("get-job-logs", args)
+
+        self.assertEqual(result["Logs"].value, "last 20 lines")
+        mock_cmd_utils.run_cmd_and_capture_output.assert_called_once_with(
+            ["kubectl", "logs", "jwt-rotator-123-abc", "--namespace", "router", "--tail=20", "--since=1h"]
+        )
+
+
+class TestK8sBatchRunnerUnknownInstruction(unittest.TestCase):
+    def test_raises_instruction_not_found(self) -> None:
+        display_manager: Mock = Mock()
+        runner = K8sBatchRunner(display_manager=display_manager, api_client=Mock())
+
+        with self.assertRaises(InstructionNotFoundError):
+            runner.execute_instruction("unknown-instruction", _build_args())

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_core_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_core_runner.py
@@ -1,9 +1,15 @@
+import subprocess
 import unittest
 from unittest.mock import Mock, patch
 
 from jupyter_deploy.api.k8s.core import ExecResult, NodeConditionStatus, NodeInfo, PodInfo, PodPhase
 from jupyter_deploy.engine.supervised_execution import NullDisplay
-from jupyter_deploy.exceptions import InstructionNotFoundError, InteractiveSessionError, InteractiveSessionTimeoutError
+from jupyter_deploy.exceptions import (
+    InstructionError,
+    InstructionNotFoundError,
+    InteractiveSessionError,
+    InteractiveSessionTimeoutError,
+)
 from jupyter_deploy.provider.k8s.k8s_core_runner import K8sCoreRunner
 from jupyter_deploy.provider.resolved_argdefs import StrResolvedInstructionArgument
 
@@ -196,10 +202,19 @@ class TestK8sCoreRunner(unittest.TestCase):
         self.assertEqual(result["Name"].value, "pod-1")
         self.assertEqual(result["Phase"].value, "Running")
 
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
     @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
-    def test_deployment_logs_returns_logs(self, mock_k8s_core: Mock) -> None:
+    def test_deployment_logs_returns_logs(self, mock_k8s_core: Mock, mock_cmd_utils: Mock) -> None:
         runner = self._make_runner()
-        mock_k8s_core.get_deployment_logs.return_value = "log output"
+        mock_deployment: Mock = Mock()
+        mock_deployment.spec.selector.match_labels = {"app": "web"}
+        mock_apps_api: Mock = runner.apps_api  # type: ignore[assignment]
+        mock_apps_api.read_namespaced_deployment.return_value = mock_deployment
+        mock_k8s_core.list_pods.return_value = (
+            [PodInfo(name="web-pod-abc", phase=PodPhase.RUNNING)],
+            None,
+        )
+        mock_cmd_utils.run_cmd_and_capture_output.return_value = "log output"
 
         result = runner.execute_instruction(
             instruction_name="deployment-logs",
@@ -210,19 +225,23 @@ class TestK8sCoreRunner(unittest.TestCase):
         )
 
         self.assertEqual(result["Logs"].value, "log output")
-        mock_k8s_core.get_deployment_logs.assert_called_once_with(
-            runner.core_api,
-            runner.apps_api,
-            name="my-deploy",
-            namespace="default",
-            container=None,
-            tail_lines=None,
+        mock_cmd_utils.run_cmd_and_capture_output.assert_called_once_with(
+            ["kubectl", "logs", "web-pod-abc", "--namespace", "default"]
         )
 
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
     @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
-    def test_deployment_logs_passes_container_and_tail_lines(self, mock_k8s_core: Mock) -> None:
-        runner = self._make_runner()
-        mock_k8s_core.get_deployment_logs.return_value = "log"
+    def test_deployment_logs_passes_container_and_extra(self, mock_k8s_core: Mock, mock_cmd_utils: Mock) -> None:
+        runner = self._make_runner(kubeconfig_path="/tmp/kubeconfig")
+        mock_deployment: Mock = Mock()
+        mock_deployment.spec.selector.match_labels = {"app": "web"}
+        mock_apps_api: Mock = runner.apps_api  # type: ignore[assignment]
+        mock_apps_api.read_namespaced_deployment.return_value = mock_deployment
+        mock_k8s_core.list_pods.return_value = (
+            [PodInfo(name="web-pod-abc", phase=PodPhase.RUNNING)],
+            None,
+        )
+        mock_cmd_utils.run_cmd_and_capture_output.return_value = "log"
 
         runner.execute_instruction(
             instruction_name="deployment-logs",
@@ -230,17 +249,24 @@ class TestK8sCoreRunner(unittest.TestCase):
                 "name": StrResolvedInstructionArgument(argument_name="name", value="my-deploy"),
                 "scope": StrResolvedInstructionArgument(argument_name="scope", value="ns"),
                 "container": StrResolvedInstructionArgument(argument_name="container", value="main"),
-                "tail_lines": StrResolvedInstructionArgument(argument_name="tail_lines", value="50"),
+                "extra": StrResolvedInstructionArgument(argument_name="extra", value="--tail=50 --since=1h"),
             },
         )
 
-        mock_k8s_core.get_deployment_logs.assert_called_once_with(
-            runner.core_api,
-            runner.apps_api,
-            name="my-deploy",
-            namespace="ns",
-            container="main",
-            tail_lines=50,
+        mock_cmd_utils.run_cmd_and_capture_output.assert_called_once_with(
+            [
+                "kubectl",
+                "logs",
+                "web-pod-abc",
+                "--namespace",
+                "ns",
+                "--kubeconfig",
+                "/tmp/kubeconfig",
+                "-c",
+                "main",
+                "--tail=50",
+                "--since=1h",
+            ]
         )
 
     @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
@@ -439,6 +465,89 @@ class TestK8sCoreRunner(unittest.TestCase):
         mock_cmd_utils.run_cmd_and_pipe_to_terminal.assert_called_once_with(
             ["kubectl", "exec", "-it", "pod-1", "-n", "ns", "--", "/bin/bash"]
         )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_deployment_logs_unknown_flag_raises_instruction_error(
+        self, mock_k8s_core: Mock, mock_cmd_utils: Mock
+    ) -> None:
+        runner = self._make_runner()
+        mock_deployment: Mock = Mock()
+        mock_deployment.spec.selector.match_labels = {"app": "web"}
+        mock_apps_api: Mock = runner.apps_api  # type: ignore[assignment]
+        mock_apps_api.read_namespaced_deployment.return_value = mock_deployment
+        mock_k8s_core.list_pods.return_value = (
+            [PodInfo(name="web-pod-abc", phase=PodPhase.RUNNING)],
+            None,
+        )
+        mock_cmd_utils.run_cmd_and_capture_output.side_effect = subprocess.CalledProcessError(
+            1, "kubectl", stderr="Error: unknown flag: --head=3"
+        )
+
+        with self.assertRaises(InstructionError):
+            runner.execute_instruction(
+                instruction_name="deployment-logs",
+                resolved_arguments={
+                    "name": StrResolvedInstructionArgument(argument_name="name", value="my-deploy"),
+                    "scope": StrResolvedInstructionArgument(argument_name="scope", value="default"),
+                    "extra": StrResolvedInstructionArgument(argument_name="extra", value="--head=3"),
+                },
+            )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_deployment_logs_invalid_argument_raises_instruction_error(
+        self, mock_k8s_core: Mock, mock_cmd_utils: Mock
+    ) -> None:
+        runner = self._make_runner()
+        mock_deployment: Mock = Mock()
+        mock_deployment.spec.selector.match_labels = {"app": "web"}
+        mock_apps_api: Mock = runner.apps_api  # type: ignore[assignment]
+        mock_apps_api.read_namespaced_deployment.return_value = mock_deployment
+        mock_k8s_core.list_pods.return_value = (
+            [PodInfo(name="web-pod-abc", phase=PodPhase.RUNNING)],
+            None,
+        )
+        mock_cmd_utils.run_cmd_and_capture_output.side_effect = subprocess.CalledProcessError(
+            1,
+            "kubectl",
+            stderr='invalid argument "abc" for "--tail" flag: strconv.ParseInt: parsing "abc": invalid syntax',
+        )
+
+        with self.assertRaises(InstructionError):
+            runner.execute_instruction(
+                instruction_name="deployment-logs",
+                resolved_arguments={
+                    "name": StrResolvedInstructionArgument(argument_name="name", value="my-deploy"),
+                    "scope": StrResolvedInstructionArgument(argument_name="scope", value="default"),
+                    "extra": StrResolvedInstructionArgument(argument_name="extra", value="--tail=abc"),
+                },
+            )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.cmd_utils")
+    @patch("jupyter_deploy.provider.k8s.k8s_core_runner.k8s_core")
+    def test_deployment_logs_other_error_bubbles_up(self, mock_k8s_core: Mock, mock_cmd_utils: Mock) -> None:
+        runner = self._make_runner()
+        mock_deployment: Mock = Mock()
+        mock_deployment.spec.selector.match_labels = {"app": "web"}
+        mock_apps_api: Mock = runner.apps_api  # type: ignore[assignment]
+        mock_apps_api.read_namespaced_deployment.return_value = mock_deployment
+        mock_k8s_core.list_pods.return_value = (
+            [PodInfo(name="web-pod-abc", phase=PodPhase.RUNNING)],
+            None,
+        )
+        mock_cmd_utils.run_cmd_and_capture_output.side_effect = subprocess.CalledProcessError(
+            1, "kubectl", stderr="error: pod web-pod-abc is not running"
+        )
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            runner.execute_instruction(
+                instruction_name="deployment-logs",
+                resolved_arguments={
+                    "name": StrResolvedInstructionArgument(argument_name="name", value="my-deploy"),
+                    "scope": StrResolvedInstructionArgument(argument_name="scope", value="default"),
+                },
+            )
 
     def test_unknown_instruction_raises_error(self) -> None:
         runner = self._make_runner()

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_runner.py
@@ -106,6 +106,58 @@ class TestK8sApiRunner(unittest.TestCase):
                     runner.execute_instruction(instruction_name=invalid_instruction, resolved_arguments={})
                 self.assertIn(invalid_instruction, str(context.exception))
 
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sAppsRunner")
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sClientFactory")
+    def test_execute_instantiates_apps_runner_and_delegates(
+        self, mock_factory: Mock, mock_apps_runner_class: Mock
+    ) -> None:
+        mock_api_client: Mock = Mock()
+        mock_factory.from_kubeconfig.return_value = mock_api_client
+
+        mock_apps_runner: Mock = Mock()
+        mock_apps_runner_class.return_value = mock_apps_runner
+        expected_result = {"result_key": Mock(spec=ResolvedInstructionResult)}
+        mock_apps_runner.execute_instruction.return_value = expected_result
+
+        runner = K8sApiRunner(NullDisplay(), kubeconfig_path="/tmp/kubeconfig")
+        resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
+
+        result = runner.execute_instruction(
+            instruction_name="k8s.apps.get-deployment-status", resolved_arguments=resolved_args
+        )
+
+        mock_apps_runner_class.assert_called_once_with(ANY, api_client=mock_api_client)
+        mock_apps_runner.execute_instruction.assert_called_once_with(
+            instruction_name="get-deployment-status", resolved_arguments=resolved_args
+        )
+        self.assertEqual(result, expected_result)
+
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sBatchRunner")
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sClientFactory")
+    def test_execute_instantiates_batch_runner_and_delegates(
+        self, mock_factory: Mock, mock_batch_runner_class: Mock
+    ) -> None:
+        mock_api_client: Mock = Mock()
+        mock_factory.from_kubeconfig.return_value = mock_api_client
+
+        mock_batch_runner: Mock = Mock()
+        mock_batch_runner_class.return_value = mock_batch_runner
+        expected_result = {"result_key": Mock(spec=ResolvedInstructionResult)}
+        mock_batch_runner.execute_instruction.return_value = expected_result
+
+        runner = K8sApiRunner(NullDisplay(), kubeconfig_path="/tmp/kubeconfig")
+        resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
+
+        result = runner.execute_instruction(
+            instruction_name="k8s.batch.get-cronjob-status", resolved_arguments=resolved_args
+        )
+
+        mock_batch_runner_class.assert_called_once_with(ANY, api_client=mock_api_client)
+        mock_batch_runner.execute_instruction.assert_called_once_with(
+            instruction_name="get-cronjob-status", resolved_arguments=resolved_args
+        )
+        self.assertEqual(result, expected_result)
+
     @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sCoreRunner")
     @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sClientFactory")
     def test_uses_eks_cluster_when_all_params_provided(self, mock_factory: Mock, mock_core_runner_class: Mock) -> None:

--- a/libs/jupyter-deploy/tests/unit/test_manifest.py
+++ b/libs/jupyter-deploy/tests/unit/test_manifest.py
@@ -6,9 +6,15 @@ import yaml
 
 from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.enum import StoreType
-from jupyter_deploy.exceptions import InvalidStoreTypeError, SecretNotFoundError
+from jupyter_deploy.exceptions import (
+    CommandNotImplementedError,
+    ComponentNotFoundError,
+    InvalidStoreTypeError,
+    SecretNotFoundError,
+)
 from jupyter_deploy.manifest import (
     InvalidServiceError,
+    JupyterDeployComponentDefinitionV1,
     JupyterDeployManifestV1,
     JupyterDeployProjectStoreV1,
 )
@@ -192,3 +198,87 @@ class TestJupyterDeployProjectStoreV1(unittest.TestCase):
         manifest = self._make_manifest()
         result = manifest.compute_project_id("dep-abc123")
         self.assertEqual(result, "test-template-dep-abc123")
+
+
+class TestJupyterDeployManifestV1Components(unittest.TestCase):
+    def _make_manifest(self, components: dict[str, Any] | None = None) -> JupyterDeployManifestV1:
+        data: dict[str, Any] = {
+            "schema_version": 1,
+            "template": {"name": "test-template", "engine": "terraform", "version": "1.0.0"},
+        }
+        if components is not None:
+            data["components"] = components
+        return JupyterDeployManifestV1(**data)  # type: ignore
+
+    def test_get_components_parses_manifest(self) -> None:
+        manifest = self._make_manifest(
+            components={
+                "traefik": {
+                    "type": "Deployment",
+                    "scope": "router_namespace",
+                    "verbs": {
+                        "status": {"method": "k8s.apps.get-deployment-status"},
+                        "restart": {"method": "k8s.apps.rollout-restart"},
+                    },
+                },
+                "jwt-rotator": {
+                    "type": "CronJob",
+                    "scope": "router_namespace",
+                    "verbs": {
+                        "status": {"method": "k8s.batch.get-cronjob-status"},
+                        "trigger": {"method": "k8s.batch.create-job-from-cronjob"},
+                    },
+                },
+            }
+        )
+        components = manifest.get_components()
+
+        self.assertEqual(len(components), 2)
+        self.assertIn("traefik", components)
+        self.assertIn("jwt-rotator", components)
+
+    def test_get_component_returns_definition(self) -> None:
+        manifest = self._make_manifest(
+            components={
+                "traefik": {
+                    "type": "Deployment",
+                    "scope": "router_namespace",
+                    "verbs": {"status": {"method": "k8s.apps.get-deployment-status"}},
+                },
+            }
+        )
+        component = manifest.get_component("traefik")
+
+        self.assertIsInstance(component, JupyterDeployComponentDefinitionV1)
+        self.assertEqual(component.type, "Deployment")
+        self.assertEqual(component.scope, "router_namespace")
+        self.assertIn("status", component.verbs)
+        self.assertEqual(component.verbs["status"].method, "k8s.apps.get-deployment-status")
+
+    def test_get_component_raises_not_found(self) -> None:
+        manifest = self._make_manifest(
+            components={
+                "traefik": {
+                    "type": "Deployment",
+                    "scope": "ns",
+                    "verbs": {"status": {"method": "k8s.apps.get-deployment-status"}},
+                },
+            }
+        )
+        with self.assertRaises(ComponentNotFoundError) as ctx:
+            manifest.get_component("unknown")
+
+        self.assertEqual(ctx.exception.component_name, "unknown")
+        self.assertIn("traefik", ctx.exception.valid_components)
+
+    def test_get_components_raises_when_none(self) -> None:
+        manifest = self._make_manifest()
+
+        with self.assertRaises(CommandNotImplementedError):
+            manifest.get_components()
+
+    def test_get_component_raises_when_none(self) -> None:
+        manifest = self._make_manifest()
+
+        with self.assertRaises(CommandNotImplementedError):
+            manifest.get_component("traefik")

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/docker-compose.yml
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - ./.auth:/workspace/.auth
       # Mount AWS credentials (read-only) - accessible by testuser
       - ~/.aws:/home/testuser/.aws:ro
+      # Mount kube config (read-only) - needed for kubectl commands
+      - ~/.kube:/home/testuser/.kube:ro
       # Mount X11 socket for GUI applications
       - /tmp/.X11-unix:/tmp/.X11-unix
       # Project directory will be mounted dynamically via override file in justfile


### PR DESCRIPTION
This PR adds `jd component` set of commands which correspond to all the non-apps deployment and supporting infrastructure. It also declares the `component` commands w/ the `eks-oidc` template manifest.

### User experience
1. `jd component health` --> displays a dashboard w/ `| component | type | status | details | sub-component |` columns, which provides admin an overview of their infrastructure components
2. `jd component list` --> displays details about the components declared in the manifest (no k8s/api calls)
3. `jd component status --name COMPONENT` --> displays a one-liner status for a single component
4. `jd component show --name COMPONENT` --> displays detailed info (the whole k8s resource) for a single component
5. `jd component logs --name COMPONENT` --> displays the logs (last 1000 lines by default)
6. `jd component logs --name COMPONENT -- --tail=100`
7. `jd component restart --name COMPONENT` --> equivalent to a `kubectl rollout restart`
8. `jd component trigger --name COMPONENT` --> create a job from a job template

### Implementation
- add cmd group to `cli/component_app`, register w/ `cli/app`
- add `ComponentHandler` to `handlers/`
- add `apps` (deployment) and `batch` (jobs) to `api/k8s`
- add runners for `apps`, `batch` in `/provider/k8s`, and reference in `k8s_runner`
- add specific components error to `JupyterDeployError`, handle in error wrapper
- add `component:` spec in `manifest`
- update the `eks-oidc` template `manifest.yaml`
- update `logs` to shell out to `kubectl logs` so that we can pass the familiar flags (e.g. `--tail=50`)

### Testing
- added unit tests
- added E2E tests for the `eks-oidc` template
- tested manually

### Screenshots
**component --help**
<img width="516" height="262" alt="Screenshot 2026-05-14 at 5 03 44 PM" src="https://github.com/user-attachments/assets/dd5cf510-a542-4f8a-b8d0-1510eff6ba2b" />

**component list**
<img width="559" height="171" alt="Screenshot 2026-05-14 at 5 04 08 PM" src="https://github.com/user-attachments/assets/f647bb5c-fbaf-4a70-9a9f-4bef7cf4805c" />

**component health**
<img width="667" height="170" alt="Screenshot 2026-05-14 at 5 04 43 PM" src="https://github.com/user-attachments/assets/65dfdac1-0a7a-40ab-900e-5e30a85e40e7" />

**component status**
<img width="416" height="28" alt="Screenshot 2026-05-14 at 5 05 19 PM" src="https://github.com/user-attachments/assets/a7378790-6342-4fb3-87cd-7b112a4f90c1" />

**component show**
<img width="512" height="395" alt="Screenshot 2026-05-14 at 5 05 59 PM" src="https://github.com/user-attachments/assets/b38a92b0-51e5-4a82-933f-2747795195ea" />

**component show --description**
<img width="566" height="31" alt="Screenshot 2026-05-14 at 5 06 25 PM" src="https://github.com/user-attachments/assets/e27c999e-bca1-4bc3-ad8a-fd00fe642eee" />

**component logs**
<img width="1061" height="268" alt="Screenshot 2026-05-14 at 5 07 02 PM" src="https://github.com/user-attachments/assets/a70b3a36-258a-47df-923d-ed5231a118ed" />

**component logs -- --tail=10**
<img width="915" height="300" alt="Screenshot 2026-05-14 at 5 07 37 PM" src="https://github.com/user-attachments/assets/d3769e10-4189-4d74-8795-35d697063720" />

**component restart**
<img width="498" height="142" alt="Screenshot 2026-05-14 at 5 08 24 PM" src="https://github.com/user-attachments/assets/10b69f25-92e1-4277-9f9e-194c96aeeb59" />

**component trigger**
<img width="672" height="223" alt="Screenshot 2026-05-14 at 5 09 11 PM" src="https://github.com/user-attachments/assets/9db6aa62-d614-43b5-b9bc-24c7d6e85d4e" />


