### PR TITLE
fix: eks OIDC agentmd

### DIFF
--- a/docs/source/reference/project/config.md
+++ b/docs/source/reference/project/config.md
@@ -28,5 +28,5 @@ $ jd config [OPTIONS]
 * `--restore-secrets`: Restore all masked secret variable value.
 * `--restore-secret TEXT`: Restore the specific variable secret value.
 * `--reset-store-id`: Clear the pinned store ID and rediscover the store.
-* `--verbose`: Show full output without progress bar.
+* `-v, --verbose`: Show full output without progress bar.
 * `--help`: Show this message and exit.

--- a/docs/source/templates/aws-eks-oidc-template/prerequisites.md
+++ b/docs/source/templates/aws-eks-oidc-template/prerequisites.md
@@ -21,7 +21,25 @@ If you do not own a domain yet, you can buy one through Amazon Route 53 using th
 
 The template gates access to workspaces with GitHub identities via Dex as the OIDC provider. You will need to create a GitHub OAuth app for this purpose.
 
-First, log on to GitHub on your web browser, then use [this link](https://github.com/settings/applications/new) to create a new OAuth app.
+### Personal vs. organization-owned OAuth app
+
+You grant workspace access to **GitHub teams**, and teams belong to a **GitHub
+organization**. Decide which organization owns the teams you want to grant access
+to, then reference them as `org:team` in the `oauth_allowed_teams` variable.
+
+- **Organization-owned app (recommended for teams)** — create the OAuth app under the
+  organization that owns those teams. Organization owners can then manage and audit the
+  app, and you avoid per-user approval friction.
+- **Personal app** — you can also create the app under your personal account. It still
+  authenticates organization members and reads their team membership, but the organization
+  may require [third-party application approval](https://docs.github.com/en/organizations/managing-oauth-access-to-your-organizations-data/approving-oauth-apps-for-your-organization) before the app can read private membership.
+
+### Create the app
+
+- For an **organization-owned** app, log on to GitHub on your web browser as a member of the relevant organization, go to your organization's
+  `Settings → Developer settings → OAuth Apps → New OAuth App`, or use the link
+  `https://github.com/organizations/<your-org>/settings/applications/new`.
+- For a **personal** app, use [this link](https://github.com/settings/applications/new).
 
 You can choose any name for the application; for example `jupyter-deploy-eks-oidc`.
 
@@ -39,6 +57,32 @@ because authentication goes through Dex as the OIDC identity provider.
 In the next page, write down and save your app client ID. Generate an app client secret, and write it down as well.
 
 Refer to GitHub [documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) for more details.
+
+### Grant access to organizations and teams
+
+You control which GitHub users may access your cluster with two variables:
+
+- `oauth_allowed_teams` — the GitHub teams that may sign in, each in `org:team` format
+  (for example `my-org:data-science`). Only members of these teams can authenticate.
+- `workspace_rbac_namespaces` — the Kubernetes namespaces in which those teams can create
+  and manage workspaces.
+
+```bash
+# allow two teams from the my-org organization (pass each entry as a separate flag)
+jd config \
+  --oauth-allowed-teams my-org:data-science \
+  --oauth-allowed-teams my-org:ml-platform \
+  --workspace-rbac-namespaces default
+```
+
+You can also set these in `variables.yaml` instead of on the command line. If you later
+change the allowed teams or namespaces, re-run `jd config` followed by `jd up`.
+
+```{note}
+The app must read team membership for the organization that owns these teams. An
+organization-owned app does this automatically; for a personal app, an organization owner
+must approve the app first.
+```
 
 ## Tools
 

--- a/docs/source/templates/aws-eks-oidc-template/user-guide.md
+++ b/docs/source/templates/aws-eks-oidc-template/user-guide.md
@@ -55,7 +55,7 @@ jd cluster login
 jd open
 
 # open a specific workspace
-jd open --name my-workspace --scope default
+jd open --server-name my-workspace --scope default
 ```
 
 ## Manage user workspaces
@@ -93,7 +93,7 @@ jd server connect --name my-workspace --scope default
 
 ```bash
 # health dashboard for all components
-jd component health
+jd health --components
 
 # list components
 jd component list

--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/TROUBLESHOOT.md.template
@@ -27,15 +27,7 @@ To resolve:
 
 - Pick a smaller `instance_type`, or free EIPs by destroying stale deployments
   (`jd down --path <project-dir>`), then re-run `jd config` and `jd up`.
-- Or request a higher limit (replace the quota code, value, and region):
+- Or request a higher limit. For the EC2 vCPU quota, the service code is `ec2`
+  and the quota code is `L-1216C47A`.
 
-  ```bash
-  aws service-quotas request-service-quota-increase \
-    --service-code ec2 --quota-code L-1216C47A \
-    --desired-value <value> --region <region>
-  ```
-
-  Check the current value with `get-service-quota` and track the request with
-  `list-requested-service-quota-change-history-by-quota` (same `--service-code`
-  and `--quota-code`). Increases may require AWS support review and are not
-  instantaneous. The AWS Service Quotas console offers the same actions.
+{{ request-quota-increase-instructions }}

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_configuration.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_configuration.py
@@ -108,18 +108,32 @@ def test_gitignore_generated_after_init(e2e_deployment: EndToEndDeployment) -> N
     ]
 )
 def test_troubleshoot_md_exists_after_init(e2e_deployment: EndToEndDeployment) -> None:
-    """Test that TROUBLESHOOT.md exists after jd init.
+    """Test that TROUBLESHOOT.md is generated after jd init.
 
-    This test validates that TROUBLESHOOT.md is copied from the template.
+    This test validates that:
+    1. TROUBLESHOOT.md is created from its template
+    2. TROUBLESHOOT.md.template is removed after generation
+    3. All snippet placeholders are substituted
     """
     with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
         # Check that TROUBLESHOOT.md exists
         troubleshoot_path = project_path / "TROUBLESHOOT.md"
         assert troubleshoot_path.exists(), f"TROUBLESHOOT.md should exist after init: {troubleshoot_path}"
 
+        # Check that TROUBLESHOOT.md.template was removed
+        troubleshoot_template_path = project_path / "TROUBLESHOOT.md.template"
+        assert not troubleshoot_template_path.exists(), (
+            f"TROUBLESHOOT.md.template should be removed after init: {troubleshoot_template_path}"
+        )
+
         # Read and verify basic content
         troubleshoot_content = troubleshoot_path.read_text()
         assert "# Troubleshooting Guide" in troubleshoot_content, "Should have main heading"
+
+        # Verify the shared snippet was substituted and no placeholders remain
+        assert "request-service-quota-increase" in troubleshoot_content, "Should document quota increase"
+        assert "{{" not in troubleshoot_content, "Should not contain template placeholders"
+        assert "}}" not in troubleshoot_content, "Should not contain template placeholders"
 
 
 @pytest.mark.cli

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_base_template.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_base_template.py
@@ -9,6 +9,7 @@ MANDATORY_TEMPLATE_STRPATHS: list[str] = [
     "manifest.yaml",
     "variables.yaml",
     "AGENT.md.template",
+    "TROUBLESHOOT.md.template",
     "engine/presets/defaults-all.tfvars",
     "engine/presets/destroy.tfvars",
     "engine/main.tf",

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -54,6 +54,8 @@ Make sure it matches the `<domain>` and `<subdomain>` exactly.
 
 In the next page, write down and save your app client ID. Generate an app client secret, and write it down as well.
 
+The `oauth_allowed_teams` variable grants access to GitHub teams, in `org:team` format. To grant an organization's teams access, create the OAuth app under that organization (`Settings → Developer settings → OAuth Apps`) so its owners can manage the app and the app can read team membership. See [Prerequisites](https://jupyter-deploy.readthedocs.io/en/latest/templates/aws-eks-oidc-template/prerequisites.html) for details.
+
 Refer to GitHub [documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/creating-an-oauth-app) for more details.
 
 ## Usage
@@ -135,7 +137,10 @@ jd cluster login
 ### Manage components
 ```bash
 # health dashboard for all platform components
-jd component health
+jd health --components
+
+# list the platform components
+jd component list
 
 # view component logs
 jd component logs --name dex

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/AGENT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/AGENT.md.template
@@ -15,6 +15,9 @@ The template deploys:
 - Helm releases: traefik-crds, jupyter-k8s operator, aws-traefik-dex (OIDC routing)
 - Dex as an OIDC identity provider on the cluster for kubectl authentication
 
+Unlike the single-host EC2 template, this is a multi-app deployment: each user gets their own
+workspace (a "server"), addressed by `--name` and `--scope` (the Kubernetes namespace).
+
 ## Usage
 {{ jupyter-deploy-cli-general-instructions }}
 
@@ -29,6 +32,48 @@ The template deploys:
 {{ set-variables-with-file-instructions }}
 
 {{ read-variables-with-cmd-instructions }}
+
+### Manage access with a GitHub organization and teams
+
+Access to workspaces is controlled by GitHub team membership, configured through template
+variables (this template does not use the `jd users`/`jd teams` commands).
+
+- `oauth_allowed_teams` — list of GitHub teams allowed to sign in, each in `org:team` format
+  (e.g. `my-org:data-science`). Members of these teams can authenticate via the browser.
+- `workspace_rbac_namespaces` — Kubernetes namespaces where those teams are granted
+  permissions to create and manage workspaces. Each namespace gets a Role and RoleBinding.
+
+```bash
+# allow two GitHub teams (pass each entry as a separate flag)
+jd config --oauth-allowed-teams my-org:data-science --oauth-allowed-teams my-org:ml-platform
+
+# grant those teams workspace permissions in specific namespaces
+jd config --workspace-rbac-namespaces default --workspace-rbac-namespaces research
+
+# apply the change
+jd up
+```
+
+The OAuth app itself must be registered with the GitHub organization that owns these teams.
+When creating the OAuth app, log in as a member of the organization and set the
+`Authorization callback URL` to `https://<subdomain>.<domain>/dex/callback`. Organization
+owners may need to approve the OAuth app for it to access team membership; see GitHub's
+[third-party access settings](https://docs.github.com/en/organizations/managing-oauth-access-to-your-organizations-data).
+
+### Open the getting-started page or a workspace
+{{ multi-server-open-instructions }}
+
+### Manage user workspaces (servers)
+{{ jk8s-workspaces-management-instructions }}
+
+### Check the deployment health
+{{ health-check-instructions }}
+
+### Manage the cluster
+{{ eks-cluster-management-instruction }}
+
+### Manage the platform components
+{{ kubernetes-component-management-instructions }}
 
 ### View the full terraform logs
 
@@ -84,8 +129,6 @@ The web UI is deployed as part of the `jupyter-k8s-aws-oidc` Helm chart (workspa
 It provides workspace management (create, start, stop, delete) and a kubectl access page with cluster setup instructions.
 The web-app Deployment and its session-rotator CronJob run in the `workspace_router_namespace`.
 
-
-
 ### Router waiter script
 
 `waiter.tf` runs `local-await-router.sh.tftpl` as a `local-exec` provisioner after Helm releases are deployed.
@@ -99,18 +142,30 @@ It handles the DNS race condition on fresh deploys because:
 The script waits for all routing deployments (traefik, dex, oauth2-proxy, authmiddleware) to become ready,
 and triggers on domain, cluster name, or router chart version/revision changes.
 
+### Destroy-time workspace cleanup
+
+`workspaces.tf` defines `null_resource.destroy_workspaces`, a `when=destroy` provisioner that
+deletes all Workspaces and WorkspaceTemplates and waits for the operator to clear their
+finalizers BEFORE the node groups (and therefore the operator) are destroyed. This prevents a
+`jd down` deadlock. `main.tf` also defines `null_resource.wait_for_lb_cleanup` to order NLB
+teardown ahead of subnet/IGW deletion.
+
 All `local-exec` provisioners MUST set `interpreter = ["/bin/bash", "-c"]` — Terraform defaults to `/bin/sh` which breaks bash features (`[[`, `set -o pipefail`).
 
 ## The deployed EKS cluster
 
 ### Accessing the cluster
 
-After deployment, configure kubectl:
+After deployment, configure kubectl with:
 ```
-aws eks update-kubeconfig --name CLUSTER_NAME --region REGION
+jd cluster login
 ```
 
+This wraps `aws eks update-kubeconfig`. The IAM role you use MUST be listed in `admin_role_names`
+(the cluster is created with `bootstrap_cluster_creator_admin_permissions = false`).
+
 ### Key namespaces
+Unless overridden by variables, the default namespaces are:
 - `jupyter-k8s-system` — jupyter-k8s operator
 - `jupyter-k8s-router` — traefik + dex + oauth2-proxy + authmiddleware (OIDC routing)
 - `jupyter-k8s-shared` - access strategy and default template
@@ -120,5 +175,10 @@ aws eks update-kubeconfig --name CLUSTER_NAME --region REGION
 - `kubectl get pods -n jupyter-k8s-system` — operator pods
 - `kubectl get pods -n jupyter-k8s-router` — routing pods
 - `kubectl get workspaces -A` — list all workspaces
+
+### Troubleshooting
+
+Refer to `./TROUBLESHOOT.md` for specific situations (service quotas, DNS race conditions,
+`jd down` deadlocks, and cluster-access issues).
 
 {{ generated-by-footer }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
@@ -1,0 +1,152 @@
+# Troubleshooting Guide
+
+This guide details how to investigate and resolve common issues with the EKS OIDC deployment.
+
+A good first step for any issue is the aggregated health check:
+
+```bash
+jd health
+```
+
+It reports the cluster control plane, the load balancer target health, the platform
+components, and the end-to-end connection. Narrow the scope with `--cluster`,
+`--load-balancer`, `--components`, or `--connection`.
+
+## Service quota limits
+
+`jd up` can fail when an AWS service quota is exhausted. The most common cases for
+this template:
+
+- **EC2 vCPUs** — node group scaling fails with `VcpuLimitExceeded`. New accounts
+  start with a low On-Demand vCPU limit per region, and `0` for accelerated
+  families (GPU/Neuron), which blocks `workspaces` node groups that use GPU
+  instance types. Quotas are measured in vCPUs, not instance counts.
+- **Elastic IPs** — `AllocateAddress` fails with `AddressLimitExceeded`. The VPC
+  provisions one NAT gateway (and therefore one EIP) per availability zone — two by
+  default. The per-region limit defaults to 5.
+- **EKS clusters** — `CreateCluster` fails when the per-region cluster limit is
+  reached. Destroy stale deployments with `jd down` or request an increase.
+
+Relevant quota codes:
+
+| Service code | Quota code | Quota |
+|---|---|---|
+| `ec2` | `L-1216C47A` | Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances |
+| `ec2` | `L-DB2E81BA` | Running On-Demand G and VT instances (most GPU types) |
+| `ec2` | `L-417A185B` | Running On-Demand P instances |
+| `ec2` | `L-1945791B` / `L-2C3B7624` | Running On-Demand Inf / Trn instances (Neuron) |
+| `ec2` | `L-0263D0A3` | EC2-VPC Elastic IPs |
+| `eks` | `L-1194D53C` | Clusters per region |
+
+To resolve:
+
+- Pick smaller `instance_type` values in `node_groups`, reduce `desired_size`, or
+  free resources by destroying stale deployments (`jd down --path <project-dir>`),
+  then re-run `jd config` and `jd up`.
+- Or request a higher limit.
+
+{{ request-quota-increase-instructions }}
+
+## The URL does not resolve right after a fresh deploy
+
+On a fresh install, the domain does not resolve until the Network Load Balancer is
+provisioned and external-dns creates the Route 53 record (3–5 minutes). During that
+window, `oauth2-proxy` and `authmiddleware` can enter `CrashLoopBackOff` because they
+need the external domain for OIDC discovery and token validation.
+
+The template's `null_resource.wait_for_routing_ready` provisioner (see `engine/waiter.tf`)
+handles this automatically on `jd up`: it waits for the Route 53 record, flushes the
+CoreDNS negative cache, and waits for the routing deployments to become ready.
+
+If the URL still does not resolve after `jd up` completes:
+
+```bash
+# confirm the connection layer
+jd health --connection
+
+# inspect the routing components
+jd component status --name traefik
+jd component status --name oauth2-proxy
+jd component status --name authmiddleware
+
+# tail logs of a crashing component
+jd component logs --name oauth2-proxy
+
+# force a fresh pull of DNS by restarting the affected deployment
+jd component restart --name oauth2-proxy
+```
+
+If the load balancer was deleted out-of-band, the Service may cache a dead hostname.
+Re-trigger reconciliation by annotating the Traefik Service (after `jd cluster login`):
+
+```bash
+kubectl annotate svc traefik -n jupyter-k8s-router jupyter-deploy/reconcile=$(date +%s) --overwrite
+```
+
+## `jd down` hangs or fails to destroy
+
+Destroying the cluster can deadlock if workspace custom resources still carry
+operator finalizers when the operator's node group is torn down. The template ships
+`null_resource.destroy_workspaces` (see `engine/workspaces.tf`) which deletes all
+Workspaces and WorkspaceTemplates and waits for the operator to clear their finalizers
+*before* the node groups are destroyed. This runs automatically on `jd down`.
+
+If a destroy was interrupted and a later `jd down` still hangs, the operator may already
+be gone (its node group destroyed) and finalizers can no longer be cleared automatically.
+Recover manually after `jd cluster login` (or `aws eks update-kubeconfig` if the
+Terraform outputs are already gone):
+
+```bash
+# remove the orphaned operator webhooks (they block kubectl delete with "no endpoints")
+kubectl delete validatingwebhookconfiguration jupyter-k8s-validating-webhook-configuration --ignore-not-found
+kubectl delete mutatingwebhookconfiguration jupyter-k8s-mutating-webhook-configuration --ignore-not-found
+
+# strip finalizers from any stuck resources, then re-run jd down
+kubectl patch workspace <name> -n <namespace> --type=merge -p '{"metadata":{"finalizers":[]}}'
+kubectl patch workspacetemplate <name> -n <namespace> --type=merge -p '{"metadata":{"finalizers":[]}}'
+```
+
+Lingering Network Load Balancers (created by the Traefik Service) can also block VPC,
+subnet, or internet-gateway deletion. The template's `null_resource.wait_for_lb_cleanup`
+handles ordering, but if a destroy stalls for 15+ minutes on subnet deletion, look for a
+leftover NLB tagged with the cluster name and delete it with
+`aws elbv2 delete-load-balancer`.
+
+## `kubectl` / `jd cluster login` returns Forbidden
+
+The cluster is created with `bootstrap_cluster_creator_admin_permissions = false`, so
+only IAM roles listed in `admin_role_names` receive cluster admin access. A `check`
+block validates at plan time that the caller's role is included.
+
+If you assume a different IAM role than the one used to deploy, add its name to
+`admin_role_names`, then re-run `jd config` and `jd up` (pass each role name as a
+separate flag):
+
+```bash
+jd config --admin-role-names Admin --admin-role-names MyOtherRole
+jd up
+```
+
+Workspace-level access is granted by the `github-rbac` chart to the GitHub teams in
+`oauth_allowed_teams`, scoped to the namespaces in `workspace_rbac_namespaces`. If a
+user gets `Forbidden` creating a workspace, confirm their team is in `oauth_allowed_teams`
+(in `org:team` format) and that the target namespace is in `workspace_rbac_namespaces`.
+
+## A workspace does not start
+
+```bash
+# check the workspace status
+jd server status --name <workspace-name> --scope <namespace>
+
+# inspect details (events, conditions, scheduling)
+jd server show --name <workspace-name> --scope <namespace>
+
+# tail the workspace logs
+jd server logs --name <workspace-name> --scope <namespace>
+```
+
+A workspace stuck in `Starting` is often waiting on a node. GPU workspaces require a
+`workspaces` node group with GPU capacity and sufficient vCPU quota (see above). If the
+node group `desired_size` is `0`, scale it up in `node_groups` and run `jd up`.
+
+{{ generated-by-footer }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_configuration.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_configuration.py
@@ -94,6 +94,34 @@ def test_agent_md_generated_after_init(e2e_deployment: EndToEndDeployment) -> No
         "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
     ]
 )
+def test_troubleshoot_md_generated_after_init(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that TROUBLESHOOT.md is generated after jd init with all snippets substituted."""
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        troubleshoot_path = project_path / "TROUBLESHOOT.md"
+        assert troubleshoot_path.exists(), f"TROUBLESHOOT.md should exist after init: {troubleshoot_path}"
+
+        troubleshoot_template_path = project_path / "TROUBLESHOOT.md.template"
+        assert not troubleshoot_template_path.exists(), "TROUBLESHOOT.md.template should be removed after init"
+
+        troubleshoot_content = troubleshoot_path.read_text()
+
+        assert "# Troubleshooting Guide" in troubleshoot_content, "Should have main heading"
+        assert "request-service-quota-increase" in troubleshoot_content, "Should document quota increase"
+        assert "{{ " not in troubleshoot_content, "Should not contain template placeholders"
+        assert " }}" not in troubleshoot_content, "Should not contain template placeholders"
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(
+    [
+        "JD_E2E_VAR_DOMAIN",
+        "JD_E2E_VAR_EMAIL",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+        "JD_E2E_VAR_SUBDOMAIN",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    ]
+)
 def test_store_config_written_after_config(e2e_deployment: EndToEndDeployment) -> None:
     """Test that .jd/store.yaml is created after jd config with correct store type."""
     with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -11,6 +11,7 @@ MANDATORY_TEMPLATE_STRPATHS: list[str] = [
     "manifest.yaml",
     "variables.yaml",
     "AGENT.md.template",
+    "TROUBLESHOOT.md.template",
     "engine/presets/defaults-all.tfvars",
     "engine/presets/destroy.tfvars",
     "engine/main.tf",

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_outputs.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_outputs.py
@@ -19,6 +19,7 @@ from jupyter_deploy.manifest import JupyterDeployManifest
 
 _BACKEND_INIT_ERROR = "Backend initialization required"
 _FAILED_TO_LOAD_STATE = "Failed to load state"
+_INVALID_CREDENTIALS = "error validating provider credentials"
 
 
 class TerraformOutputsHandler(EngineOutputsHandler):
@@ -42,11 +43,11 @@ class TerraformOutputsHandler(EngineOutputsHandler):
             return cmd_utils.run_cmd_and_capture_output(output_cmd, exec_dir=self.engine_dir_path)
         except subprocess.CalledProcessError as e:
             stderr = e.stderr or ""
-            if _FAILED_TO_LOAD_STATE in stderr:
+            if _FAILED_TO_LOAD_STATE in stderr or _INVALID_CREDENTIALS in stderr:
                 store_config = retrieve_store_config(self.project_path)
                 raise ProjectStoreReadError(
                     "Failed to load remote state.",
-                    hint="Verify that your credentials have access to the project store.",
+                    hint="Verify that your credentials are valid and have access to the project store.",
                     store_type=store_config.store_type if store_config else None,
                     store_id=store_config.store_id if store_config else None,
                 ) from e

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/docs_generator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/docs_generator.py
@@ -39,36 +39,43 @@ class DocsGenerator:
 
     def generate_agent_md(self) -> None:
         """Generate AGENT.md file from template with CLI snippet substitutions."""
-        # Template file in project directory (copied from source)
-        template_path = self.project_path / "AGENT.md.template"
+        self._generate_from_template(template_filename="AGENT.md.template", snippet_dir_name="agent")
 
-        # If template doesn't exist, skip generation
+    def generate_troubleshoot_md(self) -> None:
+        """Generate TROUBLESHOOT.md file from template with snippet substitutions."""
+        self._generate_from_template(template_filename="TROUBLESHOOT.md.template", snippet_dir_name="troubleshoot")
+
+    def _generate_from_template(self, template_filename: str, snippet_dir_name: str) -> None:
+        """Render a project doc by substituting snippets into its `.template` file.
+
+        Reads `<template_filename>` from the project directory, replaces every
+        `{{ placeholder }}` with the matching snippet from
+        `init_static/<snippet_dir_name>/<placeholder>.md`, writes the result to the
+        file without the `.template` suffix, then removes the template.
+
+        No-op if the template file does not exist.
+        """
+        template_path = self.project_path / template_filename
+
         if not template_path.exists():
             return
 
-        # Read template
         template_content = template_path.read_text()
+        snippet_dir = self.INIT_STATIC_DIR / snippet_dir_name
+        output_content = self._substitute_snippets(template_content, snippet_dir)
 
-        # Apply substitutions
-        output_content = self._substitute_agent_template_vars(template_content)
-
-        # Write to project
-        output_path = self.project_path / "AGENT.md"
+        output_path = self.project_path / template_filename.removesuffix(".template")
         output_path.write_text(output_content)
 
         # Remove the template file after generation
         template_path.unlink()
 
-    def _substitute_agent_template_vars(self, template_content: str) -> str:
-        """Replace template variables in AGENT.md template.
+    @staticmethod
+    def _substitute_snippets(template_content: str, snippet_dir: Path) -> str:
+        """Replace `{{ placeholder }}` tokens with snippets loaded from `snippet_dir`.
 
-        Args:
-            template_content: The template content with placeholders
-
-        Returns:
-            Content with all placeholders replaced
+        Placeholders without a matching `<placeholder>.md` file are left untouched.
         """
-        agent_dir = self.INIT_STATIC_DIR / "agent"
         result = template_content
 
         # Find all placeholders in the template
@@ -76,7 +83,7 @@ class DocsGenerator:
 
         # Load and substitute each snippet
         for placeholder in placeholders:
-            snippet_path = agent_dir / f"{placeholder}.md"
+            snippet_path = snippet_dir / f"{placeholder}.md"
             if snippet_path.exists():
                 snippet_content = snippet_path.read_text().rstrip()
                 result = result.replace(f"{{{{ {placeholder} }}}}", snippet_content)

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_handler.py
@@ -91,6 +91,7 @@ class InitHandler:
         # Generate documentation files
         docs_generator.generate_gitignore()
         docs_generator.generate_agent_md()
+        docs_generator.generate_troubleshoot_md()
 
     @staticmethod
     def restore(

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/eks-cluster-management-instruction.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/eks-cluster-management-instruction.md
@@ -1,0 +1,18 @@
+The `cluster` commands operate on the Kubernetes cluster — here a cluster managed by
+AWS EKS — that hosts your apps.
+
+`jd cluster login` configures your local `kubeconfig` so that `kubectl` talks to this
+cluster. After running it, `kubectl` commands target the EKS cluster, and you can confirm
+your Kubernetes identity with `kubectl auth whoami`.
+
+```bash
+# point kubectl at this cluster (writes to ~/.kube/config)
+jd cluster login
+
+# confirm kubectl is now talking to the cluster as you
+kubectl auth whoami
+
+# check the cluster control plane status, or show its details (endpoint, version)
+jd cluster status
+jd cluster show
+```

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/health-check-instructions.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/health-check-instructions.md
@@ -1,0 +1,17 @@
+The `health` command aggregates the status of the full deployment stack: the cluster
+control plane, the load balancer target health, the platform components, and the
+end-to-end connection.
+
+```bash
+# run all health checks
+jd health
+
+# narrow to a single layer
+jd health --cluster
+jd health --load-balancer
+jd health --components
+jd health --connection
+
+# machine-readable output
+jd health --json
+```

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/jk8s-workspaces-management-instructions.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/jk8s-workspaces-management-instructions.md
@@ -1,0 +1,61 @@
+Each user app is a jupyter-k8s **Workspace** custom resource, exposed through the `server`
+commands. Address a specific workspace with `--name`, and `--scope` to select the
+Kubernetes namespace it lives in (defaults to the template's default namespace when
+omitted). `jd server list` shows every workspace when `--name` is omitted; `status`,
+`show`, `logs`, `exec`, and the lifecycle verbs require a `--name`. See the jupyter-k8s
+[Workspace documentation](https://jupyter-k8s.readthedocs.io/en/latest/getting-started/run-workspaces.html)
+for the custom resource itself.
+
+```bash
+# list all workspaces (optionally restricted to one namespace)
+jd server list
+jd server list --scope SCOPE
+```
+
+`jd server list` paginates: pass `--limit N` (`-n`) to cap the page size. When more
+workspaces remain, the command prints a continuation token — pass it back with
+`--continue-from TOKEN` to fetch the next page. Without a token, a large cluster returns a
+truncated list, so loop until no token is returned.
+
+```bash
+# first page of 20, then the next page using the returned token
+jd server list --limit 20
+jd server list --limit 20 --continue-from TOKEN
+```
+
+`jd server status` reports a single operational word derived from the Workspace's
+conditions: `Running`, `Starting`, `Stopping`, `Stopped`, or `Degraded`.
+
+```bash
+jd server status --name WORKSPACE-NAME --scope SCOPE
+```
+
+`jd server show` returns the full Workspace custom resource as JSON (spec, conditions,
+the backing Deployment name, the access URL) — useful for diagnosing why a workspace is
+not `Running`.
+
+```bash
+jd server show --name WORKSPACE-NAME --scope SCOPE
+```
+
+Stop and start patch the Workspace's `desiredStatus`; the operator reconciles it. Stopping
+keeps the persistent volume, so data survives a stop/start cycle.
+
+```bash
+jd server stop --name WORKSPACE-NAME --scope SCOPE
+jd server start --name WORKSPACE-NAME --scope SCOPE
+```
+
+Logs, exec, and connect act on the running workspace pod. Arguments after `--` on
+`jd server logs` pass straight to `kubectl logs` (e.g. `--tail 100`, `--since 10m`, `-f`).
+
+```bash
+# tail the last 100 log lines of the workspace
+jd server logs --name WORKSPACE-NAME --scope SCOPE -- --tail 100
+
+# run a one-off command inside the workspace pod with kubectl exec
+jd server exec --name WORKSPACE-NAME --scope SCOPE -- ls -la /home/jovyan
+
+# open an interactive shell in the workspace pod with kubectl exec
+jd server connect --name WORKSPACE-NAME --scope SCOPE
+```

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/kubernetes-component-management-instructions.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/kubernetes-component-management-instructions.md
@@ -1,0 +1,43 @@
+Components are the platform-level Kubernetes resources supporting your apps (e.g. router,
+identity provider, controllers). Each one is backed by a Kubernetes **Deployment** (a
+long-running workload) or a **CronJob** (a scheduled job). You address a component by
+`--name`; `jd component list` reports each one's name and type.
+
+```bash
+# list the components declared by this template (with their Deployment/CronJob type)
+jd component list
+
+# check the status of a specific component
+jd component status --name COMPONENT-NAME
+```
+
+`jd component show` reads the full Kubernetes resource and prints it as JSON — the
+equivalent of `kubectl describe`/`kubectl get -o json` for that Deployment or CronJob.
+Use it to inspect the spec, replica counts, conditions, and events.
+
+```bash
+jd component show --name COMPONENT-NAME
+```
+
+`jd component logs` fetches the logs of the component's pod. Anything after `--` is passed
+straight to `kubectl logs`, so you can use its flags — e.g. `--tail N` for the last N
+lines, `--since 10m`, `-f` to follow, `--previous` for a crashed container's prior run,
+or `-c CONTAINER` to select a container.
+
+```bash
+# last 100 lines
+jd component logs --name COMPONENT-NAME -- --tail 100
+
+# follow the logs of the previous (crashed) container instance
+jd component logs --name COMPONENT-NAME -- --previous -f
+```
+
+The remaining verbs depend on the component type:
+
+```bash
+# restart a Deployment-backed component (rolling restart; not valid for a CronJob)
+jd component restart --name COMPONENT-NAME
+
+# trigger a one-off Job from a CronJob-backed component (not valid for a Deployment)
+jd component trigger --name COMPONENT-NAME
+```

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/multi-server-open-instructions.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/multi-server-open-instructions.md
@@ -1,0 +1,7 @@
+```bash
+# open the getting-started page in your web browser
+jd open
+
+# open a specific running app (server) in your web browser
+jd open --server-name SERVER-NAME --scope SCOPE
+```

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/troubleshoot/generated-by-footer.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/troubleshoot/generated-by-footer.md
@@ -1,0 +1,1 @@
+Generated with [jupyter-deploy](https://github.com/jupyter-infra/jupyter-deploy)

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/troubleshoot/request-quota-increase-instructions.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/troubleshoot/request-quota-increase-instructions.md
@@ -1,0 +1,12 @@
+Request a higher limit (replace the service code, quota code, value, and region):
+
+```bash
+aws service-quotas request-service-quota-increase \
+  --service-code <service-code> --quota-code <quota-code> \
+  --desired-value <value> --region <region>
+```
+
+Check the current value with `get-service-quota` and track the request with
+`list-requested-service-quota-change-history-by-quota` (same `--service-code`
+and `--quota-code`). Increases may require AWS support review and are not
+instantaneous. The AWS Service Quotas console offers the same actions.

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_outputs.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_outputs.py
@@ -99,6 +99,34 @@ class TestRunOutputCmd(unittest.TestCase):
         self.assertIsNone(ctx.exception.store_type)
         self.assertIsNone(ctx.exception.store_id)
 
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.retrieve_store_config")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.cmd_utils.run_cmd_and_capture_output")
+    def test_raises_project_store_read_error_on_invalid_credentials(
+        self, mock_run_cmd: Mock, mock_retrieve_store_config: Mock
+    ) -> None:
+        creds_error = subprocess.CalledProcessError(1, "terraform output -json")
+        creds_error.stderr = (
+            "Error: error configuring S3 Backend: error validating provider credentials: "
+            "error calling sts:GetCallerIdentity: ExpiredToken: The security token included "
+            "in the request is expired"
+        )
+        mock_run_cmd.side_effect = creds_error
+
+        mock_store_config = Mock()
+        mock_store_config.store_type = "s3"
+        mock_store_config.store_id = "my-bucket"
+        mock_retrieve_store_config.return_value = mock_store_config
+
+        handler = TerraformOutputsHandler(Path("/mock/project"), Mock())
+        with self.assertRaises(ProjectStoreReadError) as ctx:
+            handler._run_output_cmd()
+
+        self.assertIn("Failed to load remote state", str(ctx.exception))
+        self.assertIn("credentials", ctx.exception.hint or "")
+        self.assertEqual(ctx.exception.store_type, "s3")
+        self.assertEqual(ctx.exception.store_id, "my-bucket")
+        mock_run_cmd.assert_called_once()
+
     @patch("jupyter_deploy.engine.terraform.tf_outputs.cmd_utils.run_cmd_and_capture_output")
     def test_does_not_retry_on_unrelated_error(self, mock_run_cmd: Mock) -> None:
         unrelated_error = subprocess.CalledProcessError(1, "terraform output -json")

--- a/libs/jupyter-deploy/tests/unit/handlers/test_docs_generator.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_docs_generator.py
@@ -166,3 +166,42 @@ Pulumi.*.yaml
         output = mock_write_text.call_args[0][0]
         assert "{{ missing-snippet }}" in output
         mock_unlink.assert_called_once()  # Template file should be deleted
+
+    @patch("pathlib.Path.unlink")
+    @patch("pathlib.Path.read_text")
+    @patch("pathlib.Path.write_text")
+    @patch("pathlib.Path.exists")
+    def test_generate_troubleshoot_md(
+        self, mock_exists: Mock, mock_write_text: Mock, mock_read_text: Mock, mock_unlink: Mock
+    ) -> None:
+        """Test generate_troubleshoot_md with single snippet."""
+        # Setup
+        mock_exists.return_value = True
+
+        template_content = "Quota: {{ request-quota-increase-instructions }}"
+        quota_snippet = "Request a higher limit:\n```bash\naws service-quotas ...\n```"
+
+        # First read is template, second is snippet
+        mock_read_text.side_effect = [template_content, quota_snippet]
+
+        # Execute
+        self.generator.generate_troubleshoot_md()
+
+        # Assert
+        assert mock_write_text.called
+        output = mock_write_text.call_args[0][0]
+        assert "service-quotas" in output
+        assert "{{" not in output  # No placeholders remain
+        mock_unlink.assert_called_once()  # Template file should be deleted
+
+    @patch("pathlib.Path.exists")
+    def test_generate_troubleshoot_md_no_template(self, mock_exists: Mock) -> None:
+        """Test generate_troubleshoot_md when template doesn't exist."""
+        # Setup
+        mock_exists.return_value = False
+
+        # Execute
+        self.generator.generate_troubleshoot_md()
+
+        # Assert - should not raise, just return
+        mock_exists.assert_called_once()


### PR DESCRIPTION
This PR improves `AGENT.md`, `TROUBLESHOOT.md` of both the `base` and `eks-oidc` templates. It also improves the prerequisites section of the documentation for the `eks-oidc` template to explain how to create a GitHub organization, how to setup teams, and how to use organization-owned oauth apps.

### User experience
- provide EKS, Kubernetes and workspace-specific inserts for `AGENT.md.template` (for the agent to debug)

### Testing
- ran the E2E tests locally (against app 4)