### PR TITLE
docs: troubleshoot EIP and EC2 quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Canary](https://img.shields.io/github/actions/workflow/status/jupyter-infra/jupyter-deploy/e2e-base-canary.yml?label=canary)](https://github.com/jupyter-infra/jupyter-deploy/actions/workflows/e2e-base-canary.yml)
 [![PyPI - jupyter-deploy](https://img.shields.io/pypi/v/jupyter-deploy?label=jupyter-deploy)](https://pypi.org/project/jupyter-deploy/)
 [![PyPI - base template](https://img.shields.io/pypi/v/jupyter-deploy-tf-aws-ec2-base?label=base-template)](https://pypi.org/project/jupyter-deploy-tf-aws-ec2-base/)
+[![PyPI - eks-oidc template](https://img.shields.io/pypi/v/jupyter-deploy-tf-aws-eks-oidc?label=eks-oidc-template)](https://pypi.org/project/jupyter-deploy-tf-aws-eks-oidc/)
 [![PyPI - pytest plugin](https://img.shields.io/pypi/v/pytest-jupyter-deploy?label=pytest-plugin)](https://pypi.org/project/pytest-jupyter-deploy/)
 
 An open-source command line interface (CLI) to deploy interactive applications to the Cloud.

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/TROUBLESHOOT.md
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/TROUBLESHOOT.md
@@ -2,4 +2,40 @@
 
 This guide details how to investigate and resolve common issues.
 
-To be added.
+## Service quota limits
+
+`jd up` can fail when an AWS service quota is exhausted. Two common cases:
+
+- **EC2 vCPUs** — `RunInstances` fails with `VcpuLimitExceeded`. New accounts
+  start with a low On-Demand vCPU limit per region, and `0` for accelerated
+  families (GPU/Neuron), so this often blocks a first deployment. Quotas are
+  measured in vCPUs, not instance counts.
+- **Elastic IPs** — `AllocateAddress` fails with `AddressLimitExceeded`. The
+  template uses one EIP per instance; the per-region limit defaults to 5.
+
+Relevant quota codes (service code `ec2`):
+
+| Quota code | Quota |
+|---|---|
+| `L-1216C47A` | Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances |
+| `L-DB2E81BA` | Running On-Demand G and VT instances (most GPU types) |
+| `L-417A185B` | Running On-Demand P instances |
+| `L-1945791B` / `L-2C3B7624` | Running On-Demand Inf / Trn instances (Neuron) |
+| `L-0263D0A3` | EC2-VPC Elastic IPs |
+
+To resolve:
+
+- Pick a smaller `instance_type`, or free EIPs by destroying stale deployments
+  (`jd down --path <project-dir>`), then re-run `jd config` and `jd up`.
+- Or request a higher limit (replace the quota code, value, and region):
+
+  ```bash
+  aws service-quotas request-service-quota-increase \
+    --service-code ec2 --quota-code L-1216C47A \
+    --desired-value <value> --region <region>
+  ```
+
+  Check the current value with `get-service-quota` and track the request with
+  `list-requested-service-quota-change-history-by-quota` (same `--service-code`
+  and `--quota-code`). Increases may require AWS support review and are not
+  instantaneous. The AWS Service Quotas console offers the same actions.

--- a/scripts/ci_helpers.py
+++ b/scripts/ci_helpers.py
@@ -12,6 +12,45 @@ import boto3
 from mypy_boto3_secretsmanager import SecretsManagerClient
 from mypy_boto3_ssm import SSMClient
 
+# Backstop timeout for any single `jd` invocation. The canary job cap is 30
+# minutes; a stuck `jd` should fail well before that with a diagnostic rather
+# than silently eating the whole job budget.
+JD_TIMEOUT_SECONDS = 600
+
+
+def run_jd(
+    jd_args: list[str],
+    cwd: str | None = None,
+    capture: bool = False,
+    timeout: int = JD_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    """Run a `jd` CLI command with CI-safe defaults.
+
+    Closes stdin so a no-TTY interactive prompt fails fast instead of hanging,
+    enforces a timeout backstop, and surfaces stderr on failure or timeout.
+    """
+    cmd = ["uv", "run", "jd", *jd_args]
+    try:
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            capture_output=capture,
+            text=True,
+            check=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as e:
+        print(f"Error: `jd {' '.join(jd_args)}` timed out after {timeout}s", file=sys.stderr)
+        if e.stderr:
+            print(e.stderr if isinstance(e.stderr, str) else e.stderr.decode(), file=sys.stderr)
+        sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        print(f"Error: `jd {' '.join(jd_args)}` failed with exit code {e.returncode}", file=sys.stderr)
+        if e.stderr:
+            print(e.stderr, file=sys.stderr)
+        sys.exit(1)
+
 
 def arn_region(arn: str) -> str:
     """Extract the AWS region (field 4) from an ARN."""
@@ -24,12 +63,7 @@ def arn_region(arn: str) -> str:
 
 def jd_output(output_name: str, ci_dir: str) -> str:
     """Read a jd output value as plain text."""
-    result = subprocess.run(
-        ["uv", "run", "jd", "show", "-o", output_name, "--text", "-p", ci_dir],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    result = run_jd(["show", "-o", output_name, "--text", "-p", ci_dir], capture=True)
     return result.stdout.strip().replace("\n", "")
 
 
@@ -68,8 +102,4 @@ def put_secret_value(arn: str, value: str) -> None:
 
 def run_jd_config(config_args: list[str], project_dir: str) -> None:
     """Run jd config with the given arguments in a project directory."""
-    subprocess.run(
-        ["uv", "run", "jd", "config", *config_args],
-        cwd=project_dir,
-        check=True,
-    )
+    run_jd(["config", *config_args], cwd=project_dir)

--- a/scripts/ci_restore.py
+++ b/scripts/ci_restore.py
@@ -8,21 +8,15 @@ Usage: scripts/ci_restore.py <ci-dir>
 from __future__ import annotations
 
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
-from ci_helpers import run_jd_config
+from ci_helpers import run_jd, run_jd_config
 
 
 def discover_project_id() -> str:
     """Discover the CI project ID from S3 store."""
-    result = subprocess.run(
-        ["uv", "run", "jd", "projects", "list", "--store-type", "s3-only", "--text"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    result = run_jd(["projects", "list", "--store-type", "s3-only", "--text"], capture=True)
     matches = [line for line in result.stdout.strip().splitlines() if line.startswith("tf-aws-iam-ci-")]
 
     if not matches:
@@ -44,10 +38,7 @@ def restore_project(project_id: str, ci_dir: Path) -> None:
         shutil.rmtree(ci_dir)
 
     print(f"Restoring CI project to {ci_dir}...")
-    subprocess.run(
-        ["uv", "run", "jd", "init", str(ci_dir), "--restore-project", project_id, "--store-type", "s3-only"],
-        check=True,
-    )
+    run_jd(["init", str(ci_dir), "--restore-project", project_id, "--store-type", "s3-only"])
 
 
 def restore_secrets_and_configure(ci_dir: Path) -> None:

--- a/scripts/ci_restore_base.py
+++ b/scripts/ci_restore_base.py
@@ -17,22 +17,16 @@ from __future__ import annotations
 import ast
 import re
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
-from ci_helpers import run_jd_config
+from ci_helpers import run_jd, run_jd_config
 
 
 def get_subdomain_from_ci(ci_dir: str, oauth_app_num: str) -> str:
     """Read the expected subdomain from the CI OAuth app's homepage_url."""
-    result = subprocess.run(
-        ["uv", "run", "jd", "show", "-v", f"github_oauth_app_{oauth_app_num}", "--text", "-p", ci_dir],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    result = run_jd(["show", "-v", f"github_oauth_app_{oauth_app_num}", "--text", "-p", ci_dir], capture=True)
     app_meta = ast.literal_eval(result.stdout.strip())
     homepage_url = app_meta["homepage_url"]
     parsed = urlparse(homepage_url)
@@ -46,23 +40,13 @@ def get_subdomain_from_ci(ci_dir: str, oauth_app_num: str) -> str:
 
 def list_project_ids() -> list[str]:
     """List all project IDs in the S3 store."""
-    result = subprocess.run(
-        ["uv", "run", "jd", "projects", "list", "--store-type", "s3-only", "--text"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    result = run_jd(["projects", "list", "--store-type", "s3-only", "--text"], capture=True)
     return [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
 
 
 def get_project_subdomain(project_id: str) -> str | None:
     """Read the var:subdomain from a project's S3 metadata."""
-    result = subprocess.run(
-        ["uv", "run", "jd", "projects", "show", project_id, "--store-type", "s3-only", "--text"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    result = run_jd(["projects", "show", project_id, "--store-type", "s3-only", "--text"], capture=True)
     for line in result.stdout.splitlines():
         m = re.match(r"^var:subdomain:\s*(.+)$", line)
         if m:
@@ -104,10 +88,7 @@ def restore_project(project_id: str, project_dir: Path) -> None:
         shutil.rmtree(project_dir)
 
     print(f"Restoring project to {project_dir}...")
-    subprocess.run(
-        ["uv", "run", "jd", "init", str(project_dir), "--restore-project", project_id, "--store-type", "s3-only"],
-        check=True,
-    )
+    run_jd(["init", str(project_dir), "--restore-project", project_id, "--store-type", "s3-only"])
 
 
 def restore_secrets(project_dir: Path) -> None:

--- a/scripts/ci_restore_eks.py
+++ b/scripts/ci_restore_eks.py
@@ -16,11 +16,10 @@ from __future__ import annotations
 
 import re
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
-from ci_helpers import run_jd_config
+from ci_helpers import run_jd, run_jd_config
 from ci_restore_base import get_subdomain_from_ci, list_project_ids
 
 
@@ -36,12 +35,7 @@ def find_eks_project_by_subdomain(subdomain: str, *, allow_missing: bool = False
         sys.exit(1)
 
     for project_id in eks_projects:
-        result = subprocess.run(
-            ["uv", "run", "jd", "projects", "show", project_id, "--store-type", "s3-only", "--text"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        result = run_jd(["projects", "show", project_id, "--store-type", "s3-only", "--text"], capture=True)
         for line in result.stdout.splitlines():
             m = re.match(r"^var:subdomain:\s*(.+)$", line)
             if m and m.group(1).strip() == subdomain:
@@ -60,10 +54,7 @@ def restore_project(project_id: str, project_dir: Path) -> None:
         shutil.rmtree(project_dir)
 
     print(f"Restoring project to {project_dir}...")
-    subprocess.run(
-        ["uv", "run", "jd", "init", str(project_dir), "--restore-project", project_id, "--store-type", "s3-only"],
-        check=True,
-    )
+    run_jd(["init", str(project_dir), "--restore-project", project_id, "--store-type", "s3-only"])
 
 
 def restore_secrets(project_dir: Path) -> None:


### PR DESCRIPTION
This PR addresses minor paper cuts for a/ fail fast on CI methods and display error logs, b/ add `eks-oidc` badge to the README, c/ add "request more quota" guidance to the `TROUBLESHOOT.md` section of the base template.

Closes: #215 

Addresses recent failure in canary [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/27081476513/job/79931304592)

### Testing
- tested CI methods locally