### PR TITLE
release: plugin v0.2.1

### DIFF
--- a/libs/pytest-jupyter-deploy/pyproject.toml
+++ b/libs/pytest-jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-jupyter-deploy"
-version = "0.2.1"
+version = "0.2.2"
 description = "Pytest plugin for E2E testing of jupyter-deploy templates"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1254,7 +1254,7 @@ wheels = [
 
 [[package]]
 name = "pytest-jupyter-deploy"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "libs/pytest-jupyter-deploy" }
 dependencies = [
     { name = "jupyter-deploy" },


### PR DESCRIPTION
This PR prepares to release a new version of the `pytest-jupyter-deploy` plugin that captures the fix for the regression in `terraform` install from #221 

Plugin: `v0.2.1` -> `v0.2.2`