### PR TITLE
fix: use k8s namespace v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,25 @@ jobs:
     uses: ./.github/workflows/test.yml
     with:
       working-directory: ${{ matrix.working-directory }}
+
+  docs-sync:
+    name: Verify CLI reference docs are in sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: '3.13'
+          working-directory: '.'
+
+      - name: Install dependencies
+        run: |
+          rm -f uv.lock
+          uv sync --all-extras
+
+      - name: Verify generated CLI reference docs
+        run: |
+          uv run python scripts/verify_docs.py

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ jd --help
 ## Packages
 
 - [jupyter-deploy](./libs/jupyter-deploy/README.md): Core package providing the command line interface tool (CLI).
-- [jupyter-deploy-tf-aws-ec2-base](./libs/jupyter-deploy-tf-aws-ec2-base/README.md): The AWS Base Template to deploy a JupyterLab to an EC2 instance, serve it on your own domain and control access with GitHub OIDC.
+- [jupyter-deploy-tf-aws-ec2-base](./libs/jupyter-deploy-tf-aws-ec2-base/README.md): A template to deploy a single JupyterLab app to an EC2 instance, serve it on your own domain and control access with GitHub identities.
+- [jupyter-deploy-tf-aws-eks-oidc](./libs/jupyter-deploy-tf-aws-eks-oidc/README.md): A template for multi-tenants JupyterLab or other interactive apps to an AWS EKS cluster, serve them on your own domain and control access with GitHub identities.
 - [jupyter-infra-tf-aws-iam-ci](./libs/jupyter-infra-tf-aws-iam-ci/README.md): The template to configure the AWS resources for the CI.
 - [pytest-jupyter-deploy](./libs/pytest-jupyter-deploy/README.md): The pytest plugin for E2E tests that integrates with Playwright.
 

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ lint:
 docs-cli-ref:
     uv run python scripts/generate_cli_ref.py docs/source/reference
 
+# Verify the committed CLI reference docs are in sync with the CLI
+docs-verify:
+    uv run python scripts/verify_docs.py
+
 # Build documentation locally
 docs-build: docs-cli-ref
     cd docs && uv run sphinx-build -b html source build

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -43,14 +43,14 @@ resource "null_resource" "destroy_workspaces" {
     helm_release.workspace_defaults,
     helm_release.github_rbac,
     module.node_group,
-    kubernetes_namespace.shared,
+    kubernetes_namespace_v1.shared,
     module.eks_cluster,
     aws_eks_access_policy_association.admin,
     aws_eks_access_policy_association.caller,
   ]
 }
 
-resource "kubernetes_namespace" "shared" {
+resource "kubernetes_namespace_v1" "shared" {
   metadata {
     name = var.workspace_shared_namespace
     labels = {
@@ -93,7 +93,7 @@ resource "helm_release" "github_rbac" {
     ]),
   )
 
-  depends_on = [kubernetes_namespace.shared, helm_release.workspace_router]
+  depends_on = [kubernetes_namespace_v1.shared, helm_release.workspace_router]
 }
 
 resource "helm_release" "workspace_defaults" {
@@ -161,5 +161,5 @@ resource "helm_release" "workspace_defaults" {
     },
   ]
 
-  depends_on = [kubernetes_namespace.shared, helm_release.workspace_router]
+  depends_on = [kubernetes_namespace_v1.shared, helm_release.workspace_router]
 }

--- a/libs/jupyter-deploy/README.md
+++ b/libs/jupyter-deploy/README.md
@@ -141,4 +141,4 @@ jupyter-deploy down
 
 ## License
 
-The `jupyter-deploy` CLI is licensed under the [MIT License](LICENSE).
+The `jupyter-deploy` CLI is licensed under the [MIT License](https://github.com/jupyter-infra/jupyter-deploy/blob/main/libs/jupyter-deploy/LICENSE).

--- a/libs/pytest-jupyter-deploy/README.md
+++ b/libs/pytest-jupyter-deploy/README.md
@@ -93,4 +93,4 @@ from pytest_jupyter_deploy.image import IMAGE_PATH
 
 ## License
 
-The Pytest plugin for Jupyter Deploy templates is licensed under the [MIT License](LICENSE).
+The Pytest plugin for Jupyter Deploy templates is licensed under the [MIT License](https://github.com/jupyter-infra/jupyter-deploy/blob/main/libs/pytest-jupyter-deploy/LICENSE).

--- a/scripts/verify_docs.py
+++ b/scripts/verify_docs.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Verify that the generated CLI reference docs are in sync with the CLI.
+
+Regenerates the per-command reference pages under docs/source/reference/ from
+the Typer app and fails if the result differs from what is committed. This
+catches the easy-to-forget case where the CLI changes but the docs were not
+rebuilt with `just docs-build`.
+
+Usage: python scripts/verify_docs.py
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from rich.console import Console
+
+REFERENCE_DIR = Path("docs/source/reference")
+GENERATE_SCRIPT = Path("scripts/generate_cli_ref.py")
+
+
+def main() -> int:
+    console = Console()
+    repo_root = Path(__file__).resolve().parent.parent
+
+    gen_result = subprocess.run(
+        ["uv", "run", "python", str(GENERATE_SCRIPT), str(REFERENCE_DIR)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if gen_result.returncode != 0:
+        console.print("Failed to regenerate CLI reference docs:", style="bold red")
+        console.print(gen_result.stderr)
+        return 1
+
+    diff_result = subprocess.run(
+        ["git", "diff", "--exit-code", "--", str(REFERENCE_DIR)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    if diff_result.returncode != 0:
+        console.print(
+            f"CLI reference docs under '{REFERENCE_DIR}' are out of date with the CLI.",
+            style="bold red",
+        )
+        console.print(
+            "The CLI changed but the generated reference pages were not rebuilt. "
+            "Run [bold]just docs-build[/bold] and commit the changes under "
+            f"'{REFERENCE_DIR}'.",
+            style="bold red",
+        )
+        console.print("\nDiff:", style="bold red")
+        console.print(diff_result.stdout)
+        return 1
+
+    console.print(
+        f"All good, the CLI reference docs under '{REFERENCE_DIR}' are in sync with the CLI.",
+        style="bold green",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR a/ migrate `eks-oidc` HCL files to use the more recent `namespace_v1` terraform construct, b/ fixes broken links in README (on `PyPI`) and c/ add CI to ensure that docs were re-generated.

### Customer experience
- No change

### Testing
- Ran script locally