### PR TITLE
release: v0.6.1

### DIFF
--- a/libs/jupyter-deploy/pyproject.toml
+++ b/libs/jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy"
-version = "0.6.0"
+version = "0.6.1"
 description = "CLI based tool to deploy Jupyter applications that integrates with infrastructure as code frameworks."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-monorepo"
-version = "0.6.0"
+version = "0.6.1"
 description = "Monorepo for Jupyter deploy packages"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Bump patch of `jupyter-deploy` package since `v0.6.0` was already published to PyPI.
- `jupyter-deploy`: `v0.6.0` -> `v0.6.1`

Failed [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/26537908614).

