### PR TITLE
fix: delete ws before down to avoid race conditions

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/local-destroy-workspaces.sh.tftpl
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/local-destroy-workspaces.sh.tftpl
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+# Destroy-time script: removes operator-managed Workspaces and WorkspaceTemplates
+# BEFORE the operator and its nodes are torn down.
+#
+# Why this is needed:
+#   The jupyter-k8s operator protects Workspace and WorkspaceTemplate resources
+#   with finalizers (and Templates that reference an AccessStrategy will soon pin
+#   one on it too). Those finalizers are only cleared by the operator's
+#   controller-manager. On `terraform destroy`, the node groups (which host the
+#   controller-manager) and the Helm releases that ship these CRs are torn down
+#   concurrently — so Helm's uninstall blocks on a finalizer the now-dead operator
+#   can never clear, hits its timeout ("context deadline exceeded"), and aborts
+#   the whole destroy. We delete Workspaces then Templates (every namespace);
+#   WorkspaceAccessStrategy is the top-level construct and is left to Helm.
+#
+#   This null_resource depends_on the operator/CR Helm releases and node groups,
+#   so its destroy provisioner runs FIRST (destroy is reverse-dependency order) —
+#   while the operator is still alive to process finalizer removal. By the time
+#   Helm uninstalls workspace-defaults / workspace-router, the CRs are gone and
+#   the uninstall is a no-op.
+#
+# Best-effort throughout: a destroy must never be blocked by this cleanup. If the
+# operator is already unreachable (e.g. recovering a half-destroyed cluster), we
+# fall back to stripping finalizers directly.
+
+set -uo pipefail
+
+CLUSTER_NAME="${cluster_name}"
+REGION="${region}"
+GRACEFUL_WAIT_SECONDS=120
+SLEEP_INTERVAL=10
+
+# Operator CRDs we tear down, in deletion order. Workspaces reference Templates,
+# so they must go first. WorkspaceAccessStrategy is the top-level construct and is
+# left to the Helm uninstall — but Templates can reference an AccessStrategy, which
+# will soon pin a deletion-blocking finalizer on it, so we must clear ALL Templates
+# (every namespace) before the access-strategy Helm release is uninstalled.
+WORKSPACE_KIND="workspaces.workspace.jupyter.org"
+TEMPLATE_KIND="workspacetemplates.workspace.jupyter.org"
+
+FINALIZER_KINDS="$WORKSPACE_KIND $TEMPLATE_KIND"
+
+setup_kubeconfig() {
+    echo "Configuring kubectl for cluster $CLUSTER_NAME..."
+    if ! aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "$REGION" 2>&1; then
+        echo "WARNING: Failed to configure kubeconfig — cluster may already be gone. Skipping CR cleanup."
+        return 1
+    fi
+
+    # Guard against ever acting on the wrong cluster.
+    local current_context
+    current_context=$(kubectl config current-context 2>/dev/null)
+    if [[ "$current_context" != *"$CLUSTER_NAME"* ]] || [[ "$current_context" != *"$REGION"* ]]; then
+        echo "WARNING: kubectl context '$current_context' does not match cluster '$CLUSTER_NAME' in region '$REGION'."
+        echo "Skipping CR cleanup to avoid touching the wrong cluster."
+        return 1
+    fi
+    echo "kubectl configured (context: $current_context)."
+}
+
+# Count remaining instances of all operator CRDs across every namespace.
+count_remaining() {
+    local total=0
+    for kind in $FINALIZER_KINDS; do
+        local n
+        n=$(kubectl get "$kind" --all-namespaces --no-headers 2>/dev/null | wc -l | tr -d ' ')
+        total=$((total + $${n:-0}))
+    done
+    echo "$total"
+}
+
+# Issue a non-blocking delete on every operator CR. Workspaces first.
+delete_custom_resources() {
+    echo "Deleting Workspaces (all namespaces)..."
+    kubectl delete "$WORKSPACE_KIND" --all-namespaces --all --wait=false --ignore-not-found 2>&1 || true
+
+    echo "Deleting WorkspaceTemplates (all namespaces)..."
+    kubectl delete "$TEMPLATE_KIND" --all-namespaces --all --wait=false --ignore-not-found 2>&1 || true
+}
+
+# Wait for the operator to clear finalizers and let the resources disappear.
+wait_for_graceful_deletion() {
+    local waited=0
+    while true; do
+        local remaining
+        remaining=$(count_remaining)
+        if [ "$remaining" -eq 0 ]; then
+            echo "All operator custom resources deleted gracefully."
+            return 0
+        fi
+
+        if [ $waited -ge $GRACEFUL_WAIT_SECONDS ]; then
+            echo "WARNING: $remaining custom resource(s) still present after $${GRACEFUL_WAIT_SECONDS}s."
+            echo "Operator may be unreachable — falling back to finalizer removal."
+            return 1
+        fi
+
+        echo "  $remaining custom resource(s) remaining, waiting... ($${waited}s / $${GRACEFUL_WAIT_SECONDS}s)"
+        sleep $SLEEP_INTERVAL
+        waited=$((waited + SLEEP_INTERVAL))
+    done
+}
+
+# Last resort: the operator can't clear finalizers (its nodes are already gone).
+# Remove the admission webhooks (they have no endpoints and would reject the
+# patches) then strip finalizers so the API server can garbage-collect the CRs.
+force_remove_finalizers() {
+    echo "Removing orphaned operator admission webhooks..."
+    kubectl delete validatingwebhookconfiguration jupyter-k8s-validating-webhook-configuration --ignore-not-found 2>&1 || true
+    kubectl delete mutatingwebhookconfiguration jupyter-k8s-mutating-webhook-configuration --ignore-not-found 2>&1 || true
+
+    for kind in $FINALIZER_KINDS; do
+        # Format: "<namespace> <name>" per line.
+        local resources
+        resources=$(kubectl get "$kind" --all-namespaces \
+            -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null)
+        [ -z "$resources" ] && continue
+
+        while read -r ns name; do
+            [ -z "$name" ] && continue
+            echo "  Stripping finalizers: $kind $ns/$name"
+            kubectl patch "$kind" "$name" -n "$ns" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>&1 || true
+        done <<< "$resources"
+    done
+}
+
+main() {
+    # If kubeconfig setup fails the cluster is likely already gone — nothing to do.
+    setup_kubeconfig || exit 0
+
+    if [ "$(count_remaining)" -eq 0 ]; then
+        echo "No operator custom resources found, nothing to clean up."
+        exit 0
+    fi
+
+    delete_custom_resources
+
+    if ! wait_for_graceful_deletion; then
+        force_remove_finalizers
+    fi
+
+    exit 0
+}
+
+main

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -4,6 +4,52 @@ locals {
   workspace_storage_class = "ebs-sc"
 }
 
