### PR TITLE
chore: harden ci, improve web-app e2e tests

### DIFF
--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -64,7 +64,17 @@ jobs:
           BUILD_ARGS="--build-arg INSTALL_MODE=pypi"
           BUILD_ARGS="$BUILD_ARGS --build-arg INSTALL_VARIANT=bare"
           BUILD_ARGS="$BUILD_ARGS --build-arg PKG_VERSION=${{ inputs.pkg-version }}"
-          just ci-e2e-cli-build "$ECR_URL:jd-bare" "$BUILD_ARGS"
+          for i in 1 2; do
+            if just ci-e2e-cli-build "$ECR_URL:jd-bare" "$BUILD_ARGS" 2>&1 | tee /tmp/build.log; then exit 0; fi
+            if ! grep -qi "No solution found\|no version of jupyter-deploy" /tmp/build.log; then
+              echo "::error::Build failed with non-transient error"
+              exit 1
+            fi
+            echo "Attempt ${i}/2 failed (package not yet available), retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::CLI E2E image (bare) build failed after 2 attempts"
+          exit 1
 
       - name: Push to ECR
         run: just ci-e2e-cli-push bare
@@ -113,7 +123,17 @@ jobs:
           BUILD_ARGS="--build-arg INSTALL_MODE=pypi"
           BUILD_ARGS="$BUILD_ARGS --build-arg INSTALL_VARIANT=aws"
           BUILD_ARGS="$BUILD_ARGS --build-arg PKG_VERSION=${{ inputs.pkg-version }}"
-          just ci-e2e-cli-build "$ECR_URL:jd-aws" "$BUILD_ARGS"
+          for i in 1 2; do
+            if just ci-e2e-cli-build "$ECR_URL:jd-aws" "$BUILD_ARGS" 2>&1 | tee /tmp/build.log; then exit 0; fi
+            if ! grep -qi "No solution found\|no version of jupyter-deploy" /tmp/build.log; then
+              echo "::error::Build failed with non-transient error"
+              exit 1
+            fi
+            echo "Attempt ${i}/2 failed (package not yet available), retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::CLI E2E image (aws) build failed after 2 attempts"
+          exit 1
 
       - name: Push to ECR
         run: just ci-e2e-cli-push aws
@@ -162,7 +182,17 @@ jobs:
           BUILD_ARGS="--build-arg INSTALL_MODE=pypi"
           BUILD_ARGS="$BUILD_ARGS --build-arg INSTALL_VARIANT=aws-k8s"
           BUILD_ARGS="$BUILD_ARGS --build-arg PKG_VERSION=${{ inputs.pkg-version }}"
-          just ci-e2e-cli-build "$ECR_URL:jd-aws-k8s" "$BUILD_ARGS"
+          for i in 1 2; do
+            if just ci-e2e-cli-build "$ECR_URL:jd-aws-k8s" "$BUILD_ARGS" 2>&1 | tee /tmp/build.log; then exit 0; fi
+            if ! grep -qi "No solution found\|no version of jupyter-deploy" /tmp/build.log; then
+              echo "::error::Build failed with non-transient error"
+              exit 1
+            fi
+            echo "Attempt ${i}/2 failed (package not yet available), retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::CLI E2E image (aws-k8s) build failed after 2 attempts"
+          exit 1
 
       - name: Push to ECR
         run: just ci-e2e-cli-push aws-k8s

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -116,10 +116,22 @@ jobs:
       - name: Test installation from Test PyPI
         run: |
           uv venv
-          uv pip install \
-            --extra-index-url https://test.pypi.org/simple/ \
-            --index-strategy unsafe-best-match \
-            ${{ env.PKG_NAME }}==${{ env.VERSION }}
+          for i in 1 2; do
+            if uv pip install \
+              --extra-index-url https://test.pypi.org/simple/ \
+              --index-strategy unsafe-best-match \
+              ${{ env.PKG_NAME }}==${{ env.VERSION }} 2>&1 | tee /tmp/install.log; then
+              exit 0
+            fi
+            if ! grep -qi "No solution found\|no version of" /tmp/install.log; then
+              echo "::error::Install failed with non-transient error"
+              exit 1
+            fi
+            echo "Attempt ${i}/2 failed (package not yet installable), retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::Test PyPI install failed after 2 attempts"
+          exit 1
 
   e2e-base-release:
     name: E2E release gate (base template)

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -160,10 +160,22 @@ jobs:
       - name: Test installation from Test PyPI
         run: |
           uv venv
-          uv pip install \
-            --extra-index-url https://test.pypi.org/simple/ \
-            --index-strategy unsafe-best-match \
-            ${{ env.PKG_NAME }}==${{ env.VERSION }}
+          for i in 1 2; do
+            if uv pip install \
+              --extra-index-url https://test.pypi.org/simple/ \
+              --index-strategy unsafe-best-match \
+              ${{ env.PKG_NAME }}==${{ env.VERSION }} 2>&1 | tee /tmp/install.log; then
+              exit 0
+            fi
+            if ! grep -qi "No solution found\|no version of" /tmp/install.log; then
+              echo "::error::Install failed with non-transient error"
+              exit 1
+            fi
+            echo "Attempt ${i}/2 failed (package not yet installable), retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::Test PyPI install failed after 2 attempts"
+          exit 1
 
   e2e-cli-release:
     name: E2E release gate (CLI)

