### PR TITLE
fix: quotation in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ uv venv
 source .venv/bin/activate
 
 # install the CLI and the AWS Base Template
-uv add jupyter-deploy[aws]
+uv add "jupyter-deploy[aws]"
 uv add jupyter-deploy-tf-aws-ec2-base
 ```
 

--- a/docs/source/getting-started/index.md
+++ b/docs/source/getting-started/index.md
@@ -18,13 +18,13 @@ uv venv
 source .venv/bin/activate
 
 # install jupyter-deploy and the base template
-uv add jupyter-deploy[aws]
+uv add "jupyter-deploy[aws]"
 uv add jupyter-deploy-tf-aws-ec2-base
 ```
 
 Or with `pip`:
 ```bash
-pip install jupyter-deploy[aws]
+pip install "jupyter-deploy[aws]"
 pip install jupyter-deploy-tf-aws-ec2-base
 ```
 

--- a/docs/source/templates/aws-base-template/user-guide.md
+++ b/docs/source/templates/aws-base-template/user-guide.md
@@ -6,13 +6,13 @@ This terraform project is meant to be used with the [jupyter-deploy](https://git
 Recommended: create or activate a Python virtual environment.
 
 ```bash
-uv add jupyter-deploy[aws] jupyter-deploy-tf-aws-ec2-base
+uv add "jupyter-deploy[aws]" jupyter-deploy-tf-aws-ec2-base
 ```
 
 Or with pip:
 
 ```bash
-pip install jupyter-deploy[aws] jupyter-deploy-tf-aws-ec2-base
+pip install "jupyter-deploy[aws]" jupyter-deploy-tf-aws-ec2-base
 ```
 
 ## Project setup

--- a/docs/source/templates/aws-eks-oidc-template/user-guide.md
+++ b/docs/source/templates/aws-eks-oidc-template/user-guide.md
@@ -5,13 +5,13 @@
 Recommended: create or activate a Python virtual environment.
 
 ```bash
-uv add jupyter-deploy[aws,k8s] jupyter-deploy-tf-aws-eks-oidc
+uv add "jupyter-deploy[aws,k8s]" jupyter-deploy-tf-aws-eks-oidc
 ```
 
 Or with pip:
 
 ```bash
-pip install jupyter-deploy[aws,k8s] jupyter-deploy-tf-aws-eks-oidc
+pip install "jupyter-deploy[aws,k8s]" jupyter-deploy-tf-aws-eks-oidc
 ```
 
 ## Project setup

--- a/libs/jupyter-deploy-tf-aws-ec2-base/README.md
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/README.md
@@ -55,13 +55,13 @@ This terraform project is meant to be used with the [jupyter-deploy](https://git
 Recommended: create or activate a Python virtual environment.
 
 ```bash
-uv add jupyter-deploy[aws] jupyter-deploy-tf-aws-ec2-base
+uv add "jupyter-deploy[aws]" jupyter-deploy-tf-aws-ec2-base
 ```
 
 Or with pip:
 
 ```bash
-pip install jupyter-deploy[aws] jupyter-deploy-tf-aws-ec2-base
+pip install "jupyter-deploy[aws]" jupyter-deploy-tf-aws-ec2-base
 ```
 
 ### Project setup

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -64,13 +64,13 @@ Refer to GitHub [documentation](https://docs.github.com/en/apps/oauth-apps/build
 Recommended: create or activate a Python virtual environment.
 
 ```bash
-uv add jupyter-deploy[aws,k8s] jupyter-deploy-tf-aws-eks-oidc
+uv add "jupyter-deploy[aws,k8s]" jupyter-deploy-tf-aws-eks-oidc
 ```
 
 Or with pip:
 
 ```bash
-pip install jupyter-deploy[aws,k8s] jupyter-deploy-tf-aws-eks-oidc
+pip install "jupyter-deploy[aws,k8s]" jupyter-deploy-tf-aws-eks-oidc
 ```
 
 ### Project setup

--- a/libs/jupyter-infra-tf-aws-iam-ci/README.md
+++ b/libs/jupyter-infra-tf-aws-iam-ci/README.md
@@ -24,7 +24,7 @@ This terraform project is meant to be used with the [jupyter-deploy](https://git
 Recommended: create or activate a python virtual environment.
 
 ```bash
-pip install jupyter-deploy[aws]
+pip install "jupyter-deploy[aws]"
 pip install jupyter-infra-tf-aws-iam-ci
 ```
 

--- a/libs/pytest-jupyter-deploy/README.md
+++ b/libs/pytest-jupyter-deploy/README.md
@@ -14,7 +14,7 @@ pip install pytest-jupyter-deploy
 
 For UI testing with Playwright:
 ```bash
-pip install pytest-jupyter-deploy[ui]
+pip install "pytest-jupyter-deploy[ui]"
 playwright install firefox
 ```
 


### PR DESCRIPTION
This PR fixes the documentation to quote any optional installs: `uv add jupyter-deploy[aws]` > `uv add "jupyter-deploy[aws]"`.

This is necessary for many shells, such as zsh.