### PR TITLE
feat: cluster cmds

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -96,6 +96,48 @@ commands:
   - result-name: secret-value
     source: result
     source-key: '[0].SecretString'
+- cmd: cluster.login
+  sequence:
+  - api-name: aws.eks.update-kubeconfig
+    arguments:
+    - api-attribute: cluster_name
+      source: output
+      source-key: cluster_name
+  results:
+  - result-name: cluster.login.output
+    source: result
+    source-key: '[0].Output'
+- cmd: cluster.status
+  sequence:
+  - api-name: aws.eks.describe-cluster
+    arguments:
+    - api-attribute: cluster_name
+      source: output
+      source-key: cluster_name
+  results:
+  - result-name: cluster.status
+    source: result
+    source-key: '[0].Status'
+- cmd: cluster.show
+  sequence:
+  - api-name: aws.eks.describe-cluster
+    arguments:
+    - api-attribute: cluster_name
+      source: output
+      source-key: cluster_name
+  results:
+  - result-name: cluster.show.name
+    source: result
+    source-key: '[0].ClusterName'
+  - result-name: cluster.show.status
+    source: result
+    source-key: '[0].Status'
+  - result-name: cluster.show.endpoint
+    source: result
+    source-key: '[0].Endpoint'
+  - result-name: cluster.show.version
+    source: result
+    source-key: '[0].Version'
 - cmd: host.list
   sequence:
   - api-name: k8s.core.list-nodes

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_cluster.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_cluster.py
@@ -1,0 +1,80 @@
+"""E2E tests for cluster commands on the EKS OIDC template."""
+
+import json
+import subprocess
+from pathlib import Path
+
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+
+KUBECONFIG_PATH = Path.home() / ".kube" / "config"
+
+# ── cluster status ──────────────────────────────────────────────────────────
+
+
+def test_cluster_status_returns_active(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that cluster status returns ACTIVE for a running cluster."""
+    e2e_deployment.ensure_deployed()
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "cluster", "status"])
+    assert "ACTIVE" in result.stdout, f"Expected 'ACTIVE' in output:\n{result.stdout}"
+
+
+# ── cluster show ────────────────────────────────────────────────────────────
+
+
+def test_cluster_show_returns_metadata(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that cluster show returns cluster metadata as pretty-printed JSON."""
+    e2e_deployment.ensure_deployed()
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "cluster", "show"])
+    assert result.stdout.strip(), "Expected non-empty output from cluster show"
+    assert "endpoint" in result.stdout.lower(), f"Expected 'endpoint' in output:\n{result.stdout}"
+
+
+def test_cluster_show_json(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that cluster show --json returns valid JSON with expected fields."""
+    e2e_deployment.ensure_deployed()
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "cluster", "show", "--json"])
+    data = json.loads(result.stdout)
+    assert "name" in data, f"Expected 'name' key in JSON, got: {list(data.keys())}"
+    assert "status" in data, f"Expected 'status' key in JSON, got: {list(data.keys())}"
+    assert "endpoint" in data, f"Expected 'endpoint' key in JSON, got: {list(data.keys())}"
+    assert "version" in data, f"Expected 'version' key in JSON, got: {list(data.keys())}"
+    assert data["status"] == "ACTIVE", f"Expected status 'ACTIVE', got: {data['status']}"
+    assert data["endpoint"].startswith("https://"), f"Expected endpoint to start with https://, got: {data['endpoint']}"
+
+
+# ── cluster login ───────────────────────────────────────────────────────────
+
+
+def test_cluster_login_configures_kubeconfig(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that cluster login creates a kubeconfig from scratch."""
+    e2e_deployment.ensure_deployed()
+
+    backup = KUBECONFIG_PATH.read_bytes() if KUBECONFIG_PATH.exists() else None
+    try:
+        KUBECONFIG_PATH.unlink(missing_ok=True)
+
+        result = e2e_deployment.cli.run_command(["jupyter-deploy", "cluster", "login"])
+        output = result.stdout.lower()
+        assert "context" in output or "updated" in output or "added" in output, (
+            f"Expected kubeconfig update confirmation in output:\n{result.stdout}"
+        )
+        assert KUBECONFIG_PATH.exists(), "Expected kubeconfig to be created after login"
+
+        config_content = KUBECONFIG_PATH.read_text()
+        assert "clusters:" in config_content, "Expected 'clusters:' section in kubeconfig"
+        assert "contexts:" in config_content, "Expected 'contexts:' section in kubeconfig"
+        show_result = e2e_deployment.cli.run_command(["jupyter-deploy", "cluster", "show", "--json"])
+        show_data = json.loads(show_result.stdout)
+
+        kubectl_output = subprocess.run(["kubectl", "cluster-info"], capture_output=True, text=True, check=True)
+        assert show_data["endpoint"] in kubectl_output.stdout, (
+            f"Expected endpoint {show_data['endpoint']} in kubectl cluster-info output:\n{kubectl_output.stdout}"
+        )
+    finally:
+        if backup is not None:
+            KUBECONFIG_PATH.write_bytes(backup)
+        elif KUBECONFIG_PATH.exists():
+            KUBECONFIG_PATH.unlink()

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -10,8 +10,8 @@ from rich.console import Console
 from rich.table import Table
 
 from jupyter_deploy import cmd_utils
-from jupyter_deploy.cli.component_app import component_app
 from jupyter_deploy.cli.cluster_app import cluster_app
+from jupyter_deploy.cli.component_app import component_app
 from jupyter_deploy.cli.error_decorator import handle_cli_errors
 from jupyter_deploy.cli.history_app import history_app
 from jupyter_deploy.cli.host_app import host_app

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -11,6 +11,7 @@ from rich.table import Table
 
 from jupyter_deploy import cmd_utils
 from jupyter_deploy.cli.component_app import component_app
+from jupyter_deploy.cli.cluster_app import cluster_app
 from jupyter_deploy.cli.error_decorator import handle_cli_errors
 from jupyter_deploy.cli.history_app import history_app
 from jupyter_deploy.cli.host_app import host_app
@@ -58,6 +59,7 @@ class JupyterDeployCliRunner:
         self.app.add_typer(organization_app, name="organization")
         self.app.add_typer(host_app, name="host")
         self.app.add_typer(component_app, name="component")
+        self.app.add_typer(cluster_app, name="cluster")
         self.app.add_typer(history_app, name="history")
         self.app.add_typer(projects_app, name="projects")
 

--- a/libs/jupyter-deploy/jupyter_deploy/cli/cluster_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/cluster_app.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from jupyter_deploy import cmd_utils
+from jupyter_deploy.cli.error_decorator import handle_cli_errors
+from jupyter_deploy.cli.simple_display import SimpleDisplayManager
+from jupyter_deploy.handlers.resource import cluster_handler
+
+cluster_app = typer.Typer(
+    help="Interact with the cluster managing your hosts where your apps run.",
+    no_args_is_help=True,
+)
+
+
+@cluster_app.command()
+def login(
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project whose cluster to configure access for."),
+    ] = None,
+) -> None:
+    """Configure your local client to access the cluster.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = cluster_handler.ClusterHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner("Configuring local client..."):
+            output = handler.login()
+
+        console.print(output)
+
+
+@cluster_app.command()
+def status(
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project whose cluster to check status."),
+    ] = None,
+) -> None:
+    """Check the status of the cluster control plane.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = cluster_handler.ClusterHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner("Checking cluster status..."):
+            result = handler.get_cluster_status()
+
+        console.print(f"Cluster status: [bold cyan]{result}[/]")
+
+
+@cluster_app.command()
+def show(
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project whose cluster to show details for."),
+    ] = None,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON.")] = False,
+) -> None:
+    """Display detailed information about the cluster.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = cluster_handler.ClusterHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner("Getting cluster details..."):
+            details = handler.show_cluster()
+
+        if json_output:
+            console.print(json.dumps(details), highlight=False, markup=False)
+            return
+
+        console.print_json(json.dumps(details))

--- a/libs/jupyter-deploy/jupyter_deploy/cli/cluster_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/cluster_app.py
@@ -11,7 +11,7 @@ from jupyter_deploy.cli.simple_display import SimpleDisplayManager
 from jupyter_deploy.handlers.resource import cluster_handler
 
 cluster_app = typer.Typer(
-    help="Interact with the cluster managing your hosts where your apps run.",
+    help="Interact with the cluster managing the host machines where your apps run.",
     no_args_is_help=True,
 )
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/cluster_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/cluster_handler.py
@@ -1,0 +1,63 @@
+from typing import Any
+
+from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
+from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import DisplayManager
+from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
+from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
+from jupyter_deploy.handlers.resource.resource_utils import collect_results
+from jupyter_deploy.provider import manifest_command_runner as cmd_runner
+
+
+class ClusterHandler(BaseProjectHandler):
+    """Handler class to interact with the cluster running the deployment."""
+
+    _output_handler: EngineOutputsHandler
+
+    def __init__(self, display_manager: DisplayManager) -> None:
+        super().__init__(display_manager=display_manager)
+
+        if self.engine == EngineType.TERRAFORM:
+            self._output_handler = tf_outputs.TerraformOutputsHandler(
+                project_path=self.project_path, project_manifest=self.project_manifest
+            )
+            self._variable_handler = tf_variables.TerraformVariablesHandler(
+                project_path=self.project_path,
+                project_manifest=self.project_manifest,
+                display_manager=self.display_manager,
+            )
+        else:
+            raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
+
+    def login(self) -> str:
+        """Configure local client to access to the cluster, returns the output message."""
+        command = self.project_manifest.get_command("cluster.login")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        runner.run_command_sequence(command, cli_paramdefs={})
+        return runner.get_result_value(command, "cluster.login.output", str)
+
+    def get_cluster_status(self) -> str:
+        """Returns the control plane state string."""
+        command = self.project_manifest.get_command("cluster.status")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        runner.run_command_sequence(command, cli_paramdefs={})
+        return runner.get_result_value(command, "cluster.status", str)
+
+    def show_cluster(self) -> dict[str, Any]:
+        """Returns cluster metadata dict."""
+        command = self.project_manifest.get_command("cluster.show")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        runner.run_command_sequence(command, cli_paramdefs={})
+        return collect_results(runner, command)

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_cluster_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_cluster_handler.py
@@ -1,0 +1,228 @@
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import NullDisplay
+from jupyter_deploy.handlers.resource.cluster_handler import ClusterHandler
+from jupyter_deploy.manifest import JupyterDeployManifestV1
+
+
+class TestClusterHandler(unittest.TestCase):
+    def get_mock_manifest_and_fns(self) -> tuple[Mock, dict[str, Mock]]:
+        mock_manifest = Mock()
+        mock_get_engine = Mock()
+        mock_get_command = Mock()
+        mock_get_engine.return_value = EngineType.TERRAFORM
+        mock_get_command.return_value = Mock()
+        mock_manifest.get_command = mock_get_command
+        mock_manifest.get_engine = mock_get_engine
+        return mock_manifest, {"get_command": mock_get_command, "get_engine": mock_get_engine}
+
+    def get_mock_cmd_runner_and_fns(self) -> tuple[Mock, dict[str, Mock]]:
+        mock_cmd_runner = Mock()
+        mock_run_command_sequence = Mock()
+        mock_get_result_value = Mock()
+        mock_get_result_value_with_fallback = Mock()
+
+        mock_cmd_runner.run_command_sequence = mock_run_command_sequence
+        mock_cmd_runner.get_result_value = mock_get_result_value
+        mock_cmd_runner.get_result_value_with_fallback = mock_get_result_value_with_fallback
+
+        return mock_cmd_runner, {
+            "run_command_sequence": mock_run_command_sequence,
+            "get_result_value": mock_get_result_value,
+            "get_result_value_with_fallback": mock_get_result_value_with_fallback,
+        }
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("pathlib.Path.cwd")
+    def test_can_instantiate_terraform_project(
+        self,
+        mock_cwd: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        path = Path("/some/cur/dir")
+        mock_cwd.return_value = path
+        mock_tf_outputs_handler.return_value = Mock()
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_manifest, _ = self.get_mock_manifest_and_fns()
+        mock_retrieve_manifest.return_value = mock_manifest
+
+        handler = ClusterHandler(display_manager=NullDisplay())
+
+        mock_retrieve_manifest.assert_called_once()
+        self.assertEqual(handler.engine, EngineType.TERRAFORM)
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    def test_methods_raise_not_implemented_error_if_manifest_does_not_define_cmd(
+        self, mock_tf_variables_handler: Mock, mock_tf_outputs_handler: Mock, mock_retrieve_manifest: Mock
+    ) -> None:
+        mock_tf_outputs_handler.return_value = Mock()
+        mock_tf_variables_handler.return_value = Mock()
+
+        no_cmd_manifest = JupyterDeployManifestV1(
+            **{  # type: ignore
+                "schema_version": 1,
+                "template": {
+                    "name": "mock-template-name",
+                    "engine": "terraform",
+                    "version": "1.0.0",
+                },
+            }
+        )
+        mock_retrieve_manifest.return_value = no_cmd_manifest
+
+        handler = ClusterHandler(display_manager=NullDisplay())
+
+        with self.assertRaises(NotImplementedError):
+            handler.login()
+
+        with self.assertRaises(NotImplementedError):
+            handler.get_cluster_status()
+
+        with self.assertRaises(NotImplementedError):
+            handler.show_cluster()
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_login_calls_run_command_and_returns_output(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = Mock()
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_cmd_runner_and_fns()
+        mock_cmd_runner_fns[
+            "get_result_value"
+        ].return_value = "Added new context arn:aws:eks:us-west-2:123:cluster/test"
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ClusterHandler(display_manager=NullDisplay())
+        result = handler.login()
+
+        self.assertEqual(result, "Added new context arn:aws:eks:us-west-2:123:cluster/test")
+        mock_manifest_fns["get_command"].assert_called_once_with("cluster.login")
+        mock_cmd_runner_fns["run_command_sequence"].assert_called_once_with(mock_cmd, cli_paramdefs={})
+        mock_cmd_runner_fns["get_result_value"].assert_called_once_with(mock_cmd, "cluster.login.output", str)
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_get_cluster_status_calls_run_command_and_returns_status(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = Mock()
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value"].return_value = "ACTIVE"
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ClusterHandler(display_manager=NullDisplay())
+        result = handler.get_cluster_status()
+
+        self.assertEqual(result, "ACTIVE")
+        mock_manifest_fns["get_command"].assert_called_once_with("cluster.status")
+        mock_cmd_runner_fns["run_command_sequence"].assert_called_once_with(mock_cmd, cli_paramdefs={})
+        mock_cmd_runner_fns["get_result_value"].assert_called_once_with(mock_cmd, "cluster.status", str)
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_show_cluster_calls_run_command_and_returns_details(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, mock_manifest_fns = self.get_mock_manifest_and_fns()
+        mock_cmd = Mock()
+        mock_cmd.cmd = "cluster.show"
+        mock_result_name = Mock(result_name="cluster.show.name")
+        mock_result_status = Mock(result_name="cluster.show.status")
+        mock_result_endpoint = Mock(result_name="cluster.show.endpoint")
+        mock_result_version = Mock(result_name="cluster.show.version")
+        mock_cmd.results = [mock_result_name, mock_result_status, mock_result_endpoint, mock_result_version]
+        mock_manifest_fns["get_command"].return_value = mock_cmd
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = Mock()
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value_with_fallback"].side_effect = [
+            "my-cluster",
+            "ACTIVE",
+            "https://ABC.eks.amazonaws.com",
+            "1.29.0",
+        ]
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ClusterHandler(display_manager=NullDisplay())
+        result = handler.show_cluster()
+
+        self.assertEqual(result["name"], "my-cluster")
+        self.assertEqual(result["status"], "ACTIVE")
+        self.assertEqual(result["endpoint"], "https://ABC.eks.amazonaws.com")
+        self.assertEqual(result["version"], "1.29.0")
+        mock_manifest_fns["get_command"].assert_called_once_with("cluster.show")
+        mock_cmd_runner_fns["run_command_sequence"].assert_called_once_with(mock_cmd, cli_paramdefs={})
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_methods_raise_if_run_command_raises(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_manifest, _ = self.get_mock_manifest_and_fns()
+        mock_retrieve_manifest.return_value = mock_manifest
+        mock_tf_outputs_handler.return_value = Mock()
+        mock_tf_variables_handler.return_value = Mock()
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_cmd_runner_and_fns()
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+        mock_cmd_runner_fns["run_command_sequence"].side_effect = RuntimeError()
+
+        handler = ClusterHandler(display_manager=NullDisplay())
+
+        with self.assertRaises(RuntimeError):
+            handler.login()
+
+        with self.assertRaises(RuntimeError):
+            handler.get_cluster_status()
+
+        with self.assertRaises(RuntimeError):
+            handler.show_cluster()

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/docker-compose.yml
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       - ./.auth:/workspace/.auth
       # Mount AWS credentials (read-only) - accessible by testuser
       - ~/.aws:/home/testuser/.aws:ro
-      # Mount kube config (read-only) - needed for kubectl commands
-      - ~/.kube:/home/testuser/.kube:ro
+      # Mount kube config - needed for kubectl commands and jd cluster login
+      - ~/.kube:/home/testuser/.kube
       # Mount X11 socket for GUI applications
       - /tmp/.X11-unix:/tmp/.X11-unix
       # Project directory will be mounted dynamically via override file in justfile


### PR DESCRIPTION
This PR adds cluster commands, and use them in the `eks-oidc` template.

### User experience
1. `jd cluster status` --> return a one-liner status (of the control plane)
2. `jd cluster show` --> return details about the cluster, such as endpoint, software version, etc
3. `jd cluster login` --> configure local client (e.g. `kubectl`) to talk to the cluster

### Implementation
- add `cli/cluster_app`, use in `cli/app`
- add `ClusterHandler` to `/handlers/resource`
- declare commands implementation in `manifest.yaml` of `eks-oidc`

### Testing
- add unit tests
- add E2E tests for the `eks-oidc` template
- test manually against deployment

### Screenshots
**jd cluster --help**
<img width="494" height="201" alt="Screenshot 2026-05-14 at 6 18 10 PM" src="https://github.com/user-attachments/assets/202d3a88-f4ad-4b1a-996b-c51d0fbaaf22" />

**jd cluster status**
<img width="328" height="31" alt="Screenshot 2026-05-14 at 6 18 36 PM" src="https://github.com/user-attachments/assets/15121bd2-80b8-419b-8a66-258ab3ee16e1" />

**jd cluster show**
<img width="634" height="100" alt="Screenshot 2026-05-14 at 6 19 03 PM" src="https://github.com/user-attachments/assets/73dacf92-819c-4e85-8e53-7a195a85bf28" />

**jd cluster login**
<img width="811" height="32" alt="Screenshot 2026-05-14 at 6 19 30 PM" src="https://github.com/user-attachments/assets/57342d6c-35b0-4297-b96d-ff4d309f965b" />