--- a/.github/workflows/release-eks-oidc.yml
+++ b/.github/workflows/release-eks-oidc.yml
@@ -116,10 +116,22 @@ jobs:
       - name: Test installation from Test PyPI
         run: |
           uv venv
-          uv pip install \
-            --extra-index-url https://test.pypi.org/simple/ \
-            --index-strategy unsafe-best-match \
-            ${{ env.PKG_NAME }}==${{ env.VERSION }}
+          for i in 1 2; do
+            if uv pip install \
+              --extra-index-url https://test.pypi.org/simple/ \
+              --index-strategy unsafe-best-match \
+              ${{ env.PKG_NAME }}==${{ env.VERSION }} 2>&1 | tee /tmp/install.log; then
+              exit 0
+            fi
+            if ! grep -qi "No solution found\|no version of" /tmp/install.log; then
+              echo "::error::Install failed with non-transient error"
+              exit 1
+            fi
+            echo "Attempt ${i}/2 failed (package not yet installable), retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::Test PyPI install failed after 2 attempts"
+          exit 1
 
   # TODO: add e2e-eks-oidc-release gate once PyPI canary workflows are wired up
 

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -116,10 +116,22 @@ jobs:
       - name: Test installation from Test PyPI
         run: |
           uv venv
-          uv pip install \
-            --extra-index-url https://test.pypi.org/simple/ \
-            --index-strategy unsafe-best-match \
-            ${{ env.PKG_NAME }}==${{ env.VERSION }}
+          for i in 1 2; do
+            if uv pip install \
+              --extra-index-url https://test.pypi.org/simple/ \
+              --index-strategy unsafe-best-match \
+              ${{ env.PKG_NAME }}==${{ env.VERSION }} 2>&1 | tee /tmp/install.log; then
+              exit 0
+            fi
+            if ! grep -qi "No solution found\|no version of" /tmp/install.log; then
+              echo "::error::Install failed with non-transient error"
+              exit 1
+            fi
+            echo "Attempt ${i}/2 failed (package not yet installable), retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::Test PyPI install failed after 2 attempts"
+          exit 1
 
   prod-pypi-publish:
     name: Publish to PyPI

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/conftest.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/conftest.py
@@ -73,6 +73,10 @@ def seeded_cluster(
 
     Yields a dict: {"admin": [...], "seeded": [...]}
     Tears down all workspaces on session end.
+
+    These workspaces are long-lived (session-scoped) and must not be mutated or
+    deleted by tests. Tests in test_workspace.py use separate, self-contained
+    workspace names (e2e-ws-*) with their own create/delete lifecycle.
     """
     group = _get_impersonation_group()
     if not group:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_web_app.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_web_app.py
@@ -2,219 +2,186 @@
 
 Tests web UI page loads, workspace CRUD via the browser, and access control.
 The web UI is gated by oauth2-proxy (Dex OAuth flow).
-Uses the dex_oauth_app fixture to authenticate through oauth2-proxy → Dex → GitHub.
 
 Auth model:
 - "User A" = the GitHub bot user (github:<JD_E2E_USER>) — same identity as the browser session
+- Seeded workspaces = owned by a synthetic "other user" (github:e2e-other-user)
 """
 
-import subprocess
-from collections.abc import Generator
-
 import pytest
-from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+from pytest_jupyter_deploy.workspaces.kubectl import ensure_workspace_no_longer_exists
+from pytest_jupyter_deploy.workspaces.web_app import WebAppNavigator
 
 pytestmark = pytest.mark.usefixtures("cluster_login")
-
-NAMESPACE = "default"
-
-
-@pytest.fixture()
-def create_workspace_via_page(
-    getting_started_url: str,
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-) -> Generator[str, None, None]:
-    """Create a workspace through the UI and yield its name. Deletes on teardown."""
-    dex_oauth_app.ensure_authenticated()
-
-    base_url = getting_started_url.rstrip("/")
-    page = dex_oauth_app.page
-
-    page.goto(base_url + "/create", wait_until="networkidle", timeout=60000)
-
-    name_field = page.get_by_label("Name").first
-    name_field.wait_for(state="visible", timeout=30000)
-    workspace_name = name_field.input_value()
-    assert workspace_name != "", "Expected auto-generated workspace name"
-
-    create_button = page.get_by_role("button", name="Create Workspace")
-    create_button.click()
-
-    # Wait for creation to complete (app redirects to list)
-    page.wait_for_timeout(3000)
-
-    # Navigate to detail page
-    page.goto(base_url + f"/workspace/{workspace_name}", wait_until="networkidle", timeout=60000)
-    page.get_by_text(workspace_name).wait_for(state="visible", timeout=30000)
-
-    yield workspace_name
-
-    subprocess.run(
-        ["kubectl", "delete", "workspace", workspace_name, "-n", NAMESPACE, "--ignore-not-found"],
-        capture_output=True,
-    )
 
 
 # ── Page load tests ──────────────────────────────────────────────────────────
 
 
 @skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
-def test_web_app_loads_after_oauth(
-    getting_started_url: str,
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-) -> None:
+def test_web_app_loads_after_oauth(dex_oauth_web_app: WebAppNavigator) -> None:
     """Verify the web UI loads successfully behind OAuth."""
-    dex_oauth_app.ensure_authenticated()
+    dex_oauth_web_app.goto_workspace_list()
 
-    base_url = getting_started_url.rstrip("/")
-    dex_oauth_app.page.goto(base_url + "/", wait_until="networkidle", timeout=60000)
-
-    heading = dex_oauth_app.page.get_by_role("heading", name="Workspaces", exact=True)
+    heading = dex_oauth_web_app.page.get_by_role("heading", name="Workspaces", exact=True)
     assert heading.is_visible(timeout=30000), "Expected 'Workspaces' heading to be visible"
 
 
 @skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
-def test_web_app_health_endpoint(
-    getting_started_url: str,
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-) -> None:
+def test_web_app_health_endpoint(dex_oauth_web_app: WebAppNavigator) -> None:
     """Verify the web app health endpoint responds."""
-    dex_oauth_app.ensure_authenticated()
-
-    base_url = getting_started_url.rstrip("/")
-    response = dex_oauth_app.page.goto(base_url + "/api/v1/health", wait_until="load", timeout=30000)
-
+    response = dex_oauth_web_app.page.goto(
+        dex_oauth_web_app.base_url + "/api/v1/health", wait_until="load", timeout=30000
+    )
     assert response is not None
     assert response.status == 200
 
 
 @skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
-def test_web_app_kubectl_page(
-    getting_started_url: str,
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-) -> None:
+def test_web_app_kubectl_page(dex_oauth_web_app: WebAppNavigator) -> None:
     """Verify the kubectl access page loads and shows cluster info."""
-    dex_oauth_app.ensure_authenticated()
+    dex_oauth_web_app.goto_kubectl_page()
 
-    base_url = getting_started_url.rstrip("/")
-    dex_oauth_app.page.goto(base_url + "/kubectl", wait_until="networkidle", timeout=60000)
-
-    heading = dex_oauth_app.page.get_by_role("heading", name="Kubectl Access")
+    heading = dex_oauth_web_app.page.get_by_role("heading", name="Kubectl Access")
     assert heading.is_visible(timeout=30000), "Expected 'Kubectl Access' heading to be visible"
 
 
-# ── Workspace CRUD ───────────────────────────────────────────────────────────
+# ── Workspace lifecycle ────────────────────────────────────────────────────────
 
 
 @skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
-def test_create_workspace(
-    getting_started_url: str,
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-    create_workspace_via_page: str,
-) -> None:
-    """Create a workspace through the UI and verify it appears in the list."""
-    workspace_name = create_workspace_via_page
+def test_create_default_workspace(dex_oauth_web_app: WebAppNavigator) -> None:
+    """Create a workspace through the UI, verify Running, open it → JupyterLab loads."""
+    with dex_oauth_web_app.default_workspace() as workspace_name:
+        dex_oauth_web_app.wait_for_status("Starting")
+        dex_oauth_web_app.wait_for_running()
 
-    base_url = getting_started_url.rstrip("/")
-    page = dex_oauth_app.page
+        # Open button should appear when workspace is Running
+        open_button = dex_oauth_web_app.get_open_button()
+        assert open_button.is_visible(), "Expected Open button on Running workspace detail page"
 
-    # Navigate to workspace list and verify the workspace shows up
-    page.goto(base_url + "/", wait_until="networkidle", timeout=60000)
-    page.get_by_role("heading", name="Workspaces", exact=True).wait_for(state="visible", timeout=30000)
-    page.get_by_text(workspace_name).wait_for(state="visible", timeout=30000)
+        # Verify it shows up in the list with an Open button on the card
+        dex_oauth_web_app.goto_workspace_list()
+        card = dex_oauth_web_app.get_workspace_card(workspace_name)
+        assert card.is_visible(timeout=30000), f"Workspace '{workspace_name}' not found in list"
 
-
-@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
-def test_workspace_detail_page(
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-    create_workspace_via_page: str,
-) -> None:
-    """Create a workspace and verify the detail page shows status and actions."""
-    workspace_name = create_workspace_via_page
-    page = dex_oauth_app.page
-
-    # Detail page should show workspace name (already navigated by fixture)
-    page.get_by_text(workspace_name).wait_for(state="visible", timeout=30000)
-
-    # Should show a status indicator (Starting or Running)
-    status = page.get_by_text("Starting").or_(page.get_by_text("Running"))
-    status.first.wait_for(state="visible", timeout=30000)
+        # Click Open on the card → new tab → JupyterLab should load
+        dex_oauth_web_app.open_workspace_from_card(workspace_name)
+        dex_oauth_web_app.verify_jupyterlab_loaded()
 
 
 @skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
-def test_stop_workspace(
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-    create_workspace_via_page: str,
-) -> None:
-    """Create a workspace, wait for Running, then stop it."""
-    _ = create_workspace_via_page
-    page = dex_oauth_app.page
+def test_stop_and_restart_workspace(dex_oauth_web_app: WebAppNavigator) -> None:
+    """Create a workspace, stop it (Open disappears), restart it, open → JupyterLab."""
+    with dex_oauth_web_app.default_workspace():
+        dex_oauth_web_app.wait_for_running()
 
-    # Wait for workspace to reach Running
-    page.get_by_text("Running").wait_for(state="visible", timeout=300000)
+        # Open button should be visible while Running
+        open_button = dex_oauth_web_app.get_open_button()
+        assert open_button.is_visible(), "Expected Open button while workspace is Running"
 
-    # Click stop button
-    page.get_by_role("button", name="Stop").click()
+        # Stop the workspace
+        dex_oauth_web_app.stop_workspace()
+        assert dex_oauth_web_app.get_status_chip_text() == "Stopped"
+        assert not open_button.is_visible(), "Open button should disappear when workspace is Stopped"
 
-    # Confirm the action in the dialog
-    page.get_by_role("button", name="Confirm").or_(page.get_by_role("button", name="Stop")).last.click(timeout=5000)
+        # Restart the workspace
+        dex_oauth_web_app.start_workspace()
+        dex_oauth_web_app.wait_for_running()
+        assert dex_oauth_web_app.get_status_chip_text() == "Running"
 
-    # Verify workspace transitions to Stopped
-    page.get_by_text("Stopped").wait_for(state="visible", timeout=180000)
-
-
-@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
-def test_start_stopped_workspace(
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-    create_workspace_via_page: str,
-) -> None:
-    """Create a workspace, stop it, then restart it."""
-    _ = create_workspace_via_page
-    page = dex_oauth_app.page
-
-    # Wait for Running, then stop
-    page.get_by_text("Running").wait_for(state="visible", timeout=300000)
-    page.get_by_role("button", name="Stop").click()
-
-    page.get_by_role("button", name="Confirm").or_(page.get_by_role("button", name="Stop")).last.click(timeout=5000)
-
-    page.get_by_text("Stopped").wait_for(state="visible", timeout=180000)
-
-    # Restart the workspace
-    page.get_by_role("button", name="Start").click()
-
-    # Verify workspace transitions back to Running
-    page.get_by_text("Running").wait_for(state="visible", timeout=300000)
+        # Open the workspace from detail page → JupyterLab should load
+        dex_oauth_web_app.open_workspace_from_details_page()
+        dex_oauth_web_app.verify_jupyterlab_loaded()
 
 
 @skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
-def test_delete_workspace(
-    getting_started_url: str,
-    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
-    create_workspace_via_page: str,
+def test_delete_workspace(dex_oauth_web_app: WebAppNavigator) -> None:
+    """Create a workspace, delete it through the UI, verify kubectl can't find it."""
+    with dex_oauth_web_app.default_workspace() as workspace_name:
+        dex_oauth_web_app.wait_for_running()
+        dex_oauth_web_app.delete_workspace_from_list(workspace_name)
+        ensure_workspace_no_longer_exists(workspace_name)
+
+
+# ── Cross-user visibility (other user's workspaces) ───────────────────────────
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_sees_other_user_workspaces_in_list(
+    seeded_cluster: dict[str, list[str]], dex_oauth_web_app: WebAppNavigator
 ) -> None:
-    """Create a workspace and delete it through the UI."""
-    workspace_name = create_workspace_via_page
-    page = dex_oauth_app.page
+    """Verify the 'All' view shows workspaces owned by other users."""
+    other_public = seeded_cluster["seeded"][0]
+    other_private = seeded_cluster["seeded"][1]
+    dex_oauth_web_app.goto_workspace_list(view_all=True)
 
-    # Wait for workspace to be Running on detail page
-    page.get_by_text("Running").wait_for(state="visible", timeout=300000)
+    public_card = dex_oauth_web_app.get_workspace_card(other_public)
+    public_card.wait_for(state="visible", timeout=30000)
+    assert public_card.is_visible(), f"Expected other user's public workspace '{other_public}' in list"
 
-    # Go to list page and delete via the card menu
-    base_url = getting_started_url.rstrip("/")
-    page.goto(base_url + "/", wait_until="networkidle", timeout=60000)
-    page.get_by_text(workspace_name).wait_for(state="visible", timeout=30000)
+    private_card = dex_oauth_web_app.get_workspace_card(other_private)
+    assert private_card.is_visible(), f"Expected other user's private workspace '{other_private}' in list"
 
-    # Find the card for this workspace and open its menu
-    card = page.locator(".MuiCard-root").filter(has_text=workspace_name)
-    card.get_by_role("button", name="More options").click()
-    page.get_by_role("menuitem", name="Delete").click()
 
-    # Confirm deletion in the dialog
-    page.get_by_role("button", name="Delete").click()
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_does_not_see_other_user_workspaces_in_my_workspaces_list(
+    seeded_cluster: dict[str, list[str]], dex_oauth_web_app: WebAppNavigator
+) -> None:
+    """Verify the default 'My Workspaces' view does NOT show other users' workspaces."""
+    other_public = seeded_cluster["seeded"][0]
+    other_private = seeded_cluster["seeded"][1]
+    dex_oauth_web_app.goto_workspace_list()
 
-    # Verify workspace is no longer in the list
-    page.wait_for_timeout(3000)
-    page.reload(wait_until="networkidle", timeout=60000)
-    page.get_by_text(workspace_name).wait_for(state="hidden", timeout=30000)
+    public_card = dex_oauth_web_app.get_workspace_card(other_public)
+    assert not public_card.is_visible(), (
+        f"Other user's public workspace '{other_public}' should NOT be in My Workspaces"
+    )
+
+    private_card = dex_oauth_web_app.get_workspace_card(other_private)
+    assert not private_card.is_visible(), (
+        f"Other user's private workspace '{other_private}' should NOT be in My Workspaces"
+    )
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_can_view_other_user_workspace_detail(
+    seeded_cluster: dict[str, list[str]], dex_oauth_web_app: WebAppNavigator
+) -> None:
+    """Verify the user can navigate to another user's workspace detail page."""
+    other_public = seeded_cluster["seeded"][0]
+    dex_oauth_web_app.goto_workspace_detail(other_public)
+
+    assert dex_oauth_web_app.page.get_by_text(other_public).is_visible()
+
+
+# ── Cross-user access: public workspace ───────────────────────────────────────
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_can_open_other_user_public_workspace(
+    seeded_cluster: dict[str, list[str]], dex_oauth_web_app: WebAppNavigator
+) -> None:
+    """Verify the user can open another user's public workspace and JupyterLab loads."""
+    other_public = seeded_cluster["seeded"][0]
+    dex_oauth_web_app.goto_workspace_list(view_all=True)
+    open_button = dex_oauth_web_app.get_workspace_card_open_button(other_public)
+    assert open_button.is_visible(), f"Expected Open button on public workspace '{other_public}'"
+
+    dex_oauth_web_app.open_workspace_from_card(other_public)
+    dex_oauth_web_app.verify_jupyterlab_loaded()
+
+
+# ── Cross-user access: private workspace ──────────────────────────────────────
+
+
+@skip_if_testvars_not_set(["JD_E2E_USER", "JD_E2E_ORG", "JD_E2E_RBAC_TEAM"])
+def test_user_cannot_open_other_user_private_workspace(
+    seeded_cluster: dict[str, list[str]], dex_oauth_web_app: WebAppNavigator
+) -> None:
+    """Verify the Open button is NOT present on another user's private workspace card."""
+    other_private = seeded_cluster["seeded"][1]
+    dex_oauth_web_app.goto_workspace_list(view_all=True)
+    stop_button = dex_oauth_web_app.get_workspace_card_stop_button(other_private)
+    assert not stop_button.is_visible(), f"Stop button should NOT be visible on private workspace '{other_private}'"

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/plugin.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/plugin.py
@@ -16,6 +16,7 @@ from pytest_jupyter_deploy.oauth2_proxy.ci_credentials import fetch_ci_credentia
 from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
 from pytest_jupyter_deploy.oauth2_proxy.github import GitHubOAuth2ProxyApplication
 from pytest_jupyter_deploy.suite_config import SuiteConfig
+from pytest_jupyter_deploy.workspaces.web_app import WebAppNavigator
 
 # Type variable for function decorators
 F = TypeVar("F", bound=Callable[..., Any])
@@ -354,3 +355,18 @@ def dex_oauth_app(
         ci_password=ci_password,
         ci_totp_fn=ci_totp_fn,
     )
+
+
+@pytest.fixture(scope="function")
+def dex_oauth_web_app(
+    dex_oauth_app: DexGitHubOAuth2ProxyApplication, e2e_deployment: EndToEndDeployment
+) -> WebAppNavigator:
+    """Authenticated WebAppNavigator for templates using Dex OIDC.
+
+    Resolves the web app URL from the template's declared `open_url` value,
+    authenticates via the Dex OAuth flow, and returns a ready-to-use navigator.
+    The oauth_app is passed through so workspace opens can handle auth redirects.
+    """
+    dex_oauth_app.ensure_authenticated()
+    url = e2e_deployment.cli.get_jupyterlab_url()
+    return WebAppNavigator(page=dex_oauth_app.page, base_url=url, oauth_app=dex_oauth_app)

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/kubectl.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/kubectl.py
@@ -76,6 +76,29 @@ def kubectl_patch_workspace(
     return subprocess.run(cmd, capture_output=True, text=True)
 
 
+def kubectl_workspace_exists(name: str, namespace: str = "default") -> bool:
+    """Check if a Workspace CR exists via kubectl."""
+    result = subprocess.run(
+        ["kubectl", "get", "workspace", name, "-n", namespace],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def ensure_workspace_no_longer_exists(name: str, namespace: str = "default", timeout_s: int = 60) -> None:
+    """Poll until a Workspace CR no longer exists.
+
+    Raises AssertionError if the workspace still exists after timeout_s.
+    """
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if not kubectl_workspace_exists(name, namespace):
+            return
+        time.sleep(5)
+    raise AssertionError(f"Workspace '{name}' still exists after {timeout_s}s")
+
+
 def kubectl_get_workspace(
     name: str,
     namespace: str = "default",

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/web_app.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/web_app.py
@@ -1,0 +1,256 @@
+"""Browser-based workspace navigation and CRUD utilities for E2E testing.
+
+Provides reusable Playwright-based interactions for the jupyter-k8s-ui web app,
+including workspace creation, lifecycle management (start/stop/delete), and page
+navigation. Shared across templates that use the same web UI entry point.
+"""
+
+import contextlib
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from playwright.sync_api import Locator, Page
+
+from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
+from pytest_jupyter_deploy.workspaces.kubectl import kubectl_delete_workspace
+
+DEFAULT_NAMESPACE = "default"
+
+
+class WebAppNavigator:
+    """Navigate and interact with the jupyter-k8s-ui web application.
+
+    Wraps common Playwright interactions with the workspace web UI:
+    - Page navigation (list, detail, create, kubectl)
+    - Workspace lifecycle actions (create, stop, start, delete)
+    - Card inspection (locators for buttons/status on workspace cards)
+    """
+
+    def __init__(
+        self,
+        page: Page,
+        base_url: str,
+        namespace: str = DEFAULT_NAMESPACE,
+        oauth_app: DexGitHubOAuth2ProxyApplication | None = None,
+    ) -> None:
+        self.page = page
+        self.base_url = base_url.rstrip("/")
+        self.namespace = namespace
+        self.oauth_app = oauth_app
+
+    # ── Navigation ────────────────────────────────────────────────────────────
+
+    def goto_workspace_list(self, timeout: int = 60000, view_all: bool = False) -> None:
+        """Navigate to the workspace list page and wait for heading.
+
+        With view_all=True, toggles to the "All" filter to show all users' workspaces.
+        """
+        self.page.goto(self.base_url + "/", wait_until="networkidle", timeout=timeout)
+        self.page.get_by_role("heading", name="Workspaces", exact=True).wait_for(state="visible", timeout=30000)
+
+        if view_all:
+            filter_group = self.page.get_by_role("group", name="Filter workspaces")
+            filter_group.get_by_text("All", exact=True).click()
+            self.page.wait_for_timeout(1000)
+
+    def goto_workspace_detail(self, workspace_name: str, timeout: int = 60000) -> None:
+        """Navigate to a workspace's detail page."""
+        self.page.goto(
+            self.base_url + f"/workspace/{workspace_name}",
+            wait_until="networkidle",
+            timeout=timeout,
+        )
+        self.page.get_by_text(workspace_name).wait_for(state="visible", timeout=30000)
+
+    def goto_create_page(self, timeout: int = 60000) -> None:
+        """Navigate to the workspace creation page."""
+        self.page.goto(self.base_url + "/create", wait_until="networkidle", timeout=timeout)
+
+    def goto_kubectl_page(self, timeout: int = 60000) -> None:
+        """Navigate to the kubectl access page."""
+        self.page.goto(self.base_url + "/kubectl", wait_until="networkidle", timeout=timeout)
+
+    # ── Workspace creation ────────────────────────────────────────────────────
+
+    def create_default_workspace(self) -> str:
+        """Create a workspace through the UI and return its auto-generated name.
+
+        Navigates to the create page, reads the auto-generated name, clicks Create,
+        and waits for the workspace to appear on its detail page.
+        """
+        self.goto_create_page()
+
+        name_field = self.page.get_by_label("Name").first
+        name_field.wait_for(state="visible", timeout=30000)
+        workspace_name = name_field.input_value()
+        assert workspace_name != "", "Expected auto-generated workspace name"
+
+        create_button = self.page.get_by_role("button", name="Create Workspace")
+        create_button.click()
+
+        self.page.wait_for_timeout(3000)
+
+        self.goto_workspace_detail(workspace_name)
+        return workspace_name
+
+    @contextmanager
+    def default_workspace(self) -> Generator[str, None, None]:
+        """Create a workspace via the UI and delete it via kubectl on exit.
+
+        Yields the workspace name. Cleanup is best-effort — if the workspace
+        was already deleted (by the test or a creation failure), no error is raised.
+        """
+        name = self.create_default_workspace()
+        try:
+            yield name
+        finally:
+            kubectl_delete_workspace(name, namespace=self.namespace)
+
+    # ── Detail page actions ───────────────────────────────────────────────────
+
+    def get_status_chip(self) -> Locator:
+        """Return the status chip locator on the detail page (MuiChip-filled)."""
+        return self.page.locator(".MuiChip-filled")
+
+    def get_status_chip_text(self) -> str:
+        """Return the text content of the status chip on the detail page."""
+        return self.get_status_chip().inner_text()
+
+    def wait_for_status(self, status: str, timeout: int = 300000) -> None:
+        """Wait for the status chip to show the given text."""
+        self.get_status_chip().filter(has_text=status).wait_for(state="visible", timeout=timeout)
+
+    def wait_for_running(self, timeout: int = 300000) -> None:
+        """Wait for the status chip to show 'Running'."""
+        self.wait_for_status("Running", timeout=timeout)
+
+    def get_open_button(self) -> Locator:
+        """Return the Open button locator on the workspace detail page."""
+        return self.page.get_by_role("button", name="Open")
+
+    def open_workspace_from_details_page(self, timeout: int = 60000) -> None:
+        """Click the Open button on the detail page.
+
+        Captures the new tab, handles workspace auth redirect via oauth_app,
+        then updates the navigator's page to the workspace tab.
+        """
+        open_button = self.get_open_button()
+
+        with self.page.context.expect_page(timeout=timeout) as new_page_info:
+            open_button.click()
+        new_page = new_page_info.value
+        new_page.wait_for_load_state("load", timeout=timeout)
+
+        if self.oauth_app is not None:
+            original_page = self.oauth_app.page
+            self.oauth_app.page = new_page
+            self.oauth_app._wait_for_workspace_auth_redirect()
+            self.oauth_app.page = original_page
+
+        self.page = new_page
+
+    def stop_workspace(self, timeout: int = 180000) -> None:
+        """Click the Stop button on the detail page and confirm.
+
+        Waits for the status chip to show 'Stopped'.
+        """
+        self.page.get_by_role("button", name="Stop").click()
+        self.page.get_by_role("button", name="Confirm").or_(self.page.get_by_role("button", name="Stop")).last.click(
+            timeout=5000
+        )
+        self.wait_for_status("Stopped", timeout=timeout)
+
+    def start_workspace(self, timeout: int = 300000) -> None:
+        """Click the Start button on the detail page.
+
+        Waits for the status chip to show 'Running'.
+        """
+        self.page.get_by_role("button", name="Start").click()
+        self.wait_for_status("Running", timeout=timeout)
+
+    def delete_workspace_from_list(self, workspace_name: str) -> None:
+        """Delete a workspace via the list page's card menu.
+
+        Opens the card's menu, clicks Delete, confirms in the dialog,
+        then waits for the card to be removed from the DOM.
+        """
+        self.goto_workspace_list()
+
+        card = self.get_workspace_card(workspace_name)
+        card.wait_for(state="visible", timeout=30000)
+        card.get_by_role("button", name="More options").click()
+        self.page.get_by_role("menuitem", name="Delete").click()
+
+        # Confirm in the delete dialog
+        dialog = self.page.locator(".MuiDialog-paper")
+        dialog.wait_for(state="visible", timeout=10000)
+        dialog.get_by_role("button", name="Delete").click()
+
+        # Wait for the card to be removed from the DOM
+        card.wait_for(state="detached", timeout=30000)
+
+    # ── Post-navigation verification ────────────────────────────────────────────
+
+    def verify_jupyterlab_loaded(self, timeout: int = 120000) -> None:
+        """Assert that JupyterLab has loaded on the current page.
+
+        Handles the workspace auth redirect chain (/auth → OAuth → workspace).
+        Waits for the URL to leave the /auth path, then checks for JupyterLab DOM.
+        """
+
+        # Wait for /auth redirect to complete (if navigating through workspace proxy)
+        with contextlib.suppress(Exception):
+            if "/auth" in self.page.url:
+                self.page.wait_for_url(lambda url: "/auth" not in url, timeout=60000)
+
+        jupyterlab = self.page.locator("#jp-top-panel, #jp-main-dock-panel, #jp-main-content-panel")
+        jupyterlab.first.wait_for(state="attached", timeout=timeout)
+        assert jupyterlab.first.is_visible(timeout=30000), "Expected JupyterLab UI to be visible"
+
+    # ── Card inspection (workspace list page) ─────────────────────────────────
+
+    def get_workspace_card(self, workspace_name: str) -> Locator:
+        """Return the card locator for a workspace on the list page.
+
+        Uses has= with an exact text match to avoid substring collisions
+        between similarly-named workspaces. Caller must already be on the list page.
+        """
+        return self.page.locator(".MuiCard-root").filter(has=self.page.get_by_text(workspace_name, exact=True))
+
+    def get_workspace_card_open_button(self, workspace_name: str) -> Locator:
+        """Return the Open button locator on a workspace card."""
+        card = self.get_workspace_card(workspace_name)
+        return card.get_by_role("button", name="Open")
+
+    def get_workspace_card_stop_button(self, workspace_name: str) -> Locator:
+        """Return the Stop button locator on a workspace card."""
+        card = self.get_workspace_card(workspace_name)
+        return card.get_by_role("button", name="Stop")
+
+    def get_workspace_card_start_button(self, workspace_name: str) -> Locator:
+        """Return the Start button locator on a workspace card."""
+        card = self.get_workspace_card(workspace_name)
+        return card.get_by_role("button", name="Start")
+
+    def open_workspace_from_card(self, workspace_name: str, timeout: int = 60000) -> None:
+        """Click the Open button on a workspace card.
+
+        If the button opens a new tab, captures it and handles the workspace
+        auth redirect via the oauth_app (if provided). After completion the
+        navigator's page points to the workspace tab.
+        """
+        open_button = self.get_workspace_card_open_button(workspace_name)
+
+        with self.page.context.expect_page(timeout=timeout) as new_page_info:
+            open_button.click()
+        new_page = new_page_info.value
+        new_page.wait_for_load_state("load", timeout=timeout)
+
+        # Handle workspace auth redirect on the new tab
+        if self.oauth_app is not None:
+            original_page = self.oauth_app.page
+            self.oauth_app.page = new_page
+            self.oauth_app._wait_for_workspace_auth_redirect()
+            self.oauth_app.page = original_page
+
+        self.page = new_page

--- a/scripts/ci_helpers.py
+++ b/scripts/ci_helpers.py
@@ -104,6 +104,24 @@ def put_secret_value(arn: str, value: str) -> None:
     client.put_secret_value(SecretId=arn, SecretString=value)
 
 
+def is_project_deployed(project_dir: str) -> bool:
+    """Check if a project has live infrastructure (non-empty terraform state).
+
+    Runs `jd show --outputs --list` and returns True if any outputs are present.
+    A project with empty state (e.g. destroyed but still in S3) returns False.
+    """
+    result = subprocess.run(
+        ["uv", "run", "jd", "show", "--outputs", "--list", "--text", "-p", project_dir],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=JD_TIMEOUT_SECONDS,
+    )
+    if result.returncode != 0:
+        return False
+    return bool(result.stdout.strip())
+
+
 def run_jd_config(config_args: list[str], project_dir: str, check: bool = True) -> bool:
     """Run jd config with the given arguments in a project directory.
 

--- a/scripts/ci_restore_base.py
+++ b/scripts/ci_restore_base.py
@@ -21,7 +21,7 @@ import sys
 from pathlib import Path
 from urllib.parse import urlparse
 
-from ci_helpers import run_jd, run_jd_config
+from ci_helpers import is_project_deployed, run_jd, run_jd_config
 
 
 def get_subdomain_from_ci(ci_dir: str, oauth_app_num: str) -> str:
@@ -130,6 +130,18 @@ def main() -> None:
     print(f"  Found project: {project_id}")
 
     restore_project(project_id, project_dir)
+
+    if not is_project_deployed(str(project_dir)):
+        print(
+            f"\nError: Project '{project_id}' exists in the S3 store but has no live infrastructure.",
+            file=sys.stderr,
+        )
+        print(
+            "Run the fresh deploy workflow to recreate it, or delete the stale entry with:\n"
+            f"  uv run jd projects delete {project_id} --store-type s3-only -y",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     print()
     print("Restoring secrets from cloud provider...")

--- a/scripts/ci_restore_eks.py
+++ b/scripts/ci_restore_eks.py
@@ -19,7 +19,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from ci_helpers import run_jd, run_jd_config
+from ci_helpers import is_project_deployed, run_jd, run_jd_config
 from ci_restore_base import get_subdomain_from_ci, list_project_ids
 
 
@@ -96,6 +96,18 @@ def main() -> None:
     print(f"  Found project: {project_id}")
 
     restore_project(project_id, project_dir)
+
+    if not is_project_deployed(str(project_dir)):
+        print(
+            f"\nError: Project '{project_id}' exists in the S3 store but has no live infrastructure.",
+            file=sys.stderr,
+        )
+        print(
+            "Run the fresh deploy workflow to recreate it, or delete the stale entry with:\n"
+            f"  uv run jd projects delete {project_id} --store-type s3-only -y",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     print()
     print("Restoring secrets from cloud provider...")

--- a/scripts/find_takedown_base.py
+++ b/scripts/find_takedown_base.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from ci_helpers import is_project_deployed
 from ci_restore_base import (
     find_project_by_subdomain,
     get_subdomain_from_ci,
@@ -72,6 +73,12 @@ def main() -> None:
     print(f"  Found project: {project_id}")
 
     restore_project(project_id, project_dir)
+
+    if not is_project_deployed(str(project_dir)):
+        print(f"  Project {project_id} has no live infrastructure (empty state) — skipping jd down.")
+        delete_project_from_store(project_id)
+        print(f"\nStale project {project_id} deleted from store (subdomain: {subdomain})")
+        return
 
     # Takedown uses destroy.tfvars and never reads the restored secret value, so a
     # missing secret (e.g. a prior destroy was interrupted after deleting it) must

--- a/scripts/find_takedown_eks.py
+++ b/scripts/find_takedown_eks.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from ci_helpers import is_project_deployed
 from ci_restore_base import get_subdomain_from_ci
 from ci_restore_eks import find_eks_project_by_subdomain, restore_project, restore_secrets
 from jupyter_deploy.cmd_utils import run_cmd_and_pipe_to_terminal
@@ -68,6 +69,12 @@ def main() -> None:
     print(f"  Found project: {project_id}")
 
     restore_project(project_id, project_dir)
+
+    if not is_project_deployed(str(project_dir)):
+        print(f"  Project {project_id} has no live infrastructure (empty state) — skipping jd down.")
+        delete_project_from_store(project_id)
+        print(f"\nStale project {project_id} deleted from store (subdomain: {subdomain})")
+        return
 
     # Takedown uses destroy.tfvars and never reads the restored secret value, so a
     # missing secret (e.g. a prior destroy was interrupted after deleting it) must


### PR DESCRIPTION
This PR a/ hardens release and image build against `test-pypi` ultimate consistency race conditions, b/ hardens against projects taken down (`state=<empty>`) but kept in store, c/ improve web-app e2e tests

Closes: #251
Closes: #252
Closes: #246

### Implementation (web-app tests)
- create a reusable fixture: `dex_oauth_web_app` which provides an instance of `WebAppNavigator`
- use the `WebAppNavigator` instance to handle most UI flows -> benefit, we only need to update the tests in the plugin and reuse in multiple templates

### Test coverage
- create default workspace, verify transition Starting > Running, verify can open JupyterLab
- can stop, restart own workspace and then open JupyterLab
- can discover other users' workspaces
- can open other users' public workspaces
- cannot open other users' private workspaces

### Testing
- ran `test_web_app` E2E tests