### PR TITLE
test: e2e workspace tests

### DIFF
--- a/env.example
+++ b/env.example
@@ -63,8 +63,12 @@ JD_E2E_ORG=
 # based on their org membership.
 JD_E2E_SAFE_ORG=
 
-# Name of a GitHub team within the organization that the logged user is a member of.
+# Name of a GitHub team within the organization that the logged user is a member of (OAuth app access).
 JD_E2E_TEAM=
+
+# Name of a GitHub team with workspace RBAC permissions (github-rbac chart RoleBinding).
+# Used for impersonation in EKS template tests.
+JD_E2E_RBAC_TEAM=
 
 # Name of a GitHub team within the organization that the logged user is not a member of,
 # but that you trust to grant access to your app.

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/conftest.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/conftest.py
@@ -1,6 +1,44 @@
 """E2E test configuration for the EKS OIDC template."""
 
+import os
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
 import pytest
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.plugin import handle_browser_context_args
+from pytest_jupyter_deploy.workspaces.kubectl import (
+    kubectl_apply_workspace,
+    kubectl_delete_workspace,
+)
+
+WORKSPACE_NAMESPACE = "default"
+WORKSPACES_DIR = Path(__file__).parent / "workspaces"
+
+# Synthetic user for impersonated workspaces (uses github: prefix to match Dex OIDC claims)
+IMPERSONATED_USER = "github:e2e-other-user"
+
+# Admin workspaces (created as the admin IAM identity)
+ADMIN_WORKSPACES = ["e2e-jupyterlab-admin-public"]
+
+# Workspaces created via impersonation during cluster seeding
+SEEDED_WORKSPACES = ["e2e-jupyterlab-other-public", "e2e-jupyterlab-other-private"]
+
+
+def _get_impersonation_group() -> str | None:
+    """Build the impersonation group from env vars (github:<org>:<team>).
+
+    Uses JD_E2E_RBAC_TEAM — the team with workspace CRUD permissions via the
+    github-rbac Helm chart RoleBinding. This is distinct from JD_E2E_TEAM which
+    controls OAuth app access.
+    """
+    org = os.getenv("JD_E2E_ORG")
+    team = os.getenv("JD_E2E_RBAC_TEAM")
+    if org and team:
+        return f"github:{org}:{team}"
+    return None
 
 
 def pytest_collection_modifyitems(items: list) -> None:
@@ -8,3 +46,83 @@ def pytest_collection_modifyitems(items: list) -> None:
     for item in items:
         if "e2e" in str(item.fspath):
             item.add_marker(pytest.mark.e2e)
