### PR TITLE
fix: k8s deps in aws smoke tests

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -139,6 +139,7 @@ Smoke tests live in `libs/jupyter-deploy/tests/e2e/`. No browser interaction, no
 They run inside a container built from `.github/e2e-cli/`.
 - **aws** (workspace code): `just ci-e2e-cli-build && just test-smoke-cli aws jupyter-deploy-e2e-cli:latest`
 - **bare** (published PyPI): `just test-smoke-cli bare` — auto-builds a pypi image; tests validate that `boto3` is NOT installed
+- **bare** (from Test PyPI): `just ci-e2e-cli-build "" "--build-arg INSTALL_MODE=pypi --build-arg INSTALL_VARIANT=bare --build-arg PKG_VERSION=<version> --build-arg EXTRA_INDEX_URL=https://test.pypi.org/simple/" && just test-smoke-cli bare jupyter-deploy-e2e-cli:latest`
 
 
 ## Writing E2E tests

--- a/justfile
+++ b/justfile
@@ -972,7 +972,7 @@ test-smoke-cli variant image="" log_level="INFO":
     if [ "{{variant}}" = "bare" ]; then
         FILTER='-k "not aws_installation and not k8s_installation"'
     elif [ "{{variant}}" = "aws" ]; then
-        FILTER='-k "not bare_installation"'
+        FILTER='-k "not bare_installation and not k8s_installation"'
     else
         echo "Error: variant must be 'bare' or 'aws', got '{{variant}}'"
         exit 1


### PR DESCRIPTION
This PR removes the `k8s` tests from the `aws` smoke tests of `jupyter-deploy` release CI. This is broken because the image only installs `jupyter-deploy[aws]`, not `jupyter-deploy[aws,k8s]`

see [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/26537908614/job/78173636526)

### Testing
- run the smoke tests locally