### PR TITLE
fix: eks OIDC ci

### DIFF
--- a/.github/workflows/e2e-eks-oidc-fresh.yml
+++ b/.github/workflows/e2e-eks-oidc-fresh.yml
@@ -161,6 +161,13 @@ jobs:
         id: install-just
         uses: ./.github/actions/install-just
 
+      # `jd init` discovers templates via entry points, which only register when
+      # the template package is installed. The eks-oidc package is a workspace
+      # member but not a dependency of the root, so a plain `uv run` won't install
+      # it — sync all workspace packages to register the aws:eks:oidc template.
+      - name: Sync workspace (install template packages)
+        run: uv sync --all-packages
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -98,11 +98,24 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v3
 
+      - name: Wait for Test PyPI availability
+        run: |
+          url="https://test.pypi.org/pypi/${PKG_NAME}/${VERSION}/json"
+          echo "Polling ${url}"
+          for i in $(seq 1 20); do
+            if curl -fsS -o /dev/null "${url}"; then
+              echo "${PKG_NAME}==${VERSION} is available on Test PyPI"
+              exit 0
+            fi
+            echo "Attempt ${i}/20: not yet available, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::${PKG_NAME}==${VERSION} did not appear on Test PyPI within 5 minutes"
+          exit 1
+
       - name: Test installation from Test PyPI
         run: |
           uv venv
-          # Wait a bit for the package to be available
-          sleep 60
           uv pip install \
             --extra-index-url https://test.pypi.org/simple/ \
             --index-strategy unsafe-best-match \

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -98,11 +98,24 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v3
 
+      - name: Wait for Test PyPI availability
+        run: |
+          url="https://test.pypi.org/pypi/${PKG_NAME}/${VERSION}/json"
+          echo "Polling ${url}"
+          for i in $(seq 1 20); do
+            if curl -fsS -o /dev/null "${url}"; then
+              echo "${PKG_NAME}==${VERSION} is available on Test PyPI"
+              exit 0
+            fi
+            echo "Attempt ${i}/20: not yet available, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::${PKG_NAME}==${VERSION} did not appear on Test PyPI within 5 minutes"
+          exit 1
+
       - name: Test installation from Test PyPI
         run: |
           uv venv
-          # Wait a bit for the package to be available
-          sleep 60
           uv pip install \
             --extra-index-url https://test.pypi.org/simple/ \
             --index-strategy unsafe-best-match \

--- a/.github/workflows/release-eks-oidc.yml
+++ b/.github/workflows/release-eks-oidc.yml
@@ -98,11 +98,24 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v3
 
+      - name: Wait for Test PyPI availability
+        run: |
+          url="https://test.pypi.org/pypi/${PKG_NAME}/${VERSION}/json"
+          echo "Polling ${url}"
+          for i in $(seq 1 20); do
+            if curl -fsS -o /dev/null "${url}"; then
+              echo "${PKG_NAME}==${VERSION} is available on Test PyPI"
+              exit 0
+            fi
+            echo "Attempt ${i}/20: not yet available, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::${PKG_NAME}==${VERSION} did not appear on Test PyPI within 5 minutes"
+          exit 1
+
       - name: Test installation from Test PyPI
         run: |
           uv venv
-          # Wait a bit for the package to be available
-          sleep 60
           uv pip install \
             --extra-index-url https://test.pypi.org/simple/ \
             --index-strategy unsafe-best-match \

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -98,11 +98,24 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v3
 
+      - name: Wait for Test PyPI availability
+        run: |
+          url="https://test.pypi.org/pypi/${PKG_NAME}/${VERSION}/json"
+          echo "Polling ${url}"
+          for i in $(seq 1 20); do
+            if curl -fsS -o /dev/null "${url}"; then
+              echo "${PKG_NAME}==${VERSION} is available on Test PyPI"
+              exit 0
+            fi
+            echo "Attempt ${i}/20: not yet available, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::${PKG_NAME}==${VERSION} did not appear on Test PyPI within 5 minutes"
+          exit 1
+
       - name: Test installation from Test PyPI
         run: |
           uv venv
-          # Wait a bit for the package to be available
-          sleep 60
           uv pip install \
             --extra-index-url https://test.pypi.org/simple/ \
             --index-strategy unsafe-best-match \

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -294,7 +294,7 @@ def config(
         bool,
         typer.Option("--reset-store-id", help="Clear the pinned store ID and rediscover the store."),
     ] = False,
-    verbose: Annotated[bool, typer.Option("--verbose", help="Show full output without progress bar.")] = False,
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="Show full output without progress bar.")] = False,
     variables: Annotated[
         dict[str, TemplateVariableDefinition] | None,
         typer.Option("--variables", "-v", help="Will be removed by the decorator."),

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_config.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_config.py
@@ -158,6 +158,19 @@ class TestConfigCommand(unittest.TestCase):
         self.assertIsInstance(call_kwargs["display_manager"], SimpleDisplayManager)
 
     @patch("jupyter_deploy.handlers.project.config_handler.ConfigHandler")
+    def test_config_accepts_short_verbose_flag(self, mock_config_handler: Mock) -> None:
+        """-v is an alias for --verbose (parity with <jd up> / <jd down>)."""
+        mock_config_handler_instance, _ = self.get_mock_config_handler()
+        mock_config_handler.return_value = mock_config_handler_instance
+
+        # Act
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["config", "-v"])
+
+        # Verify
+        self.assertEqual(result.exit_code, 0)
+
+    @patch("jupyter_deploy.handlers.project.config_handler.ConfigHandler")
     def test_config_passes_no_preset_when_user_passes_none(self, mock_config_handler: Mock) -> None:
         mock_config_handler_instance, mock_config_fns = self.get_mock_config_handler()
         mock_config_handler.return_value = mock_config_handler_instance