+# Destroy-time hook: delete operator-managed Workspaces and WorkspaceTemplates
+# BEFORE the operator and its nodes are torn down. These CRs carry operator
+# finalizers; if the operator dies first, Helm's uninstall of workspace-defaults /
+# workspace-router blocks on a finalizer nothing can clear and times out with
+# "context deadline exceeded".
+#
+# Destroy ordering (via depends_on, which on destroy runs in reverse):
+#   this script runs (delete CRs, wait for operator to clear finalizers)
+#     → Helm releases uninstall (CRs already gone → no-op)
+#       → node groups + operator + cluster destroyed
+resource "null_resource" "destroy_workspaces" {
+  triggers = {
+    cluster_name = local.cluster_name
+    region       = var.region
+    script = templatefile("${path.module}/local-destroy-workspaces.sh.tftpl", {
+      cluster_name = local.cluster_name
+      region       = var.region
+    })
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    command     = self.triggers.script
+  }
+
+  # Everything the cleanup needs alive when it runs must be listed here, so that
+  # on destroy this resource is torn down first:
+  #   - operator + node group: the controller-manager must be running to clear the
+  #     finalizers, and it is scheduled onto the "components" node group.
+  #   - cluster + access entries/associations: the script authenticates via
+  #     `aws eks get-token`; without the caller's access association, kubectl gets
+  #     "forbidden". These must outlive every K8s operation.
+  depends_on = [
+    helm_release.jupyter_k8s,
+    helm_release.workspace_router,
+    helm_release.workspace_defaults,
+    helm_release.github_rbac,
+    module.node_group,
+    kubernetes_namespace.shared,
+    module.eks_cluster,
+    aws_eks_access_policy_association.admin,
+    aws_eks_access_policy_association.caller,
+  ]
+}
+
 resource "kubernetes_namespace" "shared" {
   metadata {
     name = var.workspace_shared_namespace

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -18,6 +18,7 @@ MANDATORY_TEMPLATE_STRPATHS: list[str] = [
     "engine/variables.tf",
     "engine/waiter.tf",
     "engine/local-await-router.sh.tftpl",
+    "engine/local-destroy-workspaces.sh.tftpl",
     "charts/workspace-defaults/Chart.yaml",
     "charts/console/Chart.yaml",
     "charts/github-rbac/Chart.yaml",

--- a/scripts/ci_helpers.py
+++ b/scripts/ci_helpers.py
@@ -23,11 +23,15 @@ def run_jd(
     cwd: str | None = None,
     capture: bool = False,
     timeout: int = JD_TIMEOUT_SECONDS,
+    check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Run a `jd` CLI command with CI-safe defaults.
 
     Closes stdin so a no-TTY interactive prompt fails fast instead of hanging,
     enforces a timeout backstop, and surfaces stderr on failure or timeout.
+
+    With check=False a non-zero exit is returned to the caller instead of
+    terminating the process, so optional steps can fail without aborting.
     """
     cmd = ["uv", "run", "jd", *jd_args]
     try:
@@ -37,7 +41,7 @@ def run_jd(
             stdin=subprocess.DEVNULL,
             capture_output=capture,
             text=True,
-            check=True,
+            check=check,
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as e:
@@ -100,6 +104,11 @@ def put_secret_value(arn: str, value: str) -> None:
     client.put_secret_value(SecretId=arn, SecretString=value)
 
 
-def run_jd_config(config_args: list[str], project_dir: str) -> None:
-    """Run jd config with the given arguments in a project directory."""
-    run_jd(["config", *config_args], cwd=project_dir)
+def run_jd_config(config_args: list[str], project_dir: str, check: bool = True) -> bool:
+    """Run jd config with the given arguments in a project directory.
+
+    Returns True on success. With check=False a non-zero exit returns False
+    instead of aborting, so optional config steps can be skipped on failure.
+    """
+    result = run_jd(["config", *config_args], cwd=project_dir, check=check)
+    return result.returncode == 0

--- a/scripts/ci_restore_base.py
+++ b/scripts/ci_restore_base.py
@@ -91,9 +91,16 @@ def restore_project(project_id: str, project_dir: Path) -> None:
     run_jd(["init", str(project_dir), "--restore-project", project_id, "--store-type", "s3-only"])
 
 
-def restore_secrets(project_dir: Path) -> None:
-    """Restore all masked secrets in the base project via jd config --restore-secrets."""
-    run_jd_config(["--restore-secrets"], str(project_dir))
+def restore_secrets(project_dir: Path, required: bool = True) -> None:
+    """Restore all masked secrets in the base project via jd config --restore-secrets.
+
+    With required=False, a failure (e.g. the `secret_arn` output is gone because a
+    prior destroy was interrupted mid-way) is logged and ignored. This is safe for
+    the takedown path, where `jd down` uses destroy.tfvars and never reads the
+    restored secret value.
+    """
+    if not run_jd_config(["--restore-secrets"], str(project_dir), check=required) and not required:
+        print("⚠️  Secret restore failed — continuing (not required for takedown).")
 
 
 def main() -> None:

--- a/scripts/ci_restore_eks.py
+++ b/scripts/ci_restore_eks.py
@@ -57,9 +57,16 @@ def restore_project(project_id: str, project_dir: Path) -> None:
     run_jd(["init", str(project_dir), "--restore-project", project_id, "--store-type", "s3-only"])
 
 
-def restore_secrets(project_dir: Path) -> None:
-    """Restore all masked secrets in the EKS project via jd config --restore-secrets."""
-    run_jd_config(["--restore-secrets"], str(project_dir))
+def restore_secrets(project_dir: Path, required: bool = True) -> None:
+    """Restore all masked secrets in the EKS project via jd config --restore-secrets.
+
+    With required=False, a failure (e.g. the `secret_arn` output is gone because a
+    prior destroy was interrupted mid-way) is logged and ignored. This is safe for
+    the takedown path, where `jd down` uses destroy.tfvars and never reads the
+    restored secret value.
+    """
+    if not run_jd_config(["--restore-secrets"], str(project_dir), check=required) and not required:
+        print("⚠️  Secret restore failed — continuing (not required for takedown).")
 
 
 def main() -> None:

--- a/scripts/find_takedown_base.py
+++ b/scripts/find_takedown_base.py
@@ -73,8 +73,11 @@ def main() -> None:
 
     restore_project(project_id, project_dir)
 
+    # Takedown uses destroy.tfvars and never reads the restored secret value, so a
+    # missing secret (e.g. a prior destroy was interrupted after deleting it) must
+    # not block the teardown.
     print("\nRestoring secrets from cloud provider...")
-    restore_secrets(project_dir)
+    restore_secrets(project_dir, required=False)
 
     takedown_project(project_dir)
     delete_project_from_store(project_id)

--- a/scripts/find_takedown_eks.py
+++ b/scripts/find_takedown_eks.py
@@ -69,8 +69,11 @@ def main() -> None:
 
     restore_project(project_id, project_dir)
 
+    # Takedown uses destroy.tfvars and never reads the restored secret value, so a
+    # missing secret (e.g. a prior destroy was interrupted after deleting it) must
+    # not block the teardown.
     print("\nRestoring secrets from cloud provider...")
-    restore_secrets(project_dir)
+    restore_secrets(project_dir, required=False)
 
     takedown_project(project_dir)
     delete_project_from_store(project_id)


### PR DESCRIPTION
This PR adds a destroy null-resource step to delete all workspace resources that may reference other resources and therefore prevent their deletion: workspaces (may reference template or access strategies) and templates (may reference access strategies).

This prevents a deadlock destroy case observed in [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/27175437366/job/80223200948), where the `workspace_defaults` chart gets locked on template/access strategy deletion finalizers.

Also ignore failure to restore secret on delete action as observed in cascading failure [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/27175851111/job/80224445117).

### Implementation
- add a `destroy_workspaces` null resource in `<template>/engine/workspace.tf`
- tolerate failure on restore secret for delete operations in the CI

### Testing
- update a deployment in place (app 4), created a workspace manually, ran `jd down`
