### PR TITLE
release: cli 0.6.0, plugin 0.2.3, eks-oidc 0.1.0rc1

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/__init__.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/__init__.py
@@ -1,3 +1,3 @@
 """AWS EKS OIDC Terraform template for deploying JupyterLab workspaces on Kubernetes."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.0rc1"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/Chart.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/console/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: console
-version: 0.1.0
+version: 0.1.0-rc.1
 description: Get-started console page with kubectl OIDC setup instructions
 type: application

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/github-rbac/Chart.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/github-rbac/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: github-rbac
 description: GitHub team RBAC for jupyter-k8s workspaces
-version: 0.1.0
+version: 0.1.0-rc.1
 type: application

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/Chart.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: workspace-defaults
-version: 0.1.0
+version: 0.1.0-rc.1
 description: Default workspace resources (access strategy, workspace template, console)
 type: application

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/main.tf
@@ -63,7 +63,7 @@ resource "random_id" "postfix" {
 
 locals {
   template_name    = "tf-aws-eks-oidc"
-  template_version = "0.1.0"
+  template_version = "0.1.0-rc.1"
 
   default_tags = {
     Source       = "jupyter-deploy"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 template:
   name: tf-aws-eks-oidc
   engine: terraform
-  version: 0.1.0
+  version: 0.1.0-rc.1
 health:
   active: true
   expected-status-code: 302

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-tf-aws-eks-oidc"
-version = "0.1.0"
+version = "0.1.0rc1"
 description = "OIDC terraform template to deploy JupyterLab workspaces on AWS EKS with GitHub authentication."
 readme = "README.md"
 authors = [

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_version.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_version.py
@@ -7,6 +7,15 @@ from pathlib import Path
 import yaml
 
 
+def pep440_to_semver(version: str) -> str:
+    """Convert PEP 440 pre-release version to SemVer (e.g. '0.1.0rc1' -> '0.1.0-rc.1')."""
+    match = re.match(r"^(\d+\.\d+\.\d+)(rc|a|b)(\d+)$", version)
+    if match:
+        base, pre_type, pre_num = match.groups()
+        return f"{base}-{pre_type}.{pre_num}"
+    return version
+
+
 def test_version_consistency() -> None:
     """Test that version numbers are consistent across pyproject.toml, __init__.py, manifest.yaml, and main.tf."""
     project_path = Path(__file__).parent.parent.parent
@@ -35,9 +44,10 @@ def test_version_consistency() -> None:
     assert pyproject_version == init_version, (
         f"Version mismatch: pyproject.toml ({pyproject_version}) != __init__.py ({init_version})"
     )
-    assert pyproject_version == manifest_version, (
-        f"Version mismatch: pyproject.toml ({pyproject_version}) != manifest.yaml ({manifest_version})"
+    semver_version = pep440_to_semver(pyproject_version)
+    assert semver_version == manifest_version, (
+        f"Version mismatch: pyproject.toml ({pyproject_version} -> {semver_version}) != manifest.yaml ({manifest_version})"
     )
-    assert pyproject_version == main_tf_version, (
-        f"Version mismatch: pyproject.toml ({pyproject_version}) != main.tf template_version ({main_tf_version})"
+    assert semver_version == main_tf_version, (
+        f"Version mismatch: pyproject.toml ({pyproject_version} -> {semver_version}) != main.tf ({main_tf_version})"
     )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_version.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_version.py
@@ -46,8 +46,10 @@ def test_version_consistency() -> None:
     )
     semver_version = pep440_to_semver(pyproject_version)
     assert semver_version == manifest_version, (
-        f"Version mismatch: pyproject.toml ({pyproject_version} -> {semver_version}) != manifest.yaml ({manifest_version})"
+        f"Version mismatch: pyproject.toml ({pyproject_version} -> {semver_version})"
+        f" != manifest.yaml ({manifest_version})"
     )
     assert semver_version == main_tf_version, (
-        f"Version mismatch: pyproject.toml ({pyproject_version} -> {semver_version}) != main.tf ({main_tf_version})"
+        f"Version mismatch: pyproject.toml ({pyproject_version} -> {semver_version})"
+        f" != main.tf ({main_tf_version})"
     )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_version.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_version.py
@@ -50,6 +50,5 @@ def test_version_consistency() -> None:
         f" != manifest.yaml ({manifest_version})"
     )
     assert semver_version == main_tf_version, (
-        f"Version mismatch: pyproject.toml ({pyproject_version} -> {semver_version})"
-        f" != main.tf ({main_tf_version})"
+        f"Version mismatch: pyproject.toml ({pyproject_version} -> {semver_version}) != main.tf ({main_tf_version})"
     )

--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy"
-version = "0.5.1"
+version = "0.6.0"
 description = "CLI based tool to deploy Jupyter applications that integrates with infrastructure as code frameworks."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/libs/pytest-jupyter-deploy/pyproject.toml
+++ b/libs/pytest-jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-jupyter-deploy"
-version = "0.2.2"
+version = "0.2.3"
 description = "Pytest plugin for E2E testing of jupyter-deploy templates"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-monorepo"
-version = "0.5.0"
+version = "0.6.0"
 description = "Monorepo for Jupyter deploy packages"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/upgrade_eks_oidc_template_version.py
+++ b/scripts/upgrade_eks_oidc_template_version.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Script to upgrade version information across all files in the jupyter-deploy-tf-aws-eks-oidc template.
+
+Usage:
+    python scripts/upgrade_eks_oidc_template_version.py NEW_VERSION
+"""
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+import tomli_w
+
+
+def pep440_to_semver(version: str) -> str:
+    """Convert PEP 440 pre-release to SemVer (e.g. '0.1.0rc1' -> '0.1.0-rc.1')."""
+    match = re.match(r"^(\d+\.\d+\.\d+)(rc|a|b)(\d+)$", version)
+    if match:
+        base, pre_type, pre_num = match.groups()
+        return f"{base}-{pre_type}.{pre_num}"
+    return version
+
+
+def update_pyproject_toml(file_path: Path, new_version: str) -> None:
+    """Update version in pyproject.toml file."""
+    with open(file_path, "rb") as f:
+        data = tomllib.load(f)
+
+    data["project"]["version"] = new_version
+
+    with open(file_path, "wb") as f:
+        tomli_w.dump(data, f)
+
+    print(f"✓ Updated version in {file_path}")
+
+
+def update_init_py(file_path: Path, new_version: str) -> None:
+    """Update __version__ in __init__.py file."""
+    content = file_path.read_text()
+    updated_content = re.sub(
+        r'__version__\s*=\s*["\']([^"\']+)["\']',
+        f'__version__ = "{new_version}"',
+        content,
+    )
+
+    if content == updated_content:
+        print(f"! Warning: No version pattern found in {file_path}")
+    else:
+        file_path.write_text(updated_content)
+        print(f"✓ Updated version in {file_path}")
+
+
+def update_manifest_yaml(file_path: Path, new_version: str) -> None:
+    """Update version in manifest.yaml file (regex to preserve formatting)."""
+    content = file_path.read_text()
+    updated_content = re.sub(
+        r"^(\s+version:\s*).+$",
+        rf"\g<1>{new_version}",
+        content,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    if content == updated_content:
+        print(f"! Warning: No version pattern found in {file_path}")
+    else:
+        file_path.write_text(updated_content)
+        print(f"✓ Updated version in {file_path}")
+
+
+def update_main_tf(file_path: Path, new_version: str) -> None:
+    """Update template_version in main.tf file."""
+    content = file_path.read_text()
+    updated_content = re.sub(
+        r'template_version\s*=\s*["\']([^"\']+)["\']',
+        f'template_version = "{new_version}"',
+        content,
+    )
+
+    if content == updated_content:
+        print(f"! Warning: No template_version pattern found in {file_path}")
+    else:
+        file_path.write_text(updated_content)
+        print(f"✓ Updated version in {file_path}")
+
+
+def update_chart_yaml(file_path: Path, new_version: str) -> None:
+    """Update version in a Helm Chart.yaml file (regex to preserve formatting)."""
+    content = file_path.read_text()
+    updated_content = re.sub(
+        r"^(version:\s*).+$",
+        rf"\g<1>{new_version}",
+        content,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    if content == updated_content:
+        print(f"! Warning: No version pattern found in {file_path}")
+    else:
+        file_path.write_text(updated_content)
+        print(f"✓ Updated version in {file_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Update version across all EKS OIDC template files.")
+    parser.add_argument("new_version", help="New version string in PEP 440 format (e.g., '0.1.0rc1', '0.1.0')")
+
+    args = parser.parse_args()
+    pep440_version = args.new_version
+    semver_version = pep440_to_semver(pep440_version)
+
+    project_path = Path(__file__).parent.parent / "libs" / "jupyter-deploy-tf-aws-eks-oidc"
+
+    if not project_path.exists():
+        print(f"Error: Project path {project_path} not found")
+        sys.exit(1)
+
+    print(f"Updating versions: PEP 440 = {pep440_version}, SemVer = {semver_version}\n")
+
+    template_path = project_path / "jupyter_deploy_tf_aws_eks_oidc" / "template"
+
+    # Python files use PEP 440
+    update_pyproject_toml(project_path / "pyproject.toml", pep440_version)
+    update_init_py(project_path / "jupyter_deploy_tf_aws_eks_oidc" / "__init__.py", pep440_version)
+
+    # Template files use SemVer (Helm requires it)
+    update_manifest_yaml(template_path / "manifest.yaml", semver_version)
+    update_main_tf(template_path / "engine" / "main.tf", semver_version)
+
+    chart_dirs = ["workspace-defaults", "console", "github-rbac"]
+    for chart_dir in chart_dirs:
+        update_chart_yaml(template_path / "charts" / chart_dir / "Chart.yaml", semver_version)
+
+    print("\nVersion update completed successfully!")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -695,7 +695,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-deploy"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "libs/jupyter-deploy" }
 dependencies = [
     { name = "certifi" },
@@ -779,7 +779,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-monorepo"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "jupyter-deploy", extra = ["aws", "k8s"] },
@@ -899,7 +899,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-tf-aws-eks-oidc"
-version = "0.1.0"
+version = "0.1.0rc1"
 source = { editable = "libs/jupyter-deploy-tf-aws-eks-oidc" }
 dependencies = [
     { name = "boto3" },
@@ -1743,7 +1743,7 @@ wheels = [
 
 [[package]]
 name = "pytest-jupyter-deploy"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "libs/pytest-jupyter-deploy" }
 dependencies = [
     { name = "jupyter-deploy" },


### PR DESCRIPTION
Release PR for:
- `jupyter-deploy`: `0.5.0` -> `0.6.0`
- `pytest-jupyter-deploy`: `0.2.2` -> `0.2.3`
- `jupyter-deploy-tf-aws-eks-oidc`: [new] `0.1.0rc1`

Order of release:
- pytest plugin
- jupyter-deploy
- eks-oidc template