--- a/scripts/env_setup_base.py
+++ b/scripts/env_setup_base.py
@@ -96,11 +96,15 @@ def normalize_list_value(value: str) -> str:
     - Unquoted brackets from shell (e.g. [a, b] -> ["a", "b"])
     - Already valid JSON is returned as-is
     """
+    # Use compact separators (no space after comma) so the value survives a bash
+    # `source .env`: a space would make bash word-split the assignment (e.g.
+    # `KEY=["a", "b"]` runs `"b"]` as a command). No base workflow sources .env
+    # today, but keeping this aligned with env_setup_eks.py avoids that footgun.
     # Try Python literal first (handles quoted strings)
     try:
         parsed = ast.literal_eval(value)
         if isinstance(parsed, list):
-            return json.dumps(parsed)
+            return json.dumps(parsed, separators=(",", ":"))
     except (ValueError, SyntaxError):
         pass
     # Handle unquoted bracket lists (shell strips quotes)
@@ -111,7 +115,7 @@ def normalize_list_value(value: str) -> str:
         if not inner:
             return "[]"
         items = [item.strip().strip('"').strip("'") for item in inner.split(",")]
-        return json.dumps(items)
+        return json.dumps(items, separators=(",", ":"))
     return value
 
 
@@ -169,7 +173,7 @@ def infer_deployment_vars(ci_dir: str, oauth_app_num: str) -> dict[str, str]:
         "JD_E2E_VAR_EMAIL": bot_email,
         "JD_E2E_VAR_OAUTH_ALLOWED_ORG": "",
         "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS": "[]",
-        "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES": json.dumps([bot_username]),
+        "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES": json.dumps([bot_username], separators=(",", ":")),
     }
 
 
@@ -264,7 +268,7 @@ def main() -> None:
         print(f"  JD_E2E_USER={bot_username} (from bot account)")
 
     if "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES" not in option_env_vars:
-        allowed_usernames = json.dumps([bot_username])
+        allowed_usernames = json.dumps([bot_username], separators=(",", ":"))
         set_env_var("JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES", allowed_usernames)
         print(f"  JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES={allowed_usernames} (from bot account)")
 

--- a/scripts/env_setup_eks.py
+++ b/scripts/env_setup_eks.py
@@ -71,10 +71,14 @@ def _parse_options(options_str: str) -> list[str]:
 
 def normalize_list_value(value: str) -> str:
     """Normalize list values to JSON syntax."""
+    # Use compact separators (no space after comma): the generated .env is
+    # `source`d by the fresh-deploy workflow, and a space inside the value would
+    # make bash word-split the assignment (e.g. `KEY=["a", "b"]` runs `"b"]` as
+    # a command). Compact JSON keeps the whole list as a single token.
     try:
         parsed = ast.literal_eval(value)
         if isinstance(parsed, list):
-            return json.dumps(parsed)
+            return json.dumps(parsed, separators=(",", ":"))
     except (ValueError, SyntaxError):
         pass
     m = re.fullmatch(r"\[([^\]]*)\]", value.strip())
@@ -83,7 +87,7 @@ def normalize_list_value(value: str) -> str:
         if not inner:
             return "[]"
         items = [item.strip().strip('"').strip("'") for item in inner.split(",")]
-        return json.dumps(items)
+        return json.dumps(items, separators=(",", ":"))
     return value
 
 
@@ -223,7 +227,7 @@ def main() -> None:
     org = parsed_options.get("org", "")
     team = parsed_options.get("team", "")
     if "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS" not in option_env_vars:
-        allowed_teams = json.dumps([f"{org}:{team}"]) if org and team else "[]"
+        allowed_teams = json.dumps([f"{org}:{team}"], separators=(",", ":")) if org and team else "[]"
         set_env_var("JD_E2E_VAR_OAUTH_ALLOWED_TEAMS", allowed_teams)
         print(f"  JD_E2E_VAR_OAUTH_ALLOWED_TEAMS={allowed_teams}")
 


### PR DESCRIPTION
This PR fixes the broken GH workflow `E2E EKS OIDC Template (Fresh)` by 1/ fixing the script, 2/ add the `-v` short flag to `jd config` (consistent w/ `jd up` and `jd down`), 3/ sync all packages in the fresh deploy flow (`eks-oidc` template must be installed in the virtual env)

Also in this PR:
- await package availability in `test-pypi` in the release workflows

Closes: #236 

### Testing:
- pushed to branch in the repo, ran `test-pypi` attempt script: +ve test (version exists) and -ve (missing)
- pushed to branch in the repo, ran full E2E fresh deployment workflow against it. Successful [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/27020692115)