+
+
+@pytest.fixture(scope="session")
+def browser_context_args(browser_context_args: dict[str, Any], request: pytest.FixtureRequest) -> dict[str, Any]:
+    """Configure browser context to load saved authentication state."""
+    return handle_browser_context_args(browser_context_args, request)
+
+
+@pytest.fixture(scope="session")
+def seeded_cluster(e2e_deployment: EndToEndDeployment) -> Generator[dict[str, list[str]], None, None]:
+    """Seed the cluster with admin and impersonated workspaces.
+
+    Runs `jd cluster login` to configure kubectl, then creates:
+    - Admin workspaces (as the current IAM identity)
+    - Impersonated workspaces (as a synthetic user via --as/--as-group)
+
+    Yields a dict: {"admin": [...], "seeded": [...]}
+    Tears down all workspaces on session end.
+    """
+    e2e_deployment.ensure_deployed()
+
+    group = _get_impersonation_group()
+    if not group:
+        pytest.skip("JD_E2E_ORG and JD_E2E_RBAC_TEAM required for cluster seeding")
+
+    # Configure kubectl for admin access
+    e2e_deployment.cli.run_command(["jupyter-deploy", "cluster", "login"])
+
+    created: dict[str, list[str]] = {"admin": [], "seeded": []}
+
+    # Create admin workspaces
+    for name in ADMIN_WORKSPACES:
+        kubectl_apply_workspace(name, WORKSPACES_DIR)
+        created["admin"].append(name)
+
+    # Create impersonated workspaces
+    groups = [group]
+    for name in SEEDED_WORKSPACES:
+        kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=IMPERSONATED_USER, as_groups=groups)
+        created["seeded"].append(name)
+
+    # Wait for all workspaces to be Running
+    all_workspaces = created["admin"] + created["seeded"]
+    for name in all_workspaces:
+        e2e_deployment.cli.poll_scoped_server_status(name, "Running", timeout_s=300)
+
+    yield created
+
+    # Configure kubectl for admin access
+    e2e_deployment.cli.run_command(["jupyter-deploy", "cluster", "login"])
+
+    for name in all_workspaces:
+        kubectl_delete_workspace(name)
+
+
+@pytest.fixture(scope="module")
+def e2e_workspace(seeded_cluster: dict[str, list[str]]) -> str:
+    """Return the admin workspace name — always Running, used for logs/exec/status tests."""
+    return seeded_cluster["admin"][0]
+
+
+@pytest.fixture(scope="module")
+def other_user_workspace(seeded_cluster: dict[str, list[str]]) -> str:
+    """Return a private workspace owned by a different user — used to test admin stop/start."""
+    return seeded_cluster["seeded"][1]
+
+
+@pytest.fixture(scope="session")
+def getting_started_url(e2e_deployment: EndToEndDeployment) -> str:
+    """Return the getting-started URL."""
+    e2e_deployment.ensure_deployed()
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "show", "--output", "get_started_url", "--text"])
+    return result.stdout.strip()
+
+
+@pytest.fixture(scope="session")
+def eks_domain(getting_started_url: str) -> str:
+    """Return the full domain for this EKS deployment."""
+    parsed = urlparse(getting_started_url)
+    return parsed.netloc

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/notebooks/kernel_simple.ipynb
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/notebooks/kernel_simple.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "basic-ops",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = 10 + 20 * 3\n",
+    "print(f\"Kernel is working: {result}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "verify",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert result == 70, f\"Expected 70, got {result}\"\n",
+    "print(\"Kernel test passed\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_console.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_console.py
@@ -1,0 +1,23 @@
+"""E2E tests for the getting-started console page on the EKS OIDC template.
+
+The getting-started page is gated by oauth2-proxy (skip-provider-button, Dex flow).
+Uses the dex_oauth_app fixture to authenticate through oauth2-proxy → Dex → GitHub.
+"""
+
+from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER"])
+def test_getting_started_script_downloadable(
+    getting_started_url: str,
+    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
+) -> None:
+    """Verify set-kubeconfig.sh is downloadable through the OAuth-protected console."""
+    dex_oauth_app.ensure_authenticated()
+
+    script_url = getting_started_url.rstrip("/") + "/set-kubeconfig.sh"
+    dex_oauth_app.page.goto(script_url, wait_until="load", timeout=60000)
+
+    content = dex_oauth_app.page.content()
+    assert "kubectl config set-cluster" in content, f"Expected kubectl config commands in script, got:\n{content[:300]}"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_open.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_open.py
@@ -1,0 +1,61 @@
+"""E2E tests for the open command URL resolution on the EKS OIDC template.
+
+Verifies that `jd open` returns correct URLs:
+- Default: matches the getting-started URL
+- With --server-name: matches the workspace's .status.accessURL
+"""
+
+import re
+
+import pytest
+from pytest_jupyter_deploy.cli import JDCliError
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.workspaces.kubectl import kubectl_get_workspace_access_url
+
+from .conftest import WORKSPACE_NAMESPACE
+
+_URL_PATTERN = re.compile(r"Opening app at:\s+(https://\S+)")
+
+
+# ── open (default) ─────────────────────────────────────────────────────────
+
+
+def test_open_default_matches_getting_started_url(e2e_deployment: EndToEndDeployment, getting_started_url: str) -> None:
+    """Verify that jd open returns the getting-started URL."""
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "open"])
+
+    match = _URL_PATTERN.search(result.stdout)
+    assert match is not None, f"Could not extract URL from output:\n{result.stdout}"
+    assert match.group(1) == getting_started_url, f"Expected '{getting_started_url}', got '{match.group(1)}'"
+
+
+# ── open --server-name ─────────────────────────────────────────────────────
+
+
+def test_open_server_name_matches_access_url(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that jd open --server-name returns the workspace's accessURL."""
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "open", "--server-name", e2e_workspace])
+
+    match = _URL_PATTERN.search(result.stdout)
+    assert match is not None, f"Could not extract URL from output:\n{result.stdout}"
+    open_url = match.group(1)
+
+    access_url = kubectl_get_workspace_access_url(e2e_workspace, WORKSPACE_NAMESPACE)
+    assert open_url == access_url, f"Expected accessURL '{access_url}', got '{open_url}'"
+
+
+# ── open negative cases ────────────────────────────────────────────────────
+
+
+def test_open_server_name_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that open with a nonexistent server name fails."""
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "open", "--server-name", "i-do-not-exist"])
+
+
+def test_open_server_name_wrong_scope(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that open with wrong --scope fails."""
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(
+            ["jupyter-deploy", "open", "--server-name", e2e_workspace, "--scope", "nonexistent-ns"]
+        )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_server.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_server.py
@@ -1,0 +1,309 @@
+"""E2E tests for server (workspace) commands on the EKS OIDC template.
+
+Relies on `seeded_cluster` (session-scoped) for pagination and scope filtering.
+Uses `e2e_workspace` (admin, always Running) for list/status/show/logs/exec tests.
+Uses `other_user_workspace` (private, owned by a different user) for stop/start —
+verifying that an admin can manage another user's private workspace.
+"""
+
+import json
+import subprocess
+
+import pytest
+from pytest_jupyter_deploy.cli import JDCliError
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+from pytest_jupyter_deploy.workspaces.kubectl import (
+    kubectl_get_workspace_owner,
+    kubectl_get_workspace_ownership_type,
+)
+
+from .conftest import IMPERSONATED_USER
+
+
+def _list_servers_json(
+    e2e_deployment: EndToEndDeployment,
+    scope: str | None = None,
+    limit: int | None = None,
+    continue_from: str | None = None,
+) -> dict:
+    cmd = ["jupyter-deploy", "server", "list", "--json"]
+    if scope is not None:
+        cmd.extend(["--scope", scope])
+    if limit is not None:
+        cmd.extend(["-n", str(limit)])
+    if continue_from is not None:
+        cmd.extend(["--continue-from", continue_from])
+    result = e2e_deployment.cli.run_command(cmd)
+    return json.loads(result.stdout)
+
+
+# ── server list ─────────────────────────────────────────────────────────────
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_server_list_contains_workspace(
+    e2e_deployment: EndToEndDeployment, e2e_workspace: str, seeded_cluster: dict[str, list[str]]
+) -> None:
+    """Verify that server list includes the test workspace and seeded workspaces."""
+    data = _list_servers_json(e2e_deployment)
+    assert e2e_workspace in data["servers"], f"Expected '{e2e_workspace}' in: {data['servers']}"
+    for ws in seeded_cluster["seeded"]:
+        assert ws in data["servers"], f"Expected '{ws}' in: {data['servers']}"
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_server_list__with_scope_contains_workspace(
+    e2e_deployment: EndToEndDeployment, e2e_workspace: str, seeded_cluster: dict[str, list[str]]
+) -> None:
+    """Verify that server list with --scope includes the test workspace and seeded workspaces."""
+    data = _list_servers_json(e2e_deployment, "default")
+    assert e2e_workspace in data["servers"], f"Expected '{e2e_workspace}' in: {data['servers']}"
+    for ws in seeded_cluster["seeded"]:
+        assert ws in data["servers"], f"Expected '{ws}' in: {data['servers']}"
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_server_list_json(
+    e2e_deployment: EndToEndDeployment, e2e_workspace: str, seeded_cluster: dict[str, list[str]]
+) -> None:
+    """Verify that server list --json returns valid JSON with expected structure."""
+    data = _list_servers_json(e2e_deployment)
+    assert "servers" in data, f"Expected 'servers' key in JSON, got: {list(data.keys())}"
+    assert isinstance(data["servers"], list), f"Expected list, got {type(data['servers'])}"
+    total = len(seeded_cluster["seeded"]) + len(seeded_cluster["admin"])
+    assert len(data["servers"]) >= total, f"Expected at least {total} servers, got {len(data['servers'])}"
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_server_list_with_scope(
+    e2e_deployment: EndToEndDeployment, e2e_workspace: str, seeded_cluster: dict[str, list[str]]
+) -> None:
+    """Verify that --scope filters server list."""
+    data = _list_servers_json(e2e_deployment, scope="default")
+    assert e2e_workspace in data["servers"], f"Expected workspace in default scope: {data['servers']}"
+
+    data = _list_servers_json(e2e_deployment, scope="nonexistent-ns")
+    assert len(data["servers"]) == 0, f"Expected empty list for nonexistent scope, got: {data['servers']}"
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_server_list_paginate_full(
+    e2e_deployment: EndToEndDeployment, e2e_workspace: str, seeded_cluster: dict[str, list[str]]
+) -> None:
+    """Paginate through servers one at a time and verify distinct results."""
+    # Page 1
+    page1 = _list_servers_json(e2e_deployment, limit=1)
+    assert len(page1["servers"]) == 1, f"Expected 1 server on page 1, got {len(page1['servers'])}"
+    token1 = page1.get("continue_from")
+    assert token1, "Expected a pagination token after requesting 1 of 3+ servers"
+
+    # Page 2
+    page2 = _list_servers_json(e2e_deployment, limit=1, continue_from=token1)
+    assert len(page2["servers"]) == 1, f"Expected 1 server on page 2, got {len(page2['servers'])}"
+    assert page2["servers"][0] != page1["servers"][0], (
+        f"Page 2 returned the same server as page 1: {page2['servers'][0]}"
+    )
+    token2 = page2.get("continue_from")
+    assert token2, "Expected a pagination token after requesting 2 of 3+ servers"
+
+    # Page 3
+    page3 = _list_servers_json(e2e_deployment, continue_from=token2)
+    assert len(page3["servers"]) >= 1, f"Expected at least 1 server on page 3, got {len(page3['servers'])}"
+    seen = {page1["servers"][0], page2["servers"][0]}
+    assert page3["servers"][0] not in seen, f"Page 3 first server '{page3['servers'][0]}' was already seen: {seen}"
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_server_list_paginate_token_hint(
+    e2e_deployment: EndToEndDeployment, e2e_workspace: str, seeded_cluster: dict[str, list[str]]
+) -> None:
+    """Verify the plain-text pagination hint includes the continuation token."""
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "list", "--scope", "default", "-n", "1"])
+    output = result.stdout
+
+    assert "--continue-from" in output, f"Expected pagination hint in output:\n{output}"
+    for line in output.splitlines():
+        if "--continue-from" in line:
+            parts = line.split("--continue-from")
+            assert len(parts) == 2, f"Expected exactly one --continue-from in hint line: {line}"
+            token = parts[1].strip()
+            assert token, f"Expected non-empty token after --continue-from in: {line}"
+            break
+
+
+def test_server_list_invalid_continuation_token(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that an invalid continuation token fails gracefully."""
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(
+            ["jupyter-deploy", "server", "list", "--scope", "default", "--continue-from", "invalid-token"]
+        )
+
+
+# ── server status ───────────────────────────────────────────────────────────
+
+
+def test_server_status_running(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server status returns Running for the test workspace."""
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "status", "--name", e2e_workspace])
+    assert "Running" in result.stdout, f"Expected 'Running' in output:\n{result.stdout}"
+
+
+def test_server_status_not_found(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server status for a nonexistent workspace fails."""
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "server", "status", "--name", "i-do-not-exist"])
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(
+            ["jupyter-deploy", "server", "status", "--name", e2e_workspace, "--scope", "i-do-not-exist"]
+        )
+
+
+# ── server show ─────────────────────────────────────────────────────────────
+
+
+def test_server_show_happy_case(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server show show returns details."""
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "show", "--name", e2e_workspace])
+    assert result.stdout, f"Expected non-empty output for server show {e2e_workspace}"
+
+
+def test_server_show_json(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server show --json returns valid JSON with expected fields."""
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "show", "--name", e2e_workspace, "--json"])
+    data = json.loads(result.stdout)
+    assert "name" in data, f"Expected 'name' in JSON, got: {list(data.keys())}"
+    assert "resource" in data, f"Expected 'resource' in JSON, got: {list(data.keys())}"
+    assert data["name"] == e2e_workspace
+
+
+def test_server_show_not_found(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server show for a nonexistent workspace fails."""
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "server", "show", "--name", "i-do-not-exist"])
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(
+            ["jupyter-deploy", "server", "show", "--name", e2e_workspace, "--scope", "i-do-not-exist"]
+        )
+
+
+# ── server logs ─────────────────────────────────────────────────────────────
+
+
+def test_server_logs_happy(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server logs returns non-empty output for a running workspace."""
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "logs", "--name", e2e_workspace])
+    assert result.stdout.strip(), f"Expected non-empty log output for {e2e_workspace}"
+
+
+def test_server_logs_with_tail(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that -- --tail=5 limits log output."""
+    full_result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "logs", "--name", e2e_workspace])
+    tail_result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "server", "logs", "--name", e2e_workspace, "--", "--tail=5"]
+    )
+    assert tail_result.stdout.strip(), "Expected non-empty output with --tail=5"
+    assert len(tail_result.stdout) <= len(full_result.stdout), "Expected --tail=5 to produce less or equal output"
+
+
+def test_server_logs_bad_flag(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify logs with an invalid kubectl flag fails with a clean error."""
+    with pytest.raises(JDCliError) as exc_info:
+        e2e_deployment.cli.run_command(["jupyter-deploy", "server", "logs", "--name", e2e_workspace, "--", "--head=20"])
+    assert "unknown flag" in str(exc_info.value).lower(), (
+        f"Expected 'unknown flag' in error message, got: {exc_info.value}"
+    )
+
+
+def test_server_logs_not_found(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server logs for a nonexistent workspace fails."""
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "server", "logs", "--name", "i-do-not-exist"])
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(
+            ["jupyter-deploy", "server", "logs", "--name", e2e_workspace, "--scope", "i-do-not-exist"]
+        )
+
+
+# ── server exec ─────────────────────────────────────────────────────────────
+
+
+def test_server_exec_simple_command(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server exec runs a command and returns stdout."""
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "server", "exec", "--name", e2e_workspace, "--scope", "default", "--", "whoami"]
+    )
+    assert result.stdout.strip(), "Expected non-empty stdout from 'whoami'"
+
+
+def test_server_exec_failed_command(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that exec with a nonexistent command fails with proper error surfacing."""
+    with pytest.raises(JDCliError) as exc_info:
+        e2e_deployment.cli.run_command(
+            [
+                "jupyter-deploy",
+                "server",
+                "exec",
+                "--name",
+                e2e_workspace,
+                "--",
+                "command_that_does_not_exist",
+            ]
+        )
+
+    assert exc_info.value.__cause__ is not None
+    assert isinstance(exc_info.value.__cause__, subprocess.CalledProcessError)
+    assert exc_info.value.__cause__.returncode != 0
+
+
+def test_server_exec_nonzero_exit(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server exec with a failing command exits non-zero."""
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--name", e2e_workspace, "--", "false"])
+
+
+def test_server_exec_not_found(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Verify that server exec for a nonexistent workspace fails."""
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--name", "i-do-not-exist", "--", "whoami"])
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(
+            [
+                "jupyter-deploy",
+                "server",
+                "exec",
+                "--name",
+                e2e_workspace,
+                "--scope",
+                "i-do-not-exist",
+                "--",
+                "whoami",
+            ]
+        )
+
+
+# ── server stop / start ─────────────────────────────────────────────────────
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_server_stop_then_start(
+    e2e_deployment: EndToEndDeployment, other_user_workspace: str, seeded_cluster: dict[str, list[str]]
+) -> None:
+    """Admin stops and starts a private workspace owned by a different user."""
+    # Verify the workspace is OwnerOnly and belongs to the impersonated user —
+    # this guarantees the admin is bypassing ownership permissions
+    owner = kubectl_get_workspace_owner(other_user_workspace)
+    assert owner == IMPERSONATED_USER, f"Expected owner '{IMPERSONATED_USER}', got '{owner}'"
+
+    ownership_type = kubectl_get_workspace_ownership_type(other_user_workspace)
+    assert ownership_type == "OwnerOnly", f"Expected ownershipType 'OwnerOnly', got '{ownership_type}'"
+
+    e2e_deployment.cli.run_command(["jupyter-deploy", "server", "stop", "--name", other_user_workspace])
+    e2e_deployment.cli.poll_scoped_server_status(other_user_workspace, "Stopped", timeout_s=180)
+
+    e2e_deployment.cli.run_command(["jupyter-deploy", "server", "start", "--name", other_user_workspace])
+    e2e_deployment.cli.poll_scoped_server_status(other_user_workspace, "Running", timeout_s=300)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace.py
@@ -1,0 +1,381 @@
+"""E2E tests for workspace lifecycle on the EKS OIDC template.
+
+Tests workspace CRUD and access control using kubectl impersonation.
+Each test is self-contained: creates workspace(s), asserts, then deletes on teardown.
+
+Auth model:
+- "User A" = the GitHub bot user (github:<JD_E2E_USER>) — same identity as the browser session
+- "User B" = a synthetic second user for cross-user access tests
+- "Admin"  = current IAM identity (from jd cluster login) with cluster-admin privileges
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+from pytest_jupyter_deploy.workspaces.kubectl import (
+    kubectl_apply_workspace,
+    kubectl_delete_workspace,
+    kubectl_get_workspace,
+    kubectl_get_workspace_access_url,
+    kubectl_get_workspace_jsonpath,
+    kubectl_patch_workspace,
+    kubectl_poll_workspace_status,
+)
+
+NAMESPACE = "default"
+WORKSPACES_DIR = Path(__file__).parent / "workspaces"
+
+USER_B = "github:e2e-other-user"
+
+
+def _get_user_a() -> str:
+    user = os.getenv("JD_E2E_USER")
+    if not user:
+        raise RuntimeError("JD_E2E_USER must be set")
+    return f"github:{user}"
+
+
+def _get_impersonation_group() -> str:
+    org = os.getenv("JD_E2E_ORG")
+    team = os.getenv("JD_E2E_RBAC_TEAM")
+    if not org or not team:
+        raise RuntimeError("JD_E2E_ORG and JD_E2E_RBAC_TEAM must be set")
+    return f"github:{org}:{team}"
+
+
+# ── Self-contained workspace tests (User A owns) ─────────────────────────────
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_creates_public_workspace_and_access(
+    e2e_deployment: EndToEndDeployment,
+    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
+) -> None:
+    """User creates a public workspace and accesses JupyterLab via browser."""
+    e2e_deployment.ensure_deployed()
+    name = "e2e-ws-public-access"
+    user_a = _get_user_a()
+    group = _get_impersonation_group()
+    groups = [group]
+
+    try:
+        kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=user_a, as_groups=groups)
+        kubectl_poll_workspace_status(
+            name,
+            "Running",
+            namespace=NAMESPACE,
+            timeout_s=300,
+            as_user=user_a,
+            as_groups=groups,
+        )
+
+        # Wait for ingress to propagate, then verify JupyterLab loads
+        access_url = kubectl_get_workspace_access_url(name, namespace=NAMESPACE)
+        dex_oauth_app.verify_workspace_accessible(access_url)
+    finally:
+        kubectl_delete_workspace(name, namespace=NAMESPACE)
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_creates_private_workspace_and_access(
+    e2e_deployment: EndToEndDeployment,
+    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
+) -> None:
+    """User creates a private (OwnerOnly) workspace and accesses JupyterLab via browser."""
+    e2e_deployment.ensure_deployed()
+    name = "e2e-ws-private-access"
+    user_a = _get_user_a()
+    group = _get_impersonation_group()
+    groups = [group]
+
+    try:
+        kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=user_a, as_groups=groups)
+        kubectl_poll_workspace_status(
+            name,
+            "Running",
+            namespace=NAMESPACE,
+            timeout_s=300,
+            as_user=user_a,
+            as_groups=groups,
+        )
+
+        access_url = kubectl_get_workspace_access_url(name, namespace=NAMESPACE)
+        dex_oauth_app.verify_workspace_accessible(access_url)
+    finally:
+        kubectl_delete_workspace(name, namespace=NAMESPACE)
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_can_delete_its_own_workspace(e2e_deployment: EndToEndDeployment) -> None:
+    """User creates a workspace and deletes it."""
+    e2e_deployment.ensure_deployed()
+    name = "e2e-ws-user-delete"
+    user_a = _get_user_a()
+    group = _get_impersonation_group()
+    groups = [group]
+
+    kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=user_a, as_groups=groups)
+    kubectl_poll_workspace_status(
+        name,
+        "Running",
+        namespace=NAMESPACE,
+        timeout_s=300,
+        as_user=user_a,
+        as_groups=groups,
+    )
+
+    # User A deletes their own workspace
+    result = subprocess.run(
+        ["kubectl", "delete", "workspace", name, "-n", NAMESPACE, "--as", user_a, "--as-group", groups[0]],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"User A cannot delete own workspace:\n{result.stderr}"
+
+    # Verify it's gone
+    result = kubectl_get_workspace(name, namespace=NAMESPACE, as_user=user_a, as_groups=groups)
+    assert result.returncode != 0, f"Workspace should be deleted but still exists:\n{result.stdout}"
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_can_modify_stop_restart_then_access_workspace(
+    e2e_deployment: EndToEndDeployment, dex_oauth_app: DexGitHubOAuth2ProxyApplication
+) -> None:
+    """User creates a workspace, modifies it, stops, restarts, then accesses via browser."""
+    e2e_deployment.ensure_deployed()
+    name = "e2e-ws-stop-start"
+    user_a = _get_user_a()
+    group = _get_impersonation_group()
+    groups = [group]
+
+    try:
+        kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=user_a, as_groups=groups)
+        kubectl_poll_workspace_status(
+            name,
+            "Running",
+            namespace=NAMESPACE,
+            timeout_s=300,
+            as_user=user_a,
+            as_groups=groups,
+        )
+
+        # Modify
+        result = kubectl_patch_workspace(
+            name,
+            '{"spec":{"displayName":"Modified Display Name"}}',
+            namespace=NAMESPACE,
+            as_user=user_a,
+            as_groups=groups,
+        )
+        assert result.returncode == 0, f"User A cannot modify own workspace:\n{result.stderr}"
+        display_name = kubectl_get_workspace_jsonpath(
+            name,
+            "{.spec.displayName}",
+            namespace=NAMESPACE,
+            as_user=user_a,
+            as_groups=groups,
+        )
+        assert display_name == "Modified Display Name"
+
+        # Stop
+        result = kubectl_patch_workspace(
+            name,
+            '{"spec":{"desiredStatus":"Stopped"}}',
+            namespace=NAMESPACE,
+            as_user=user_a,
+            as_groups=groups,
+        )
+        assert result.returncode == 0, f"User A cannot stop own workspace:\n{result.stderr}"
+        kubectl_poll_workspace_status(
+            name,
+            "Stopped",
+            namespace=NAMESPACE,
+            timeout_s=180,
+            as_user=user_a,
+            as_groups=groups,
+        )
+
+        # Restart
+        result = kubectl_patch_workspace(
+            name,
+            '{"spec":{"desiredStatus":"Running"}}',
+            namespace=NAMESPACE,
+            as_user=user_a,
+            as_groups=groups,
+        )
+        assert result.returncode == 0, f"User A cannot restart own workspace:\n{result.stderr}"
+        kubectl_poll_workspace_status(
+            name,
+            "Running",
+            namespace=NAMESPACE,
+            timeout_s=300,
+            as_user=user_a,
+            as_groups=groups,
+        )
+
+        # Access via browser
+        access_url = kubectl_get_workspace_access_url(name, namespace=NAMESPACE)
+        dex_oauth_app.verify_workspace_accessible(access_url)
+    finally:
+        kubectl_delete_workspace(name, namespace=NAMESPACE)
+
+
+# ── Cross-user access control (User B accessing User A's workspaces) ────────
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_can_access_other_user_public_workspace(
+    e2e_deployment: EndToEndDeployment,
+    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
+) -> None:
+    """Bot user can access another user's public workspace via browser."""
+    e2e_deployment.ensure_deployed()
+    name = "e2e-ws-cross-public"
+    group = _get_impersonation_group()
+    groups = [group]
+
+    try:
+        # Create as User B (a different user)
+        kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=USER_B, as_groups=groups)
+        kubectl_poll_workspace_status(
+            name,
+            "Running",
+            namespace=NAMESPACE,
+            timeout_s=300,
+            as_user=USER_B,
+            as_groups=groups,
+        )
+
+        # The bot (authenticated browser) accesses User B's public workspace
+        access_url = kubectl_get_workspace_access_url(name, namespace=NAMESPACE)
+        dex_oauth_app.verify_workspace_accessible(access_url)
+    finally:
+        kubectl_delete_workspace(name, namespace=NAMESPACE)
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_cannot_modify_stop_or_delete_other_user_private_workspace(e2e_deployment: EndToEndDeployment) -> None:
+    """User B can read but cannot modify, stop, or delete User A's private workspace."""
+    e2e_deployment.ensure_deployed()
+    name = "e2e-ws-cross-private"
+    user_a = _get_user_a()
+    group = _get_impersonation_group()
+    groups = [group]
+
+    try:
+        kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=user_a, as_groups=groups)
+        kubectl_poll_workspace_status(
+            name,
+            "Running",
+            namespace=NAMESPACE,
+            timeout_s=300,
+            as_user=user_a,
+            as_groups=groups,
+        )
+
+        # User B can read the workspace (OwnerOnly restricts writes, not reads)
+        result = kubectl_get_workspace(name, namespace=NAMESPACE, as_user=USER_B, as_groups=groups)
+        assert result.returncode == 0, f"User B should be able to read private workspace:\n{result.stderr}"
+
+        # User B cannot modify User A's private workspace
+        result = kubectl_patch_workspace(
+            name,
+            '{"spec":{"displayName":"hacked"}}',
+            namespace=NAMESPACE,
+            as_user=USER_B,
+            as_groups=groups,
+        )
+        assert result.returncode != 0, (
+            f"User B should NOT be able to modify User A's private workspace, but patch succeeded:\n{result.stdout}"
+        )
+
+        # User B cannot stop User A's private workspace
+        result = kubectl_patch_workspace(
+            name,
+            '{"spec":{"desiredStatus":"Stopped"}}',
+            namespace=NAMESPACE,
+            as_user=USER_B,
+            as_groups=groups,
+        )
+        assert result.returncode != 0, (
+            f"User B should NOT be able to stop User A's private workspace, but patch succeeded:\n{result.stdout}"
+        )
+
+        # User B cannot delete User A's private workspace
+        result = subprocess.run(
+            ["kubectl", "delete", "workspace", name, "-n", NAMESPACE, "--as", USER_B, "--as-group", groups[0]],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, (
+            f"User B should NOT be able to delete User A's private workspace, but delete succeeded:\n{result.stdout}"
+        )
+    finally:
+        kubectl_delete_workspace(name, namespace=NAMESPACE)
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_cannot_access_other_user_private_workspace(
+    e2e_deployment: EndToEndDeployment,
+    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
+) -> None:
+    """User A (browser) cannot access User B's private workspace."""
+    e2e_deployment.ensure_deployed()
+    name = "e2e-ws-cross-private"
+    group = _get_impersonation_group()
+    groups = [group]
+
+    try:
+        kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=USER_B, as_groups=groups)
+        kubectl_poll_workspace_status(
+            name,
+            "Running",
+            namespace=NAMESPACE,
+            timeout_s=300,
+            as_user=USER_B,
+            as_groups=groups,
+        )
+
+        access_url = kubectl_get_workspace_access_url(name, namespace=NAMESPACE)
+        dex_oauth_app.verify_workspace_inaccessible(access_url)
+    finally:
+        kubectl_delete_workspace(name, namespace=NAMESPACE)
+
+
+# ── Admin bypass ─────────────────────────────────────────────────────────────
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_admin_can_delete_user_private_workspace(e2e_deployment: EndToEndDeployment) -> None:
+    """Admin can delete a user's private (OwnerOnly) workspace, bypassing ownership."""
+    e2e_deployment.ensure_deployed()
+    name = "e2e-ws-admin-delete-private"
+    user_a = _get_user_a()
+    group = _get_impersonation_group()
+    groups = [group]
+
+    # Create as User A (private)
+    kubectl_apply_workspace(name, WORKSPACES_DIR, as_user=user_a, as_groups=groups)
+    kubectl_poll_workspace_status(
+        name,
+        "Running",
+        namespace=NAMESPACE,
+        timeout_s=300,
+        as_user=user_a,
+        as_groups=groups,
+    )
+
+    # Admin deletes it (no impersonation = current IAM identity = admin)
+    kubectl_delete_workspace(name, namespace=NAMESPACE)
+
+    # Verify it's gone
+    result = subprocess.run(
+        ["kubectl", "get", "workspace", name, "-n", NAMESPACE],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, f"Workspace should be deleted but still exists:\n{result.stdout}"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_home_volume.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_home_volume.py
@@ -1,0 +1,74 @@
+"""E2E tests for workspace home volume persistence on the EKS OIDC template.
+
+Verifies that data written to the home volume persists across workspace
+stop/start cycles.
+"""
+
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.files import (
+    verify_file_exists_on_server,
+    verify_file_or_dir_does_not_exist_on_server,
+)
+
+SENTINEL_FILE = "e2e-persistence-test.txt"
+
+
+def test_home_volume_persists_across_restart(e2e_deployment: EndToEndDeployment, e2e_workspace: str) -> None:
+    """Write a file, stop workspace, restart, verify file still exists."""
+    name = e2e_workspace
+
+    # Write a sentinel file to the home volume
+    e2e_deployment.cli.run_command(
+        [
+            "jupyter-deploy",
+            "server",
+            "exec",
+            "--name",
+            name,
+            "--",
+            f"sh -c 'echo persistence-ok > /home/jovyan/{SENTINEL_FILE}'",
+        ]
+    )
+    verify_file_exists_on_server(e2e_deployment, f"/home/jovyan/{SENTINEL_FILE}", name=name)
+
+    # Stop the workspace
+    e2e_deployment.cli.run_command(["jupyter-deploy", "server", "stop", "--name", name])
+    e2e_deployment.cli.poll_scoped_server_status(name, "Stopped", timeout_s=180)
+
+    # Restart the workspace
+    e2e_deployment.cli.run_command(["jupyter-deploy", "server", "start", "--name", name])
+    e2e_deployment.cli.poll_scoped_server_status(name, "Running", timeout_s=300)
+
+    # Verify the sentinel file persisted
+    verify_file_exists_on_server(e2e_deployment, f"/home/jovyan/{SENTINEL_FILE}", name=name)
+
+    # Verify content
+    result = e2e_deployment.cli.run_command(
+        [
+            "jupyter-deploy",
+            "server",
+            "exec",
+            "--name",
+            name,
+            "--",
+            "cat",
+            f"/home/jovyan/{SENTINEL_FILE}",
+        ]
+    )
+    assert "persistence-ok" in result.stdout
+
+    # Cleanup
+    e2e_deployment.cli.run_command(
+        [
+            "jupyter-deploy",
+            "server",
+            "exec",
+            "--name",
+            name,
+            "--",
+            "rm",
+            "-f",
+            f"/home/jovyan/{SENTINEL_FILE}",
+        ]
+    )
+    verify_file_or_dir_does_not_exist_on_server(e2e_deployment, f"/home/jovyan/{SENTINEL_FILE}", name=name)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_jupyterlab.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_jupyterlab.py
@@ -1,0 +1,48 @@
+"""E2E tests for JupyterLab notebook execution on the EKS OIDC template.
+
+Verifies that a workspace serves a functional JupyterLab: uploads a simple
+notebook, runs it via the browser, and checks all cells execute without error.
+Requires OIDC auth + playwright.
+"""
+
+from pathlib import Path
+
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.notebook import delete_notebook, run_notebook_in_jupyterlab, upload_notebook
+from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+from pytest_jupyter_deploy.workspaces.kubectl import kubectl_get_workspace_access_url
+
+from .conftest import WORKSPACE_NAMESPACE
+
+NOTEBOOKS_DIR = Path(__file__).parent / "notebooks"
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER"])
+def test_run_simple_notebook(
+    e2e_deployment: EndToEndDeployment,
+    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
+    e2e_workspace: str,
+) -> None:
+    """Upload and run a simple notebook in a workspace via JupyterLab UI."""
+    e2e_deployment.ensure_deployed()
+
+    # Navigate to workspace JupyterLab and authenticate
+    access_url = kubectl_get_workspace_access_url(e2e_workspace, WORKSPACE_NAMESPACE)
+    dex_oauth_app.verify_workspace_accessible(access_url)
+
+    # Upload notebook
+    notebook_path = NOTEBOOKS_DIR / "kernel_simple.ipynb"
+    server_path = upload_notebook(
+        e2e_deployment,
+        notebook_path,
+        "e2e-test/kernel_simple.ipynb",
+        name=e2e_workspace,
+        scope=WORKSPACE_NAMESPACE,
+    )
+
+    # Run the actual notebook
+    run_notebook_in_jupyterlab(dex_oauth_app.page, server_path, timeout_ms=120000)
+
+    # Cleanup
+    delete_notebook(e2e_deployment, server_path, name=e2e_workspace, scope=WORKSPACE_NAMESPACE)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-jupyterlab-admin-public.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-jupyterlab-admin-public.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-jupyterlab-admin-public
+  namespace: default
+spec:
+  displayName: "E2E JupyterLab Admin Public"
+  desiredStatus: Running
+  ownershipType: Public
+  accessType: Public

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-jupyterlab-other-private.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-jupyterlab-other-private.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-jupyterlab-other-private
+  namespace: default
+spec:
+  displayName: "E2E JupyterLab Other User Private"
+  desiredStatus: Running
+  ownershipType: OwnerOnly
+  accessType: OwnerOnly

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-jupyterlab-other-public.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-jupyterlab-other-public.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-jupyterlab-other-public
+  namespace: default
+spec:
+  displayName: "E2E JupyterLab Other User Public"
+  desiredStatus: Running
+  ownershipType: Public
+  accessType: Public

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-admin-delete-private.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-admin-delete-private.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-ws-admin-delete-private
+  namespace: default
+spec:
+  displayName: "E2E Admin Delete Private"
+  desiredStatus: Running
+  ownershipType: OwnerOnly
+  accessType: OwnerOnly

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-cross-private.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-cross-private.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-ws-cross-private
+  namespace: default
+spec:
+  displayName: "E2E Cross User Private"
+  desiredStatus: Running
+  ownershipType: OwnerOnly
+  accessType: OwnerOnly

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-cross-public.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-cross-public.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-ws-cross-public
+  namespace: default
+spec:
+  displayName: "E2E Cross User Public"
+  desiredStatus: Running
+  ownershipType: Public
+  accessType: Public

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-private-access.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-private-access.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-ws-private-access
+  namespace: default
+spec:
+  displayName: "E2E Private Access"
+  desiredStatus: Running
+  ownershipType: OwnerOnly
+  accessType: OwnerOnly

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-public-access.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-public-access.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-ws-public-access
+  namespace: default
+spec:
+  displayName: "E2E Public Access"
+  desiredStatus: Running
+  ownershipType: Public
+  accessType: Public

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-stop-start.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-stop-start.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-ws-stop-start
+  namespace: default
+spec:
+  displayName: "E2E Stop Start"
+  desiredStatus: Running
+  ownershipType: Public
+  accessType: Public

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-user-delete.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-ws-user-delete.yaml
@@ -1,0 +1,10 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-ws-user-delete
+  namespace: default
+spec:
+  displayName: "E2E User Delete"
+  desiredStatus: Running
+  ownershipType: OwnerOnly
+  accessType: OwnerOnly

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -593,7 +593,7 @@ def down(
 
 @runner.app.command()
 def open(
-    server_name: Annotated[str | None, typer.Option("--name", help="Name of the server to open.")] = None,
+    server_name: Annotated[str | None, typer.Option("--server-name", help="Name of the server to open.")] = None,
     scope: Annotated[str, typer.Option("--scope", help="Scope or group the server belongs to.")] = "",
     project_dir: Annotated[Path | None, typer.Option("--path", "-p", help="Directory of the project to open.")] = None,
 ) -> None:
@@ -604,7 +604,7 @@ def open(
 
     Call <jd config> and <jd up> first.
 
-    For a multi-apps template, open a specific app with: <jd open --name SERVER_NAME>.
+    For a multi-apps template, open a specific app with: <jd open --server-name SERVER_NAME>.
     Pass --scope <scope>.
     """
     console = Console()
@@ -616,7 +616,7 @@ def open(
 
         try:
             url = handler.open(name=server_name, scope=scope or None)
-            console.print(f"\nOpening app at: {url}", style="green")
+            console.print(f"\nOpening app at: {url}", style="green", soft_wrap=True)
         except UrlNotAvailableError as e:
             # URL not available - show helpful message but don't fail (project not deployed)
             console.print(f":x: {e}", style="bold red")

--- a/libs/jupyter-deploy/jupyter_deploy/cli/cluster_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/cluster_app.py
@@ -84,7 +84,7 @@ def show(
             details = handler.show_cluster()
 
         if json_output:
-            console.print(json.dumps(details), highlight=False, markup=False)
+            console.print(json.dumps(details), highlight=False, markup=False, soft_wrap=True)
             return
 
         console.print_json(json.dumps(details))

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -281,7 +281,7 @@ def show(
             details = handler.show_host(name=name)
 
         if json_output:
-            console.print(json.dumps(details), highlight=False, markup=False)
+            console.print(json.dumps(details), highlight=False, markup=False, soft_wrap=True)
             return
 
         console.print_json(json.dumps(details))

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -397,7 +397,7 @@ def show(
             details = handler.show_server(name=name, scope=scope or None)
 
         if json_output:
-            console.print(json.dumps(details), highlight=False, markup=False)
+            console.print(json.dumps(details), highlight=False, markup=False, soft_wrap=True)
             return
 
         console.print_json(json.dumps(details))

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_core_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_core_runner.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import subprocess
 from enum import Enum
 
@@ -188,7 +189,7 @@ class K8sCoreRunner(InstructionRunner):
             raise ValueError("Either 'name' (pod name) or 'deployment_name' must be provided")
 
         container = container_arg.value if container_arg.value and container_arg.value != "default" else None
-        command_parts = command_arg.value.split()
+        command_parts = shlex.split(command_arg.value)
         self.display_manager.info(f"Executing command on pod: {pod_name}")
         result = k8s_core.exec_pod(
             self.core_api,

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
@@ -318,6 +318,26 @@ class TestOpenCommand(unittest.TestCase):
 
     @patch("jupyter_deploy.cli.app.OpenHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_url_not_line_wrapped(
+        self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock
+    ) -> None:
+        """Test that long URLs are printed on a single line without wrapping."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler()
+        long_url = "https://another-long-subsub-domain.some-very-long-subdomain.example.com/workspaces/default/some-long-workspace-name/lab"
+        mock_open_fns["open"].return_value = long_url
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open"])
+
+        self.assertEqual(result.exit_code, 0)
+        # The full URL must appear on a single line (soft_wrap=True prevents Rich from breaking it)
+        output_lines = result.output.splitlines()
+        url_lines = [line for line in output_lines if long_url in line]
+        self.assertEqual(len(url_lines), 1, f"URL should appear intact on one line, got output:\n{result.output}")
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_open_command_with_server_name(self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock) -> None:
         """Test that open command passes server name to handler."""
         mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler()
@@ -325,7 +345,7 @@ class TestOpenCommand(unittest.TestCase):
         mock_open_handler_cls.return_value = mock_open_handler_instance
 
         runner = CliRunner()
-        result = runner.invoke(app_runner.app, ["open", "--name", "my-ws"])
+        result = runner.invoke(app_runner.app, ["open", "--server-name", "my-ws"])
 
         self.assertEqual(result.exit_code, 0)
         mock_open_fns["open"].assert_called_once_with(name="my-ws", scope=None)
@@ -342,7 +362,7 @@ class TestOpenCommand(unittest.TestCase):
         mock_open_handler_cls.return_value = mock_open_handler_instance
 
         runner = CliRunner()
-        result = runner.invoke(app_runner.app, ["open", "--name", "my-ws", "--scope", "team-a"])
+        result = runner.invoke(app_runner.app, ["open", "--server-name", "my-ws", "--scope", "team-a"])
 
         self.assertEqual(result.exit_code, 0)
         mock_open_fns["open"].assert_called_once_with(name="my-ws", scope="team-a")

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
@@ -2,6 +2,7 @@
 
 import re
 import subprocess
+import time
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
@@ -134,6 +135,64 @@ class JDCli:
                 return status
 
         raise ValueError("Could not parse server status from command output")
+
+    def get_scoped_server_status(self, name: str, scope: str = "default") -> str:
+        """Get the status of a named server (workspace) via jd CLI.
+
+        Args:
+            name: Server / workspace name
+            scope: Kubernetes namespace / scope
+
+        Returns:
+            Server status string (e.g., "Running", "Stopped")
+
+        Raises:
+            JDCliError: If command fails
+            ValueError: If status cannot be parsed
+        """
+        result = self.run_command(["jupyter-deploy", "server", "status", "--name", name, "--scope", scope])
+
+        for line in result.stdout.splitlines():
+            if "Server status:" in line:
+                status = line.split(":", 1)[1].strip()
+                status = re.sub(r"\x1b\[[0-9;]*m", "", status)
+                return status
+
+        raise ValueError(f"Could not parse server status for '{name}' from command output")
+
+    def poll_scoped_server_status(
+        self,
+        name: str,
+        target_status: str,
+        scope: str = "default",
+        timeout_s: int = 180,
+        interval_s: int = 10,
+    ) -> None:
+        """Poll server status via jd CLI until it matches target or timeout.
+
+        Args:
+            name: Server / workspace name
+            target_status: Expected status (e.g., "Running", "Stopped")
+            scope: Kubernetes namespace / scope
+            timeout_s: Maximum wait time in seconds
+            interval_s: Seconds between polls
+
+        Raises:
+            TimeoutError: If server does not reach target_status within timeout_s
+        """
+        deadline = time.time() + timeout_s
+        last_status = ""
+        while time.time() < deadline:
+            try:
+                last_status = self.get_scoped_server_status(name, scope)
+                if last_status == target_status:
+                    return
+            except (JDCliError, ValueError):
+                pass
+            time.sleep(interval_s)
+        raise TimeoutError(
+            f"Server '{name}' did not reach status '{target_status}' within {timeout_s}s (last: {last_status})"
+        )
 
     def get_jupyterlab_url(self) -> str:
         """Get the JupyterLab URL by querying the open_url value's terraform output.

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
@@ -27,6 +27,7 @@ class JDCli:
     def __init__(self, project_dir: Path) -> None:
         """Initialize CLI wrapper."""
         self.project_dir = project_dir
+        self._jupyterlab_url: str | None = None
 
     def run_command(
         self,
@@ -197,11 +198,8 @@ class JDCli:
     def get_jupyterlab_url(self) -> str:
         """Get the JupyterLab URL by querying the open_url value's terraform output.
 
-        This follows the same pattern as OpenHandler:
-        1. Get the manifest
-        2. Look up the "open_url" declared value
-        3. Get the source_key (terraform output name) from the value definition
-        4. Query that output using jd show
+        The result is cached for the lifetime of this instance since the URL
+        never changes during a test session.
 
         Returns:
             JupyterLab URL string
@@ -209,6 +207,9 @@ class JDCli:
         Raises:
             JDCliError: If command fails
         """
+        if self._jupyterlab_url is not None:
+            return self._jupyterlab_url
+
         # Get manifest and look up the declared value for "open_url"
         manifest_path = self.project_dir / jd_constants.MANIFEST_FILENAME
         manifest = retrieve_project_manifest(manifest_path)
@@ -219,7 +220,8 @@ class JDCli:
 
         # Query the actual terraform output using jd show
         result = self.run_command(["jupyter-deploy", "show", "--output", output_name, "--text"])
-        return result.stdout.strip()
+        self._jupyterlab_url = result.stdout.strip()
+        return self._jupyterlab_url
 
     def get_allowlisted_users(self) -> list[str]:
         """Return the list of allowlisted users, or empty list if none.

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/files.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/files.py
@@ -8,11 +8,24 @@ from pytest_jupyter_deploy.cli import JDCliError
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 
 
-def verify_file_exists_on_server(e2e_deployment: EndToEndDeployment, file_path: str) -> None:
+def _build_exec_cmd(args: list[str], name: str | None = None, scope: str | None = None) -> list[str]:
+    cmd = ["jupyter-deploy", "server", "exec"]
+    if name is not None:
+        cmd.extend(["--name", name])
+    if scope is not None:
+        cmd.extend(["--scope", scope])
+    cmd.append("--")
+    cmd.extend(args)
+    return cmd
+
+
+def verify_file_exists_on_server(
+    e2e_deployment: EndToEndDeployment, file_path: str, name: str | None = None, scope: str | None = None
+) -> None:
     """Verify that a file exists on the server."""
     try:
         result = e2e_deployment.cli.run_command(
-            ["jupyter-deploy", "server", "exec", "--", "stat", "--format=%F", file_path]
+            _build_exec_cmd(["stat", "--format=%F", file_path], name=name, scope=scope)
         )
     except JDCliError as e:
         raise AssertionError(f"Expected file {file_path} to exist on server, but stat failed: {e}") from e
@@ -20,11 +33,13 @@ def verify_file_exists_on_server(e2e_deployment: EndToEndDeployment, file_path: 
     assert "file" in result.stdout, f"Expected file {file_path} to be of type file: {result.stdout}"
 
 
-def verify_dir_exists_on_server(e2e_deployment: EndToEndDeployment, dir_path: str) -> None:
+def verify_dir_exists_on_server(
+    e2e_deployment: EndToEndDeployment, dir_path: str, name: str | None = None, scope: str | None = None
+) -> None:
     """Verify that a directory exists on the server."""
     try:
         result = e2e_deployment.cli.run_command(
-            ["jupyter-deploy", "server", "exec", "--", "stat", "--format=%F", dir_path]
+            _build_exec_cmd(["stat", "--format=%F", dir_path], name=name, scope=scope)
         )
     except JDCliError as e:
         raise AssertionError(f"Expected directory {dir_path} to exist on server, but stat failed: {e}") from e
@@ -32,10 +47,12 @@ def verify_dir_exists_on_server(e2e_deployment: EndToEndDeployment, dir_path: st
     assert "directory" in result.stdout, f"Expected directory {dir_path} to be of type dir: {result.stdout}"
 
 
-def verify_file_or_dir_does_not_exist_on_server(e2e_deployment: EndToEndDeployment, file_path: str) -> None:
+def verify_file_or_dir_does_not_exist_on_server(
+    e2e_deployment: EndToEndDeployment, file_path: str, name: str | None = None, scope: str | None = None
+) -> None:
     """Verify that a file or directory does not exist on the server."""
     try:
-        result = e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", "stat", file_path])
+        result = e2e_deployment.cli.run_command(_build_exec_cmd(["stat", file_path], name=name, scope=scope))
         # If stat succeeded, the file exists - this is unexpected
         raise AssertionError(
             f"Expected file {file_path} to not exist on server, but stat succeeded with output: {result.stdout}"
@@ -61,13 +78,21 @@ def verify_file_or_dir_does_not_exist_on_server(e2e_deployment: EndToEndDeployme
             raise AssertionError(f"Unexpected error type when checking if {file_path} exists: {e}") from e
 
 
-def upload_file_on_server(e2e_deployment: EndToEndDeployment, src_path: str | Path, target_path: str) -> None:
+def upload_file_on_server(
+    e2e_deployment: EndToEndDeployment,
+    src_path: str | Path,
+    target_path: str,
+    name: str | None = None,
+    scope: str | None = None,
+) -> None:
     """Upload a file to the server.
 
     Args:
         e2e_deployment: The deployment instance
         src_path: Path to the local file
         target_path: Target path on the server
+        name: Server/workspace name (for multi-server templates like EKS)
+        scope: Namespace scope (for multi-server templates like EKS)
 
     Raises:
         FileNotFoundError: If the source file doesn't exist
@@ -92,4 +117,4 @@ def upload_file_on_server(e2e_deployment: EndToEndDeployment, src_path: str | Pa
         f"open('{target_path}', 'wb').write(data)\""
     )
 
-    e2e_deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", python_cmd])
+    e2e_deployment.cli.run_command(_build_exec_cmd([python_cmd], name=name, scope=scope))

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
@@ -14,13 +14,11 @@ RUN apt-get update && \
     oathtool \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Terraform
+# Install Terraform (direct binary — HashiCorp removed older versions from their apt repo)
 ARG TF_VERSION=1.5.7
-RUN wget -qO- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
-    echo 'deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com bookworm main' | tee /etc/apt/sources.list.d/hashicorp.list && \
-    apt-get update && \
-    apt-get install -y terraform=${TF_VERSION}-1 && \
-    rm -rf /var/lib/apt/lists/*
+RUN wget -qO /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip" && \
+    unzip -o /tmp/terraform.zip -d /usr/local/bin/ && \
+    rm /tmp/terraform.zip
 
 # Install AWS CLI
 RUN curl -s 'https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip' -o 'awscliv2.zip' && \

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebook.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/notebook.py
@@ -29,7 +29,13 @@ from pytest_jupyter_deploy.notebooks.notebook_utils import (
 logger = logging.getLogger(__name__)
 
 
-def upload_notebook(deployment: EndToEndDeployment, src_path: str | Path, target_path: str) -> str:
+def upload_notebook(
+    deployment: EndToEndDeployment,
+    src_path: str | Path,
+    target_path: str,
+    name: str | None = None,
+    scope: str | None = None,
+) -> str:
     """Upload a notebook to the Jupyter server with a unique path.
 
     A UUID suffix is appended to the target filename to ensure each upload creates a
@@ -43,6 +49,8 @@ def upload_notebook(deployment: EndToEndDeployment, src_path: str | Path, target
         target_path: Base target path on the server (relative to /home/jovyan,
             e.g., "e2e-test/application_simple.ipynb"). A UUID is appended before
             the extension to create the actual unique path.
+        name: Server/workspace name (for multi-server templates like EKS)
+        scope: Namespace scope (for multi-server templates like EKS)
 
     Returns:
         The actual unique path the notebook was uploaded to
@@ -78,7 +86,14 @@ def upload_notebook(deployment: EndToEndDeployment, src_path: str | Path, target
         f"open('/home/jovyan/{unique_target}', 'wb').write(data)\""
     )
 
-    deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", python_cmd])
+    cmd = ["jupyter-deploy", "server", "exec"]
+    if name is not None:
+        cmd.extend(["--name", name])
+    if scope is not None:
+        cmd.extend(["--scope", scope])
+    cmd.extend(["--", python_cmd])
+
+    deployment.cli.run_command(cmd)
     return unique_target
 
 
@@ -333,13 +348,27 @@ def _verify_executed_and_no_cell_error(cells_info: list[dict[str, str]], noteboo
         raise RuntimeError(f"Notebook {notebook_path} execution failed with errors.")
 
 
-def delete_notebook(deployment: EndToEndDeployment, target_path: str, home_path: str = "/home/jovyan") -> None:
+def delete_notebook(
+    deployment: EndToEndDeployment,
+    target_path: str,
+    home_path: str = "/home/jovyan",
+    name: str | None = None,
+    scope: str | None = None,
+) -> None:
     """Delete a notebook from the Jupyter server.
 
     Args:
         deployment: The deployment instance
         target_path: Path to the notebook on the server (relative to home dir, e.g., "work/test.ipynb")
         home_path: Path to the home dir in the jupyterlab container (default: /home/jovyan)
+        name: Server/workspace name (for multi-server templates like EKS)
+        scope: Namespace scope (for multi-server templates like EKS)
     """
     full_cmd = f"rm -f {home_path}/{target_path}"
-    deployment.cli.run_command(["jupyter-deploy", "server", "exec", "--", full_cmd])
+    cmd = ["jupyter-deploy", "server", "exec"]
+    if name is not None:
+        cmd.extend(["--name", name])
+    if scope is not None:
+        cmd.extend(["--scope", scope])
+    cmd.extend(["--", full_cmd])
+    deployment.cli.run_command(cmd)

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/dex.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/dex.py
@@ -1,0 +1,200 @@
+"""Dex OIDC consent and authentication handling for E2E testing."""
+
+import contextlib
+import logging
+import time
+from collections.abc import Callable
+from urllib.parse import urlparse
+
+from playwright.sync_api import Page, expect
+
+from pytest_jupyter_deploy.oauth2_proxy.github import GitHubOAuth2ProxyApplication
+
+logger = logging.getLogger(__name__)
+
+
+def handle_dex_consent_if_present(page: Page, timeout_ms: int = 3000) -> bool:
+    """Click "Grant Access" on the Dex consent page if it appears.
+
+    Dex shows a consent screen after GitHub OAuth completes, asking the user
+    to grant access to profile, email, and groups. This function detects and
+    dismisses it.
+
+    Args:
+        page: Playwright Page instance
+        timeout_ms: How long to wait for the Grant Access button to appear
+
+    Returns:
+        True if the consent page was detected and granted, False otherwise
+    """
+    try:
+        grant_button = page.locator("button.dex-btn:has-text('Grant Access')")
+        if not grant_button.is_visible(timeout=timeout_ms):
+            return False
+    except Exception:
+        return False
+
+    logger.debug("Dex consent page detected, clicking Grant Access")
+    grant_button.click()
+    page.wait_for_load_state("load", timeout=30000)
+    logger.debug(f"Dex consent granted, now at: {page.url}")
+    return True
+
+
+class DexGitHubOAuth2ProxyApplication(GitHubOAuth2ProxyApplication):
+    """OAuth2 Proxy application behind Dex (skip-provider-button flow).
+
+    Flow: app → oauth2-proxy (auto-redirect) → Dex → GitHub → Dex consent → app.
+    Reuses the parent's GitHub authorize/reauthorize handling.
+    """
+
+    def _is_on_app_domain(self) -> bool:
+        current_host = urlparse(self.page.url).hostname or ""
+        app_host = urlparse(self.jupyterlab_url).hostname or ""
+        return current_host == app_host
+
+    def _complete_oauth_flow(self) -> bool:
+        """Handle OAuth redirects after navigating to a protected URL.
+
+        Handles: GitHub authorize/reauthorize page, Dex consent, cookie-based
+        auto-completion. Call after page.goto() to a protected resource.
+
+        Returns True if we end up back on the app domain.
+        """
+        with contextlib.suppress(Exception):
+            self.page.wait_for_load_state("networkidle", timeout=10000)
+
+        if self._is_on_app_domain():
+            return True
+
+        if "github.com/login/oauth/authorize" in self.page.url:
+            try:
+                self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=5000)
+            except Exception:
+                self._handle_oauth_authorize_page()
+
+        handle_dex_consent_if_present(self.page)
+
+        if self._is_on_app_domain():
+            return True
+
+        if "github.com" in self.page.url:
+            return False
+
+        return False
+
+    def _try_auth_session(self) -> bool:
+        """Try authenticating through the Dex OAuth flow with existing cookies.
+
+        With skip-provider-button=true, oauth2-proxy auto-redirects to Dex,
+        which auto-redirects to GitHub. If cookies are valid at each stage,
+        the flow completes without user interaction.
+        """
+        self._navigate_with_retry(self.jupyterlab_url, timeout=60000)
+
+        if self._complete_oauth_flow():
+            self.save_storage_state()
+            return True
+        return False
+
+    def login_with_2fa(self, email: str, password: str, totp_fn: Callable[[], str]) -> None:
+        """Login with 2FA, then handle Dex consent page after GitHub redirects back."""
+        super().login_with_2fa(email, password, totp_fn)
+        handle_dex_consent_if_present(self.page)
+        if self._is_on_app_domain():
+            self.save_storage_state()
+
+    def _wait_for_workspace_auth_redirect(self) -> None:
+        """Wait for the workspace /auth page to complete its redirect chain.
+
+        The workspace access URL ends with /auth. It triggers oauth2-proxy which
+        sets the workspace_auth cookie via Dex → GitHub. After completion the
+        page should redirect to the workspace root. If the auth proxy returns
+        502 (not ready yet), retry. If it stays at /auth with cookies set,
+        navigate to workspace root.
+        """
+        if "/auth" not in self.page.url:
+            return
+        logger.info(f"Page at /auth endpoint, waiting for redirect: {self.page.url}")
+
+        with contextlib.suppress(Exception):
+            self.page.wait_for_url(lambda url: "/auth" not in url, timeout=30000)
+
+        if not self._is_on_app_domain():
+            self._complete_oauth_flow()
+
+        handle_dex_consent_if_present(self.page)
+
+        if "/auth" in self.page.url:
+            content = self.page.content()
+            if "Bad Gateway" in content or "502" in content:
+                logger.info("Auth proxy returned 502, retrying /auth")
+                time.sleep(5)
+                self.page.reload(wait_until="load", timeout=60000)
+                with contextlib.suppress(Exception):
+                    self.page.wait_for_url(lambda url: "/auth" not in url, timeout=30000)
+                if not self._is_on_app_domain():
+                    self._complete_oauth_flow()
+                handle_dex_consent_if_present(self.page)
+
+        if "/auth" in self.page.url:
+            workspace_root = self.page.url.rsplit("/auth", 1)[0] + "/"
+            logger.info(f"Auth complete, navigating to workspace root: {workspace_root}")
+            self.page.goto(workspace_root, wait_until="load", timeout=60000)
+            with contextlib.suppress(Exception):
+                self.page.wait_for_load_state("networkidle", timeout=10000)
+
+    def _is_unauthorized_page(self) -> bool:
+        content = self.page.content()
+        return "Unauthorized" in content and len(content) < 300
+
+    def verify_workspace_accessible(self, access_url: str) -> None:
+        """Navigate to a workspace URL, complete OAuth if needed, verify JupyterLab loads."""
+        logger.info(f"Navigating to workspace: {access_url}")
+        self.page.goto(access_url, wait_until="load", timeout=60000)
+
+        self._wait_for_workspace_auth_redirect()
+
+        if not self._is_on_app_domain():
+            if not self._complete_oauth_flow():
+                self.ensure_authenticated()
+                self.page.goto(access_url, wait_until="load", timeout=60000)
+                self._wait_for_workspace_auth_redirect()
+            self.save_storage_state()
+        elif self._is_unauthorized_page():
+            logger.info("Workspace returned Unauthorized, authenticating then retrying /auth")
+            self.ensure_authenticated()
+            self.page.goto(access_url, wait_until="load", timeout=60000)
+            self._wait_for_workspace_auth_redirect()
+            if self._is_unauthorized_page():
+                raise AssertionError(f"Still unauthorized after auth retry at {self.page.url}")
+            self.save_storage_state()
+
+        # Handle Dex consent page that may appear after workspace auth redirect
+        if "/dex/approval" in self.page.url:
+            handle_dex_consent_if_present(self.page)
+
+        logger.info(f"After auth, page URL: {self.page.url}")
+        jupyterlab_locator = self.page.locator("#jp-top-panel, #jp-main-dock-panel, #jp-main-content-panel")
+        jupyterlab_locator.first.wait_for(state="attached", timeout=60000)
+        expect(jupyterlab_locator.first).to_be_visible(timeout=30000)
+
+    def verify_workspace_inaccessible(self, access_url: str) -> None:
+        """Navigate to a workspace URL and verify access is denied."""
+        logger.info(f"Verifying workspace is inaccessible: {access_url}")
+        self.page.goto(access_url, wait_until="load", timeout=60000)
+
+        self._wait_for_workspace_auth_redirect()
+
+        if not self._is_on_app_domain():
+            if not self._complete_oauth_flow():
+                self.ensure_authenticated()
+                self.page.goto(access_url, wait_until="load", timeout=60000)
+                self._wait_for_workspace_auth_redirect()
+            self.save_storage_state()
+
+        content = self.page.content()
+        denied_indicators = ["Access denied", "not authorized", "Unauthorized", "Forbidden", "403"]
+        assert any(indicator in content for indicator in denied_indicators), (
+            f"Expected access denied but got page at {self.page.url}: {content[:500]}"
+        )

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/plugin.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/plugin.py
@@ -13,6 +13,7 @@ from pytest_jupyter_deploy import constants
 from pytest_jupyter_deploy.constants import DEPLOY_TIMEOUT_SECONDS, DESTROY_TIMEOUT_SECONDS
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.oauth2_proxy.ci_credentials import fetch_ci_credentials
+from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
 from pytest_jupyter_deploy.oauth2_proxy.github import GitHubOAuth2ProxyApplication
 from pytest_jupyter_deploy.suite_config import SuiteConfig
 
@@ -309,6 +310,40 @@ def github_oauth_app(
         ci_email, ci_password, ci_totp_fn = fetch_ci_credentials(ci_dir)
 
     return GitHubOAuth2ProxyApplication(
+        page=page,
+        jupyterlab_url=jupyterlab_url,
+        storage_state_path=storage_state_path,
+        is_ci=is_ci,
+        ci_email=ci_email,
+        ci_password=ci_password,
+        ci_totp_fn=ci_totp_fn,
+    )
+
+
+@pytest.fixture(scope="function")
+def dex_oauth_app(
+    page: Page, e2e_deployment: EndToEndDeployment, request: pytest.FixtureRequest
+) -> DexGitHubOAuth2ProxyApplication:
+    """Create a Dex-aware OAuth2 Proxy application helper.
+
+    Same as github_oauth_app but for templates that use Dex as the OIDC provider
+    (e.g. EKS OIDC). Handles the Dex consent page in the OAuth flow.
+    """
+    e2e_deployment.ensure_deployed()
+    jupyterlab_url = e2e_deployment.cli.get_jupyterlab_url()
+    storage_state_path = Path.cwd() / constants.AUTH_DIR / constants.GITHUB_OAUTH_STATE_FILE
+
+    is_ci = request.config.getoption("--ci", default=False)
+    ci_email: str | None = None
+    ci_password: str | None = None
+    ci_totp_fn: Callable[[], str] | None = None
+    if is_ci:
+        ci_dir = request.config.getoption("--ci-dir")
+        if not ci_dir:
+            raise pytest.UsageError("--ci requires --ci-dir <path> for credential fetching")
+        ci_email, ci_password, ci_totp_fn = fetch_ci_credentials(ci_dir)
+
+    return DexGitHubOAuth2ProxyApplication(
         page=page,
         jupyterlab_url=jupyterlab_url,
         storage_state_path=storage_state_path,

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/__init__.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/__init__.py
@@ -1,0 +1,1 @@
+"""Workspace utilities for E2E testing of Kubernetes-based templates."""

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/kubectl.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/kubectl.py
@@ -1,0 +1,267 @@
+"""Kubectl operations for Workspace custom resources."""
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+
+def kubectl_apply_workspace(
+    name: str,
+    workspaces_dir: Path,
+    as_user: str | None = None,
+    as_groups: list[str] | None = None,
+) -> None:
+    """Apply a Workspace CR from the given directory.
+
+    Args:
+        name: Workspace name (maps to {name}.yaml in workspaces_dir)
+        workspaces_dir: Directory containing workspace YAML manifests
+        as_user: Impersonate this user (--as flag)
+        as_groups: Impersonate these groups (--as-group flags)
+    """
+    manifest_path = workspaces_dir / f"{name}.yaml"
+    cmd = ["kubectl", "apply", "-f", str(manifest_path)]
+    if as_user:
+        cmd += ["--as", as_user]
+    for group in as_groups or []:
+        cmd += ["--as-group", group]
+    subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def kubectl_delete_workspace(name: str, namespace: str = "default") -> None:
+    """Delete a Workspace CR via kubectl (ignores not-found errors).
+
+    Args:
+        name: Workspace resource name
+        namespace: Kubernetes namespace
+    """
+    subprocess.run(
+        ["kubectl", "delete", "workspace", name, "-n", namespace, "--ignore-not-found"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def kubectl_patch_workspace(
+    name: str,
+    patch: str,
+    namespace: str = "default",
+    as_user: str | None = None,
+    as_groups: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Patch a Workspace CR via kubectl (merge strategy).
+
+    Args:
+        name: Workspace resource name
+        patch: JSON merge patch string
+        namespace: Kubernetes namespace
+        as_user: Impersonate this user (--as flag)
+        as_groups: Impersonate these groups (--as-group flags)
+
+    Returns:
+        CompletedProcess (caller checks returncode for permission tests)
+    """
+    cmd = ["kubectl", "patch", "workspace", name, "-n", namespace, "--type=merge", "-p", patch]
+    if as_user:
+        cmd += ["--as", as_user]
+    for group in as_groups or []:
+        cmd += ["--as-group", group]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def kubectl_get_workspace(
+    name: str,
+    namespace: str = "default",
+    as_user: str | None = None,
+    as_groups: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Get a Workspace CR via kubectl.
+
+    Args:
+        name: Workspace resource name
+        namespace: Kubernetes namespace
+        as_user: Impersonate this user (--as flag)
+        as_groups: Impersonate these groups (--as-group flags)
+
+    Returns:
+        CompletedProcess (caller checks returncode for permission tests)
+    """
+    cmd = ["kubectl", "get", "workspace", name, "-n", namespace]
+    if as_user:
+        cmd += ["--as", as_user]
+    for group in as_groups or []:
+        cmd += ["--as-group", group]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def kubectl_get_workspace_status(
+    name: str,
+    namespace: str = "default",
+    as_user: str | None = None,
+    as_groups: list[str] | None = None,
+) -> str:
+    """Derive workspace status from conditions via kubectl.
+
+    Evaluates the same condition logic as the jd CLI status rules:
+    - Degraded condition True → "Degraded"
+    - Stopped condition True → "Stopped"
+    - Available condition True → "Running"
+    - Progressing condition True → "Starting" or "Stopping" (based on desiredStatus)
+    - Otherwise → "Unknown"
+
+    Args:
+        name: Workspace resource name
+        namespace: Kubernetes namespace
+        as_user: Impersonate this user (--as flag)
+        as_groups: Impersonate these groups (--as-group flags)
+
+    Returns:
+        Derived status string (e.g., "Running", "Stopped", "Starting", "Degraded")
+
+    Raises:
+        subprocess.CalledProcessError: If kubectl fails (e.g., workspace not found)
+        ValueError: If conditions cannot be parsed
+    """
+    cmd = [
+        "kubectl",
+        "get",
+        "workspace",
+        name,
+        "-n",
+        namespace,
+        "-o",
+        "json",
+    ]
+    if as_user:
+        cmd += ["--as", as_user]
+    for group in as_groups or []:
+        cmd += ["--as-group", group]
+    result = subprocess.run(
+        cmd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    resource = json.loads(result.stdout)
+    conditions = resource.get("status", {}).get("conditions", [])
+    desired_status = resource.get("spec", {}).get("desiredStatus", "")
+
+    condition_map: dict[str, str] = {}
+    for c in conditions:
+        condition_map[c["type"]] = c["status"]
+
+    if condition_map.get("Degraded") == "True":
+        return "Degraded"
+    if condition_map.get("Stopped") == "True":
+        return "Stopped"
+    if condition_map.get("Available") == "True":
+        return "Running"
+    if condition_map.get("Progressing") == "True":
+        return "Stopping" if desired_status == "Stopped" else "Starting"
+
+    return "Unknown"
+
+
+def _kubectl_get_workspace_field(name: str, jsonpath: str, field_label: str, namespace: str = "default") -> str:
+    result = subprocess.run(
+        ["kubectl", "get", "workspace", name, "-n", namespace, "-o", f"jsonpath={jsonpath}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    value = result.stdout.strip()
+    if not value:
+        raise ValueError(f"Workspace '{name}' has no {field_label}")
+    return value
+
+
+def kubectl_get_workspace_jsonpath(
+    name: str,
+    jsonpath: str,
+    namespace: str = "default",
+    as_user: str | None = None,
+    as_groups: list[str] | None = None,
+) -> str:
+    """Get a workspace field via jsonpath expression (with optional impersonation)."""
+    cmd = ["kubectl", "get", "workspace", name, "-n", namespace, "-o", f"jsonpath={jsonpath}"]
+    if as_user:
+        cmd += ["--as", as_user]
+    for group in as_groups or []:
+        cmd += ["--as-group", group]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def kubectl_get_workspace_owner(name: str, namespace: str = "default") -> str:
+    """Get the workspace owner from the created-by annotation."""
+    return _kubectl_get_workspace_field(
+        name,
+        r"{.metadata.annotations['workspace\.jupyter\.org/created-by']}",
+        "workspace.jupyter.org/created-by annotation",
+        namespace,
+    )
+
+
+def kubectl_get_workspace_ownership_type(name: str, namespace: str = "default") -> str:
+    """Get the workspace ownershipType from spec (e.g., "OwnerOnly", "Public")."""
+    return _kubectl_get_workspace_field(
+        name,
+        "{.spec.ownershipType}",
+        "spec.ownershipType",
+        namespace,
+    )
+
+
+def kubectl_get_workspace_access_url(name: str, namespace: str = "default") -> str:
+    """Get workspace accessURL from status via kubectl."""
+    return _kubectl_get_workspace_field(
+        name,
+        "{.status.accessURL}",
+        ".status.accessURL",
+        namespace,
+    )
+
+
+def kubectl_poll_workspace_status(
+    name: str,
+    target_status: str,
+    namespace: str = "default",
+    timeout_s: int = 180,
+    interval_s: int = 10,
+    as_user: str | None = None,
+    as_groups: list[str] | None = None,
+) -> None:
+    """Poll workspace status via kubectl until it matches target or timeout.
+
+    Args:
+        name: Workspace resource name
+        target_status: Expected status (e.g., "Running", "Stopped")
+        namespace: Kubernetes namespace
+        timeout_s: Maximum wait time in seconds
+        interval_s: Seconds between polls
+        as_user: Impersonate this user (--as flag)
+        as_groups: Impersonate these groups (--as-group flags)
+
+    Raises:
+        TimeoutError: If workspace does not reach target_status within timeout_s
+    """
+    deadline = time.time() + timeout_s
+    last_status = ""
+    while time.time() < deadline:
+        try:
+            last_status = kubectl_get_workspace_status(name, namespace, as_user=as_user, as_groups=as_groups)
+            if last_status == target_status:
+                return
+        except (subprocess.CalledProcessError, ValueError):
+            pass
+        time.sleep(interval_s)
+    raise TimeoutError(
+        f"Workspace '{name}' did not reach status '{target_status}' within {timeout_s}s (last: {last_status})"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,3 +126,4 @@ markers = [
   "bare: Tests requiring the bare install track with no AWS deps (select with '-m bare')",
 ]
 addopts = "-m 'not e2e' --import-mode=importlib"
+norecursedirs = ["**/tests/e2e"]


### PR DESCRIPTION
This PR expands e2e tests for the `eks-oidc` template to test: 1/ access to console, 2/ `jd server` commands, 3/ `jd open` command, console & workspace, 4/ workspace usage with `kubectl`, 5/ open and run notebook and 6/ write to home volume & persist workspace restarts.

Also in this PR:
- change `jd open --name SERVER-NAME` > `jd open --server-name SERVER-NAME`
- add `soft_wrap=True` flags
- fix regression in plugin: hashicorp removed `terraform` version `1.5.7` from its registry

### Implementation
- `DexGitHubOAuth2ProxyApplication` class to handle oauth flow in `<plugin>/oauth2_proxy`
- `dex_oauth_app` fixture in `<plugin>/`
- add fixtures to seed cluster w/ ws, retrieve env vars in `<eks-oidc>/tests/e2e/conftest`
- `<eks-oidc>/tests/e2e/test_open` > verify URLs + negative tests
- `<eks-oidc>/tests/e2e/test_console` > oauth access + download of `kubectl` setup script
- `<eks-oidc>/tests/e2e/test_server` > test each `server` command as admin
- `<eks-oidc>/tests/e2e/test_workspace` > test workspace management and access as user w/ `kubectl` using `--impersonate`
- `<eks-oidc>/tests/e2e/test_workspace_jupyterlab` > run notebook in JupyterLab workspace
- `<eks-oidc>/tests/e2e/test_workspace_home_volume` > write to home dir, restart workspace, verify persistence 

### Testing
- ran full E2E test suite for `eks-oidc` template
- ran a few E2E