### PR TITLE
feat: register web-app and session-rotator as manifest components

### DIFF
--- a/docs/source/templates/aws-eks-oidc-template/details.md
+++ b/docs/source/templates/aws-eks-oidc-template/details.md
@@ -151,7 +151,7 @@ The template provides two variable presets:
 | `workspace_router_namespace` | Kubernetes namespace for routing components |
 | `workspace_shared_namespace` | Kubernetes namespace for shared workspace resources |
 | `workspace_base_url` | Base URL for workspace access |
-| `get_started_url` | URL to the getting-started page |
+| `get_started_url` | URL to the web UI |
 | `secret_arn` | ARN of the Secrets Manager secret storing the OAuth app client secret |
 | `jupyterlab_image_uri` | ECR image URI for the JupyterLab workspace image |
 | `kubeconfig_path` | Path to the local kubeconfig file for this cluster |

--- a/docs/source/templates/aws-eks-oidc-template/user-guide.md
+++ b/docs/source/templates/aws-eks-oidc-template/user-guide.md
@@ -51,7 +51,7 @@ jd cluster login
 ## Access workspaces
 
 ```bash
-# open the getting-started page
+# open the web UI
 jd open
 
 # open a specific workspace

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -91,7 +91,7 @@ The first deployment takes approximately 25-30 minutes.
 
 ### User interface
 ```bash
-# open the getting-started page
+# open the web UI
 jd open
 
 # configure kubectl to access your cluster
@@ -292,7 +292,7 @@ The template provides two variable presets:
 | `workspace_router_namespace` | Kubernetes namespace for routing components |
 | `workspace_shared_namespace` | Kubernetes namespace for shared workspace resources |
 | `workspace_base_url` | Base URL for workspace access |
-| `get_started_url` | URL to the getting-started page |
+| `get_started_url` | URL to the web UI |
 | `secret_arn` | ARN of the Secrets Manager secret storing the OAuth app client secret |
 | `jupyterlab_image_uri` | ECR image URI for the JupyterLab workspace image |
 | `kubeconfig_path` | Path to the local kubeconfig file for this cluster |

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/AGENT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/AGENT.md.template
@@ -75,17 +75,14 @@ Applications are gated by a `_use` boolean variable (e.g. `workspace_app_jupyter
 
 `./charts/` contains local Helm charts:
 - `workspace-defaults/` — deploys the default access strategy and template into the shared namespace. It makes it easy for workspace users to create workspace later
-- `console/` — nginx pod serving the `/get-started/` onboarding page with kubeconfig setup instructions.
-
-To modify chart values, edit the `yamlencode({...})` block in the corresponding `.tf` file (`workspaces.tf` or `console.tf`).
+To modify chart values, edit the `yamlencode({...})` block in the corresponding `.tf` file (`workspaces.tf`).
 Charts are deployed via `helm_release` with a local path, so changes take effect on the next `jd up`.
 
-### Console page
+### Web UI
 
-The console serves two files at `/get-started/`:
-Workspace users should bookmark this URL, then use it to setup their kubectl and manage their workspaces.
-- `setup-config.html.tftpl` — static HTML onboarding page
-- `set-kubeconfig.sh.tftpl` — shell script that configures kubectl with OIDC authentication via kubelogin
+The web UI is deployed as part of the `jupyter-k8s-aws-oidc` Helm chart (workspace router release).
+It provides workspace management (create, start, stop, delete) and a kubectl access page with cluster setup instructions.
+The web-app Deployment and its session-rotator CronJob run in the `workspace_router_namespace`.
 
 
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -678,6 +678,19 @@ components:
         method: k8s.core.deployment-logs
       restart:
         method: k8s.apps.rollout-restart
+  web-app:
+    type: Deployment
+    description: Web UI for workspace management
+    scope: workspace_router_namespace
+    verbs:
+      status:
+        method: k8s.apps.get-deployment-status
+      show:
+        method: k8s.apps.get-deployment
+      logs:
+        method: k8s.core.deployment-logs
+      restart:
+        method: k8s.apps.rollout-restart
   workspace-operator:
     type: Deployment
     description: Workspace lifecycle controller
@@ -697,6 +710,20 @@ components:
     description: Periodic JWT signing key rotation
     scope: workspace_router_namespace
     query: "app=jwt-rotator"
+    verbs:
+      status:
+        method: k8s.batch.get-cronjob-status
+      show:
+        method: k8s.batch.get-cronjob
+      logs:
+        method: k8s.batch.get-job-logs
+      trigger:
+        method: k8s.batch.create-job-from-cronjob
+  web-app-session-rotator:
+    type: CronJob
+    description: Periodic web-app session key rotation
+    scope: workspace_router_namespace
+    query: "app=web-app-session-rotator"
     verbs:
       status:
         method: k8s.batch.get-cronjob-status

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/conftest.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/conftest.py
@@ -117,7 +117,7 @@ def other_user_workspace(seeded_cluster: dict[str, list[str]]) -> str:
 
 @pytest.fixture(scope="session")
 def getting_started_url(e2e_deployment: EndToEndDeployment) -> str:
-    """Return the getting-started URL."""
+    """Return the web UI URL."""
     e2e_deployment.ensure_deployed()
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "show", "--output", "get_started_url", "--text"])
     return result.stdout.strip()

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_open.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_open.py
@@ -1,7 +1,7 @@
 """E2E tests for the open command URL resolution on the EKS OIDC template.
 
 Verifies that `jd open` returns correct URLs:
-- Default: matches the getting-started URL
+- Default: matches the web UI URL
 - With --server-name: matches the workspace's .status.accessURL
 """
 
@@ -21,7 +21,7 @@ _URL_PATTERN = re.compile(r"Opening app at:\s+(https://\S+)")
 
 
 def test_open_default_matches_getting_started_url(e2e_deployment: EndToEndDeployment, getting_started_url: str) -> None:
-    """Verify that jd open returns the getting-started URL."""
+    """Verify that jd open returns the web UI URL."""
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "open"])
 
     match = _URL_PATTERN.search(result.stdout)


### PR DESCRIPTION
## Summary

- Adds `web-app` (Deployment) and `web-app-session-rotator` (CronJob) to the EKS OIDC template manifest
- These replace the removed `console` component and make the web UI visible via `jd component list`, `jd health`, `jd component logs`, etc.

## Verification

Tested against live cluster (`kube2.bgrv.people.aws.dev`):
- `jd component list` shows both new entries
- `jd health` reports `web-app: Ready (2/2 replicas)` and `web-app-session-rotator: Idle (Succeeded)`
- `jd component status --name web-app` returns `Ready`
- `jd component show --name web-app` returns full deployment spec