### PR TITLE
fix: harden state machine

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/variables.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/variables.yaml
@@ -1,7 +1,7 @@
-schema_version: 1
+schema_version: 2
+
 required:
-  # either assign values below
-  # or run 'jd config' to use the interactive experience
+  # fill in values below, or run 'jd config' for the interactive experience
   domain: null
   letsencrypt_email: null
   oauth_app_client_id: null
@@ -9,34 +9,30 @@ required:
   oauth_allowed_teams: null
   oauth_allowed_usernames: null
   subdomain: null
+
 required_sensitive:
-  # either assign values below
-  # or run 'jd config' to use the interactive experience
+  # fill in values below, or run 'jd config' for the interactive experience
   # values entered here will be masked after running 'jd config'
   oauth_app_client_secret: null
+
 overrides:
-  # set variable values as <variable-name>: <variable-value>
-  # delete or comment out a line to use the default
-  # instance_type: t3.large
-defaults:
-  # read-only: do not modify this section
-  # instead add overrides in the override section
-  ami_id: null
-  custom_tags: {}
-  iam_role_prefix: Jupyter-deploy-ec2-base
-  instance_type: t3.medium
-  jupyter_package_manager: uv
-  key_pair_name: null
-  log_files_retention_count: 10
-  log_files_retention_days: 180
-  log_files_rotation_size_mb: 50
-  oauth_provider: github
-  oauth_app_secret_prefix: Jupyter-deploy-ec2-base
-  s3_bucket_prefix: jupyter-deploy-ec2-base
-  certs_secret_prefix: Jupyter-deploy-ec2-base
-  region: us-west-2
-  min_root_volume_size_gb: 30
-  volume_size_gb: 30
-  volume_type: gp3
-  additional_ebs_mounts: []
-  additional_efs_mounts: []
+  # uncomment and change a value to override the default
+  # ami_id: null
+  # custom_tags: {}
+  # iam_role_prefix: Jupyter-deploy-ec2-base
+  # instance_type: t3.medium
+  # jupyter_package_manager: uv
+  # key_pair_name: null
+  # log_files_retention_count: 10
+  # log_files_retention_days: 180
+  # log_files_rotation_size_mb: 50
+  # oauth_provider: github
+  # oauth_app_secret_prefix: Jupyter-deploy-ec2-base
+  # s3_bucket_prefix: jupyter-deploy-ec2-base
+  # certs_secret_prefix: Jupyter-deploy-ec2-base
+  # region: us-west-2
+  # min_root_volume_size_gb: 30
+  # volume_size_gb: 30
+  # volume_type: gp3
+  # additional_ebs_mounts: []
+  # additional_efs_mounts: []

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/configurations/base.yaml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/configurations/base.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 required:
   domain: "${JD_E2E_VAR_DOMAIN}"
   letsencrypt_email: "${JD_E2E_VAR_EMAIL}"
@@ -10,29 +10,4 @@ required:
   subdomain: "${JD_E2E_VAR_SUBDOMAIN}"
 required_sensitive:
   oauth_app_client_secret: "${JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET}"
-overrides:
-  # set variable values as <variable-name>: <variable-value>
-  # delete or comment out a line to use the default
-  # instance_type: t3.large
-defaults:
-  # read-only: do not modify this section
-  # instead add overrides in the override section
-  ami_id: null
-  custom_tags: {}
-  iam_role_prefix: Jupyter-deploy-ec2-base
-  instance_type: t3.medium
-  jupyter_package_manager: uv
-  key_pair_name: null
-  log_files_retention_count: 10
-  log_files_retention_days: 180
-  log_files_rotation_size_mb: 50
-  oauth_provider: github
-  oauth_app_secret_prefix: Jupyter-deploy-ec2-base
-  s3_bucket_prefix: jupyter-deploy-ec2-base
-  certs_secret_prefix: Jupyter-deploy-ec2-base
-  region: us-west-2
-  min_root_volume_size_gb: 30
-  volume_size_gb: 30
-  volume_type: gp3
-  additional_ebs_mounts: []
-  additional_efs_mounts: []
+overrides: {}

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_backward_compatibility.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_backward_compatibility.py
@@ -1,0 +1,58 @@
+"""E2E tests for variables.yaml backward compatibility (v1 → v2 migration)."""
+
+import pytest
+import yaml
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+from pytest_jupyter_deploy.undeployed_project import undeployed_project
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(
+    [
+        "JD_E2E_VAR_DOMAIN",
+        "JD_E2E_VAR_EMAIL",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+        "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES",
+        "JD_E2E_VAR_SUBDOMAIN",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    ]
+)
+def test_variables_yaml_v1_still_readable_but_produces_v2(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify that jd config reads a v1 variables.yaml and upgrades it to v2 on write.
+
+    Flow:
+    1. Initialize a project (produces v2)
+    2. Overwrite variables.yaml with a valid v1-format file
+    3. Run `jd config` — should succeed
+    4. Verify the resulting variables.yaml is v2 (no `defaults` section)
+    """
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        # Prepare a valid configuration, then downgrade to v1
+        e2e_deployment.suite_config.prepare_configuration("base", target_dir=project_path)
+
+        variables_path = project_path / "variables.yaml"
+        with open(variables_path) as f:
+            config = yaml.safe_load(f)
+
+        v1_config = {
+            "schema_version": 1,
+            "required": config.get("required", {}),
+            "required_sensitive": config.get("required_sensitive", {}),
+            "overrides": config.get("overrides", {}),
+            "defaults": {"instance_type": "t3.medium", "region": "us-west-2"},
+        }
+        with open(variables_path, "w") as f:
+            yaml.dump(v1_config, f, sort_keys=False)
+
+        # Run jd config on the v1 file — should succeed and upgrade
+        result = cli.run_command(["jupyter-deploy", "config"])
+        assert "Your project is ready" in result.stdout
+
+        # Verify the file is now v2
+        with open(variables_path) as f:
+            upgraded = yaml.safe_load(f)
+        assert upgraded["schema_version"] == 2, f"Expected schema_version 2, got {upgraded['schema_version']}"
+        assert "defaults" not in upgraded, "v2 should not have a 'defaults' section"
+        assert "overrides" in upgraded

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_interactive.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_config_interactive.py
@@ -5,6 +5,7 @@ import os
 
 import pexpect
 import pytest
+import yaml
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 from pytest_jupyter_deploy.undeployed_project import undeployed_project
@@ -275,3 +276,56 @@ def test_config_interactive_verbose(e2e_deployment: EndToEndDeployment) -> None:
         assert users_list == expected_users, (
             f"Expected oauth_allowed_usernames to be {expected_users}, got {users_list}"
         )
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(REQUIRED_DEPLOYMENT_VARS)
+def test_config_interactive_error_recovery(e2e_deployment: EndToEndDeployment) -> None:
+    """Test that after a failed config, setting the bad value to null re-prompts only that variable.
+
+    Flow:
+    1. Set up variables.yaml with all correct values except subdomain (invalid)
+    2. Run `jd config` — fails due to subdomain validation
+    3. Set subdomain to null in variables.yaml (user signals "I want to re-enter this")
+    4. Run `jd config` again — terraform prompts ONLY for subdomain
+    5. Provide the correct value — config succeeds
+    """
+    subdomain = os.environ["JD_E2E_VAR_SUBDOMAIN"]
+    invalid_subdomain = "bad_subdomain"
+
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        # Prepare a valid configuration, then inject the bad subdomain
+        e2e_deployment.suite_config.prepare_configuration("base", target_dir=project_path)
+
+        variables_path = project_path / "variables.yaml"
+        with open(variables_path) as f:
+            config = yaml.safe_load(f)
+        config["required"]["subdomain"] = invalid_subdomain
+        with open(variables_path, "w") as f:
+            yaml.dump(config, f, sort_keys=False)
+
+        # --- First run: should fail due to subdomain validation ---
+        with cli.spawn_interactive_session("jupyter-deploy config", timeout=120) as session:
+            session.expect(pexpect.EOF, timeout=90)
+            session.close()
+            assert session.exitstatus != 0, "Expected config to fail with invalid subdomain"
+
+        # --- Set the bad subdomain to null to trigger a re-prompt ---
+        with open(variables_path) as f:
+            config = yaml.safe_load(f)
+        config["required"]["subdomain"] = None
+        with open(variables_path, "w") as f:
+            yaml.dump(config, f, sort_keys=False)
+
+        # --- Second run: only subdomain should be prompted ---
+        # All other values are set in variables.yaml and synced to .tfvars.
+        # Terraform only prompts for variables with no value — just subdomain.
+        with cli.spawn_interactive_session("jupyter-deploy config", timeout=120) as session:
+            session.expect(r"var\.subdomain", timeout=60)
+            session.sendline(subdomain)
+
+            session.expect(pexpect.EOF, timeout=90)
+            session.close()
+            assert session.exitstatus == 0, (
+                f"Expected config to succeed after fixing subdomain, got exit {session.exitstatus}"
+            )

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_configuration.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_configuration.py
@@ -1,10 +1,12 @@
 """E2E tests for project configuration validation."""
 
+import os
 import re
 import subprocess
 
 import pytest
 import yaml
+from pytest_jupyter_deploy.cli import JDCliError
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 from pytest_jupyter_deploy.undeployed_project import undeployed_project
@@ -392,3 +394,116 @@ def test_config_with_stale_store_id_fails_with_hint_and_reset_recovers(
             f"Expected same store to be rediscovered. Initial: '{initial_store_id}', "
             f"After reset: '{recovered_store_id}'"
         )
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(
+    [
+        "JD_E2E_VAR_DOMAIN",
+        "JD_E2E_VAR_EMAIL",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+        "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES",
+        "JD_E2E_VAR_SUBDOMAIN",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    ]
+)
+def test_config_error_recovery_with_variable_fix(e2e_deployment: EndToEndDeployment) -> None:
+    """Test error recovery: bad override value fails plan, fix via variables.yaml succeeds.
+
+    Flow:
+    1. Configure with valid required values + an invalid additional_efs_mounts override
+    2. `jd config` fails (terraform validation rejects the bad EFS mount)
+    3. Fix the override directly in variables.yaml
+    4. Run `jd config` again — succeeds without re-entering any values
+    """
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        # Prepare valid configuration
+        e2e_deployment.suite_config.prepare_configuration("base", target_dir=project_path)
+
+        # Inject a bad additional_efs_mounts override (missing both 'name' and 'id')
+        variables_path = project_path / "variables.yaml"
+        with open(variables_path) as f:
+            config = yaml.safe_load(f)
+
+        config["overrides"] = config.get("overrides") or {}
+        config["overrides"]["additional_efs_mounts"] = [{"invalid_key": "bad-value", "mount_point": "test-efs"}]
+        with open(variables_path, "w") as f:
+            yaml.dump(config, f, sort_keys=False)
+
+        # --- First run: should fail due to EFS mount validation ---
+        with pytest.raises(JDCliError) as exc_info:
+            cli.run_command(["jupyter-deploy", "config"])
+
+        assert "name" in str(exc_info.value).lower() or "id" in str(exc_info.value).lower(), (
+            f"Expected validation error about 'name' or 'id', got: {exc_info.value}"
+        )
+
+        # --- Fix the override directly in variables.yaml ---
+        with open(variables_path) as f:
+            config = yaml.safe_load(f)
+
+        config["overrides"]["additional_efs_mounts"] = [{"name": "test-efs", "mount_point": "test-efs"}]
+        with open(variables_path, "w") as f:
+            yaml.dump(config, f, sort_keys=False)
+
+        # --- Second run: should succeed without prompting ---
+        # All values are preserved in variables.yaml; only the bad override was fixed.
+        result = cli.run_command(["jupyter-deploy", "config"])
+        assert "Your project is ready" in result.stdout
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(
+    [
+        "JD_E2E_VAR_DOMAIN",
+        "JD_E2E_VAR_EMAIL",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+        "JD_E2E_VAR_OAUTH_ALLOWED_USERNAMES",
+        "JD_E2E_VAR_SUBDOMAIN",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    ]
+)
+def test_config_error_recovery_with_cli_variable_fix(e2e_deployment: EndToEndDeployment) -> None:
+    """Test error recovery: invalid domain fails plan, fix via --domain flag succeeds.
+
+    Flow:
+    1. Configure with an invalid domain (contains underscore)
+    2. `jd config` fails (terraform validation rejects the domain)
+    3. Re-run `jd config --domain CORRECT-DOMAIN` — the CLI flag persists the fix
+       to variables.yaml before plan, and plan succeeds
+    """
+    domain = os.environ["JD_E2E_VAR_DOMAIN"]
+    invalid_domain = "bad_domain.com"
+
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        # Prepare valid configuration, then inject the bad domain
+        e2e_deployment.suite_config.prepare_configuration("base", target_dir=project_path)
+
+        variables_path = project_path / "variables.yaml"
+        with open(variables_path) as f:
+            config = yaml.safe_load(f)
+        config["required"]["domain"] = invalid_domain
+        with open(variables_path, "w") as f:
+            yaml.dump(config, f, sort_keys=False)
+
+        # --- First run: should fail due to domain validation ---
+        with pytest.raises(JDCliError):
+            cli.run_command(["jupyter-deploy", "config"])
+
+        # Verify the bad domain is persisted in variables.yaml (not lost)
+        with open(variables_path) as f:
+            config_after_fail = yaml.safe_load(f)
+        assert config_after_fail["required"]["domain"] == invalid_domain
+
+        # --- Second run: fix via CLI --domain flag ---
+        # The --domain flag writes the correct value to variables.yaml before plan,
+        # so even if we don't manually edit the file, the fix is applied.
+        result = cli.run_command(["jupyter-deploy", "config", "--domain", domain])
+        assert "Your project is ready" in result.stdout
+
+        # Verify the fixed domain is now in variables.yaml
+        with open(variables_path) as f:
+            config_after_fix = yaml.safe_load(f)
+        assert config_after_fix["required"]["domain"] == domain

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_variables_yaml.py
@@ -139,3 +139,72 @@ class TestVariablesYaml(unittest.TestCase):
 
         overlap = required_vars.intersection(preset_vars)
         self.assertEqual(len(overlap), 0, f"Required variables should not have defaults in preset: {overlap}")
+
+    def test_commented_overrides_match_preset_keys(self) -> None:
+        """All commented-out overrides in variables.yaml should exist in the preset."""
+        commented_vars = self._parse_commented_overrides()
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        missing = set(commented_vars.keys()) - preset_vars
+        self.assertEqual(len(missing), 0, f"Commented overrides not found in preset: {missing}")
+
+    def test_commented_overrides_values_match_preset(self) -> None:
+        """Commented-out override values should match the preset defaults."""
+        commented_vars = self._parse_commented_overrides()
+
+        for var_name, var_value in commented_vars.items():
+            if var_name not in self.DEFAULTS_ALL_TFVARS:
+                continue
+            preset_value = self.DEFAULTS_ALL_TFVARS[var_name]
+            self.assertEqual(
+                var_value,
+                preset_value,
+                f"Commented override '{var_name}' has value {var_value!r} "
+                f"but preset has {preset_value!r}",
+            )
+
+    def test_all_preset_vars_appear_as_commented_overrides(self) -> None:
+        """Every variable in the preset should appear as a commented override in variables.yaml."""
+        commented_vars = self._parse_commented_overrides()
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        missing = preset_vars - set(commented_vars.keys())
+        self.assertEqual(
+            len(missing), 0, f"Preset variables missing from commented overrides: {missing}"
+        )
+
+    @classmethod
+    def _parse_commented_overrides(cls) -> dict:
+        """Parse commented-out key-value pairs from the overrides section of variables.yaml.
+
+        Handles multi-line values (lists, maps) by preserving indentation
+        relative to the `# ` prefix.
+        """
+        with open(cls.VARIABLES_CONFIG_PATH) as f:
+            lines = f.readlines()
+
+        # Find the overrides section and extract commented entries
+        in_overrides = False
+        commented_yaml_lines: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("overrides:"):
+                in_overrides = True
+                continue
+            if in_overrides and not stripped.startswith("#") and stripped:
+                # Hit a non-comment, non-empty line — check if it's a new top-level section
+                if not line.startswith(" "):
+                    break
+            if in_overrides and stripped.startswith("# "):
+                # Skip header comments (no colon or starts with a known header phrase)
+                content_after_hash = stripped[2:]
+                if content_after_hash.startswith("uncomment"):
+                    continue
+                commented_yaml_lines.append(content_after_hash)
+
+        if not commented_yaml_lines:
+            return {}
+
+        combined = "\n".join(commented_yaml_lines)
+        result = yaml.safe_load(combined)
+        return result if isinstance(result, dict) else {}

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_variables_yaml.py
@@ -159,8 +159,7 @@ class TestVariablesYaml(unittest.TestCase):
             self.assertEqual(
                 var_value,
                 preset_value,
-                f"Commented override '{var_name}' has value {var_value!r} "
-                f"but preset has {preset_value!r}",
+                f"Commented override '{var_name}' has value {var_value!r} but preset has {preset_value!r}",
             )
 
     def test_all_preset_vars_appear_as_commented_overrides(self) -> None:
@@ -169,9 +168,7 @@ class TestVariablesYaml(unittest.TestCase):
         preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
 
         missing = preset_vars - set(commented_vars.keys())
-        self.assertEqual(
-            len(missing), 0, f"Preset variables missing from commented overrides: {missing}"
-        )
+        self.assertEqual(len(missing), 0, f"Preset variables missing from commented overrides: {missing}")
 
     @classmethod
     def _parse_commented_overrides(cls) -> dict:
@@ -191,10 +188,8 @@ class TestVariablesYaml(unittest.TestCase):
             if stripped.startswith("overrides:"):
                 in_overrides = True
                 continue
-            if in_overrides and not stripped.startswith("#") and stripped:
-                # Hit a non-comment, non-empty line — check if it's a new top-level section
-                if not line.startswith(" "):
-                    break
+            if in_overrides and not stripped.startswith("#") and stripped and not line.startswith(" "):
+                break
             if in_overrides and stripped.startswith("# "):
                 # Skip header comments (no colon or starts with a known header phrase)
                 content_after_hash = stripped[2:]

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/unit/test_variables_yaml.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import hcl2  # type: ignore[import-untyped]
 import yaml
 from jupyter_deploy.engine.terraform.tf_varfiles import strip_hcl2_quotes
-from jupyter_deploy.handlers import base_project_handler
 
 from jupyter_deploy_tf_aws_ec2_base.template import TEMPLATE_PATH
 
@@ -47,31 +46,22 @@ class TestVariablesYaml(unittest.TestCase):
 
             TestVariablesYaml.TF_VARIABLES = tf_variables
 
+    def test_schema_version_is_2(self) -> None:
+        self.assertEqual(self.VARIABLES_CONFIG["schema_version"], 2)
+
     def test_all_keys_are_present(self) -> None:
         self.assertIn("required", self.VARIABLES_CONFIG)
         self.assertIn("required_sensitive", self.VARIABLES_CONFIG)
         self.assertIn("overrides", self.VARIABLES_CONFIG)
-        self.assertIn("defaults", self.VARIABLES_CONFIG)
+
+    def test_no_defaults_section(self) -> None:
+        self.assertNotIn("defaults", self.VARIABLES_CONFIG)
 
     def test_no_overlap_between_required_and_required_sensitive(self) -> None:
         required_vars = set(self.VARIABLES_CONFIG["required"].keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG["required_sensitive"].keys())
 
         overlap = required_vars.intersection(required_sensitive_vars)
-        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
-
-    def test_no_overlap_between_required_and_defaults(self) -> None:
-        required_vars = set(self.VARIABLES_CONFIG["required"].keys())
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-
-        overlap = required_vars.intersection(default_vars)
-        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
-
-    def test_no_overlap_between_required_sensitive_and_defaults(self) -> None:
-        required_sensitive_vars = set(self.VARIABLES_CONFIG["required_sensitive"].keys())
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-
-        overlap = required_sensitive_vars.intersection(default_vars)
         self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
 
     def test_all_required_set_to_none(self) -> None:
@@ -83,152 +73,69 @@ class TestVariablesYaml(unittest.TestCase):
             self.assertIsNone(var_value, f"Required sensitive variable {var_name} is not set to None")
 
     def test_no_overrides_set(self) -> None:
-        # The overrides section should be empty dictionary or have only commented lines
         overrides = self.VARIABLES_CONFIG["overrides"]
         self.assertTrue(
             overrides is None or len(overrides) == 0,
             f"Overrides should be empty in default variables.yaml, found: {overrides}",
         )
 
-    def test_all_defaults_varname_exist_in_all_preset(self) -> None:
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
-
-        missing_vars = default_vars - preset_vars
-        self.assertEqual(
-            len(missing_vars), 0, f"Variables in defaults section not found in defaults-all.tfvars: {missing_vars}"
-        )
-
-    def test_defaults_varname_count_equal_varnames_in_all_preset(self) -> None:
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
-
-        self.assertEqual(
-            len(default_vars),
-            len(preset_vars),
-            f"Number of variables in defaults ({len(default_vars)}) does not match "
-            f"number in defaults-all.tfvars ({len(preset_vars)})",
-        )
-
-    def test_all_values_in_defaults_match_preset(self) -> None:
-        for var_name, var_value in self.VARIABLES_CONFIG["defaults"].items():
-            # Special case for empty dictionaries or lists that might be represented differently
-            if var_value == {}:
-                self.assertIn(var_name, self.DEFAULTS_ALL_TFVARS)
-                self.assertEqual(
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    {},
-                    f"Value mismatch for {var_name}: variables.yaml has {var_value}, "
-                    f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                )
-            elif var_value == []:
-                self.assertIn(var_name, self.DEFAULTS_ALL_TFVARS)
-                self.assertEqual(
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    [],
-                    f"Value mismatch for {var_name}: variables.yaml has {var_value}, "
-                    f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                )
-            else:
-                # For values that should match exactly between the two files
-                self.assertIn(var_name, self.DEFAULTS_ALL_TFVARS)
-
-                # Handle null vs None comparison
-                if var_value is None:
-                    self.assertIsNone(
-                        self.DEFAULTS_ALL_TFVARS[var_name],
-                        f"Value mismatch for {var_name}: variables.yaml has None, "
-                        f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                    )
-                else:
-                    self.assertEqual(
-                        var_value,
-                        self.DEFAULTS_ALL_TFVARS[var_name],
-                        f"Value mismatch for {var_name}: variables.yaml has {var_value}, "
-                        f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                    )
-
     def test_all_variables_in_yaml_exist_in_tf(self) -> None:
         """Test that all variables referenced in variables.yaml exist in variables.tf"""
-        # Collect all variable names from variables.yaml
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
 
-        # Combine all variable names from variables.yaml
-        all_yaml_vars = required_vars.union(required_sensitive_vars).union(defaults_vars)
+        all_yaml_vars = required_vars.union(required_sensitive_vars)
 
-        # Get all variable names from variables.tf
         all_tf_vars = set(self.TF_VARIABLES.keys())
 
-        # Check if any variables in variables.yaml are missing from variables.tf
         missing_vars = all_yaml_vars - all_tf_vars
         self.assertEqual(len(missing_vars), 0, f"Variables in variables.yaml not found in variables.tf: {missing_vars}")
 
-    def test_all_variables_in_tf_are_referenced_in_yaml(self) -> None:
-        """Test that all variables in variables.tf are referenced in variables.yaml"""
-        # Collect all variable names from variables.yaml
+    def test_all_variables_in_tf_are_referenced_in_yaml_or_preset(self) -> None:
+        """Test that all variables in variables.tf are covered by either variables.yaml or the preset."""
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
 
-        # Combine all variable names from variables.yaml
-        all_yaml_vars = required_vars.union(required_sensitive_vars).union(defaults_vars)
+        all_covered_vars = required_vars.union(required_sensitive_vars).union(preset_vars)
 
-        # Get all variable names from variables.tf
         all_tf_vars = set(self.TF_VARIABLES.keys())
 
-        # Check if any variables in variables.tf are missing from variables.yaml
-        missing_vars = all_tf_vars - all_yaml_vars
+        missing_vars = all_tf_vars - all_covered_vars
         self.assertEqual(
-            len(missing_vars), 0, f"Variables in variables.tf not referenced in variables.yaml: {missing_vars}"
+            len(missing_vars),
+            0,
+            f"Variables in variables.tf not referenced in variables.yaml or preset: {missing_vars}",
         )
 
-    def test_sensitive_variables_not_in_required_or_defaults(self) -> None:
-        """Test that no variables flagged as sensitive in variables.tf are referenced in required or defaults"""
-        # Get all sensitive variables from variables.tf
+    def test_sensitive_variables_not_in_required(self) -> None:
+        """Test that no variables flagged as sensitive in variables.tf are in the required section."""
         sensitive_vars = set()
         for var_name, var_config in self.TF_VARIABLES.items():
             if var_config.get("sensitive") is True:
                 sensitive_vars.add(var_name)
 
-        # Get variables from required and defaults
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
 
-        # Check if any sensitive variables appear in required or defaults
-        sensitive_in_required = sensitive_vars.intersection(required_vars)
-        sensitive_in_defaults = sensitive_vars.intersection(defaults_vars)
+        overlap = sensitive_vars.intersection(required_vars)
+        self.assertEqual(len(overlap), 0, f"Sensitive variables should not be in 'required' section: {overlap}")
 
-        self.assertEqual(
-            len(sensitive_in_required), 0, f"Sensitive variables found in 'required' section: {sensitive_in_required}"
-        )
-
-        self.assertEqual(
-            len(sensitive_in_defaults), 0, f"Sensitive variables found in 'defaults' section: {sensitive_in_defaults}"
-        )
-
-    def test_required_sensitive_variables_are_marked_sensitive_in_tf(self) -> None:
-        """Test that all variables in required_sensitive are marked as sensitive in variables.tf"""
-        # Get all sensitive variables from variables.tf
+    def test_sensitive_variables_in_required_sensitive(self) -> None:
+        """Test that all variables flagged as sensitive in variables.tf are in required_sensitive."""
         sensitive_vars = set()
         for var_name, var_config in self.TF_VARIABLES.items():
             if var_config.get("sensitive") is True:
                 sensitive_vars.add(var_name)
 
-        # Get variables from required_sensitive
         required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
 
-        # Check if all required_sensitive variables are marked as sensitive in variables.tf
-        not_marked_sensitive = required_sensitive_vars - sensitive_vars
+        missing = sensitive_vars - required_sensitive_vars
+        self.assertEqual(len(missing), 0, f"Sensitive variables missing from required_sensitive: {missing}")
 
-        self.assertEqual(
-            len(not_marked_sensitive),
-            0,
-            f"Variables in 'required_sensitive' not marked as sensitive in variables.tf: {not_marked_sensitive}",
-        )
+    def test_no_overlap_between_required_and_preset(self) -> None:
+        """Required variables should not also have defaults in the preset."""
+        required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
 
-    def test_variables_file_parsable_by_base_project_handler(self) -> None:
-        """Test that the variables.yaml file can be parsed by the base project handler."""
-        variables_config = base_project_handler.retrieve_variables_config(self.VARIABLES_CONFIG_PATH)
-        self.assertIsNotNone(variables_config)
+        overlap = required_vars.intersection(preset_vars)
+        self.assertEqual(len(overlap), 0, f"Required variables should not have defaults in preset: {overlap}")

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
@@ -1,54 +1,60 @@
-schema_version: 1
+schema_version: 2
+
 required:
+  # fill in values below, or run 'jd config' for the interactive experience
   domain: null
   subdomain: null
   letsencrypt_email: null
   oauth_app_client_id: null
   oauth_allowed_teams: null
+
 required_sensitive:
+  # fill in values below, or run 'jd config' for the interactive experience
+  # values entered here will be masked after running 'jd config'
   oauth_app_client_secret: null
-overrides: {}
-defaults:
-  cluster_name_prefix: jupyter-deploy-eks
-  region: us-west-2
-  kubernetes_version: "1.35"
-  node_groups:
-    - name: components
-      role: components
-      instance_type: t3.medium
-      ami_type: default
-      disk_size_gb: "50"
-      min_size: "1"
-      max_size: "3"
-      desired_size: "2"
-    - name: workspaces
-      role: workspaces
-      instance_type: c5.2xlarge
-      ami_type: default
-      disk_size_gb: "50"
-      min_size: "1"
-      max_size: "5"
-      desired_size: "1"
-  workspace_rbac_namespaces:
-    - default
-  admin_role_names:
-    - Admin
-  cluster_log_retention_days: 30
-  custom_tags: {}
-  workspace_operator_namespace: jupyter-k8s-system
-  workspace_router_namespace: jupyter-k8s-router
-  workspace_shared_namespace: jupyter-k8s-shared
-  workspace_operator_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s
-  workspace_operator_chart_version: "0.1.1"
-  workspace_router_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc
-  workspace_router_chart_version: "0.1.0-rc.6"
-  traefik_crd_chart_version: "1.15.0"
-  workspaces_default_access_type: OwnerOnly
-  workspaces_default_ownership_type: OwnerOnly
-  workspaces_idle_shutdown_enabled: true
-  workspaces_idle_shutdown_timeout_default: 60
-  workspaces_idle_shutdown_timeout_max: 480
-  workspace_app_jupyterlab_use: true
-  workspace_app_jupyterlab_app_type: jupyterlab
-  workspace_app_jupyterlab_image_name: jupyterlab-v0.1.0
-  workspace_app_jupyterlab_image_build: v1
+
+overrides:
+  # uncomment and change a value to override the default
+  # cluster_name_prefix: jupyter-deploy-eks
+  # region: us-west-2
+  # kubernetes_version: "1.35"
+  # node_groups:
+  #   - name: components
+  #     role: components
+  #     instance_type: t3.medium
+  #     ami_type: default
+  #     disk_size_gb: "50"
+  #     min_size: "1"
+  #     max_size: "3"
+  #     desired_size: "2"
+  #   - name: workspaces
+  #     role: workspaces
+  #     instance_type: c5.2xlarge
+  #     ami_type: default
+  #     disk_size_gb: "50"
+  #     min_size: "1"
+  #     max_size: "5"
+  #     desired_size: "1"
+  # workspace_rbac_namespaces:
+  #   - default
+  # admin_role_names:
+  #   - Admin
+  # cluster_log_retention_days: 30
+  # custom_tags: {}
+  # workspace_operator_namespace: jupyter-k8s-system
+  # workspace_router_namespace: jupyter-k8s-router
+  # workspace_shared_namespace: jupyter-k8s-shared
+  # workspace_operator_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s
+  # workspace_operator_chart_version: "0.1.1"
+  # workspace_router_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc
+  # workspace_router_chart_version: "0.1.0-rc.6"
+  # traefik_crd_chart_version: "1.15.0"
+  # workspaces_default_access_type: OwnerOnly
+  # workspaces_default_ownership_type: OwnerOnly
+  # workspaces_idle_shutdown_enabled: true
+  # workspaces_idle_shutdown_timeout_default: 60
+  # workspaces_idle_shutdown_timeout_max: 480
+  # workspace_app_jupyterlab_use: true
+  # workspace_app_jupyterlab_app_type: jupyterlab
+  # workspace_app_jupyterlab_image_name: jupyterlab-v0.1.0
+  # workspace_app_jupyterlab_image_build: v1

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/base.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/base.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 required:
   domain: "${JD_E2E_VAR_DOMAIN}"
   subdomain: "${JD_E2E_VAR_SUBDOMAIN}"
@@ -9,47 +9,3 @@ required_sensitive:
   oauth_app_client_secret: "${JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET}"
 overrides:
   admin_role_names: ${JD_E2E_VAR_ADMIN_ROLE_NAMES}
-defaults:
-  cluster_name_prefix: jupyter-deploy-eks
-  region: us-west-2
-  kubernetes_version: "1.35"
-  node_groups:
-    - name: components
-      role: components
-      instance_type: t3.medium
-      ami_type: default
-      disk_size_gb: "50"
-      min_size: "1"
-      max_size: "3"
-      desired_size: "2"
-    - name: workspaces
-      role: workspaces
-      instance_type: c5.2xlarge
-      ami_type: default
-      disk_size_gb: "50"
-      min_size: "1"
-      max_size: "5"
-      desired_size: "1"
-  workspace_rbac_namespaces:
-    - default
-  admin_role_names:
-    - Admin
-  cluster_log_retention_days: 30
-  custom_tags: {}
-  workspace_operator_namespace: jupyter-k8s-system
-  workspace_router_namespace: jupyter-k8s-router
-  workspace_shared_namespace: jupyter-k8s-shared
-  workspace_operator_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s
-  workspace_operator_chart_version: "0.1.0"
-  workspace_router_chart_oci: oci://ghcr.io/jupyter-infra/charts/jupyter-k8s-aws-oidc
-  workspace_router_chart_version: "0.1.0-rc.4"
-  traefik_crd_chart_version: "1.15.0"
-  workspaces_default_access_type: OwnerOnly
-  workspaces_default_ownership_type: OwnerOnly
-  workspaces_idle_shutdown_enabled: true
-  workspaces_idle_shutdown_timeout_default: 60
-  workspaces_idle_shutdown_timeout_max: 480
-  workspace_app_jupyterlab_use: true
-  workspace_app_jupyterlab_app_type: jupyterlab
-  workspace_app_jupyterlab_image_name: jupyterlab-v0.1.0
-  workspace_app_jupyterlab_image_build: v1

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_configuration.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_configuration.py
@@ -4,6 +4,7 @@ import re
 
 import pytest
 import yaml
+from pytest_jupyter_deploy.cli import JDCliError
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 from pytest_jupyter_deploy.undeployed_project import undeployed_project
@@ -139,3 +140,54 @@ def test_store_config_written_after_config(e2e_deployment: EndToEndDeployment) -
         )
         assert "store-id" in store_config, ".jd/store.yaml should contain store-id"
         assert store_config["store-id"], "store-id should not be empty"
+
+
+@pytest.mark.cli
+@skip_if_testvars_not_set(
+    [
+        "JD_E2E_VAR_DOMAIN",
+        "JD_E2E_VAR_EMAIL",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_ID",
+        "JD_E2E_VAR_OAUTH_ALLOWED_TEAMS",
+        "JD_E2E_VAR_SUBDOMAIN",
+        "JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET",
+    ]
+)
+def test_config_error_recovery_invalid_admin_role(e2e_deployment: EndToEndDeployment) -> None:
+    """Test error recovery: non-existent admin_role_names fails plan, fix via variables.yaml succeeds.
+
+    Flow:
+    1. Configure with a non-existent IAM role in admin_role_names
+    2. `jd config` fails (terraform precondition rejects the role)
+    3. Remove the admin_role_names override in variables.yaml (reverts to template default)
+    4. Run `jd config` again — succeeds
+    """
+    with undeployed_project(e2e_deployment.suite_config) as (project_path, cli):
+        # Prepare valid configuration
+        e2e_deployment.suite_config.prepare_configuration("base", target_dir=project_path)
+
+        # Inject a non-existent admin role that will fail the terraform check block
+        variables_path = project_path / "variables.yaml"
+        with open(variables_path) as f:
+            config = yaml.safe_load(f)
+
+        config["overrides"] = config.get("overrides") or {}
+        config["overrides"]["admin_role_names"] = ["MustNotExist"]
+        with open(variables_path, "w") as f:
+            yaml.dump(config, f, sort_keys=False)
+
+        # --- First run: should fail because the role doesn't exist ---
+        with pytest.raises(JDCliError):
+            cli.run_command(["jupyter-deploy", "config"])
+
+        # --- Fix: remove the bad override so the template default (from preset) applies ---
+        with open(variables_path) as f:
+            config = yaml.safe_load(f)
+
+        del config["overrides"]["admin_role_names"]
+        with open(variables_path, "w") as f:
+            yaml.dump(config, f, sort_keys=False)
+
+        # --- Second run: should succeed ---
+        result = cli.run_command(["jupyter-deploy", "config"])
+        assert "Your project is ready" in result.stdout

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
@@ -187,8 +187,7 @@ class TestVariablesYaml(unittest.TestCase):
             self.assertEqual(
                 var_value,
                 preset_value,
-                f"Commented override '{var_name}' has value {var_value!r} "
-                f"but preset has {preset_value!r}",
+                f"Commented override '{var_name}' has value {var_value!r} but preset has {preset_value!r}",
             )
 
     def test_all_preset_vars_appear_as_commented_overrides(self) -> None:
@@ -197,9 +196,7 @@ class TestVariablesYaml(unittest.TestCase):
         preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
 
         missing = preset_vars - set(commented_vars.keys())
-        self.assertEqual(
-            len(missing), 0, f"Preset variables missing from commented overrides: {missing}"
-        )
+        self.assertEqual(len(missing), 0, f"Preset variables missing from commented overrides: {missing}")
 
     @classmethod
     def _parse_commented_overrides(cls) -> dict:
@@ -214,9 +211,8 @@ class TestVariablesYaml(unittest.TestCase):
             if stripped.startswith("overrides:"):
                 in_overrides = True
                 continue
-            if in_overrides and not stripped.startswith("#") and stripped:
-                if not line.startswith(" "):
-                    break
+            if in_overrides and not stripped.startswith("#") and stripped and not line.startswith(" "):
+                break
             if in_overrides and stripped.startswith("# "):
                 content_after_hash = stripped[2:]
                 if content_after_hash.startswith("uncomment"):

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
@@ -44,31 +44,22 @@ class TestVariablesYaml(unittest.TestCase):
 
             TestVariablesYaml.TF_VARIABLES = tf_variables
 
+    def test_schema_version_is_2(self) -> None:
+        self.assertEqual(self.VARIABLES_CONFIG["schema_version"], 2)
+
     def test_all_keys_are_present(self) -> None:
         self.assertIn("required", self.VARIABLES_CONFIG)
         self.assertIn("required_sensitive", self.VARIABLES_CONFIG)
         self.assertIn("overrides", self.VARIABLES_CONFIG)
-        self.assertIn("defaults", self.VARIABLES_CONFIG)
+
+    def test_no_defaults_section(self) -> None:
+        self.assertNotIn("defaults", self.VARIABLES_CONFIG)
 
     def test_no_overlap_between_required_and_required_sensitive(self) -> None:
         required_vars = set(self.VARIABLES_CONFIG["required"].keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG["required_sensitive"].keys())
 
         overlap = required_vars.intersection(required_sensitive_vars)
-        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
-
-    def test_no_overlap_between_required_and_defaults(self) -> None:
-        required_vars = set(self.VARIABLES_CONFIG["required"].keys())
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-
-        overlap = required_vars.intersection(default_vars)
-        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
-
-    def test_no_overlap_between_required_sensitive_and_defaults(self) -> None:
-        required_sensitive_vars = set(self.VARIABLES_CONFIG["required_sensitive"].keys())
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-
-        overlap = required_sensitive_vars.intersection(default_vars)
         self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
 
     def test_all_required_set_to_none(self) -> None:
@@ -86,94 +77,41 @@ class TestVariablesYaml(unittest.TestCase):
             f"Overrides should be empty, found: {overrides}",
         )
 
-    def test_all_defaults_varname_exist_in_all_preset(self) -> None:
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
-
-        missing_vars = default_vars - preset_vars
-        self.assertEqual(
-            len(missing_vars), 0, f"Variables in defaults section not found in defaults-all.tfvars: {missing_vars}"
-        )
-
-    def test_defaults_varname_count_equal_varnames_in_all_preset(self) -> None:
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
-
-        self.assertEqual(
-            len(default_vars),
-            len(preset_vars),
-            f"Number of variables in defaults ({len(default_vars)}) does not match "
-            f"number in defaults-all.tfvars ({len(preset_vars)})",
-        )
-
-    def test_all_values_in_defaults_match_preset(self) -> None:
-        for var_name, var_value in self.VARIABLES_CONFIG["defaults"].items():
-            self.assertIn(var_name, self.DEFAULTS_ALL_TFVARS)
-
-            if var_value == {}:
-                self.assertEqual(
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    {},
-                    f"Value mismatch for {var_name}",
-                )
-            elif var_value == []:
-                self.assertEqual(
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    [],
-                    f"Value mismatch for {var_name}",
-                )
-            elif var_value is None:
-                self.assertIsNone(self.DEFAULTS_ALL_TFVARS[var_name], f"Value mismatch for {var_name}")
-            else:
-                self.assertEqual(
-                    var_value,
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    f"Value mismatch for {var_name}: variables.yaml has {var_value}, "
-                    f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                )
-
     def test_all_variables_in_yaml_exist_in_tf(self) -> None:
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
 
-        all_yaml_vars = required_vars.union(required_sensitive_vars).union(defaults_vars)
+        all_yaml_vars = required_vars.union(required_sensitive_vars)
         all_tf_vars = set(self.TF_VARIABLES.keys())
 
         missing_vars = all_yaml_vars - all_tf_vars
         self.assertEqual(len(missing_vars), 0, f"Variables in variables.yaml not found in variables.tf: {missing_vars}")
 
-    def test_all_variables_in_tf_are_referenced_in_yaml(self) -> None:
+    def test_all_variables_in_tf_are_referenced_in_yaml_or_preset(self) -> None:
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
 
-        all_yaml_vars = required_vars.union(required_sensitive_vars).union(defaults_vars)
+        all_covered_vars = required_vars.union(required_sensitive_vars).union(preset_vars)
         all_tf_vars = set(self.TF_VARIABLES.keys())
 
-        missing_vars = all_tf_vars - all_yaml_vars
+        missing_vars = all_tf_vars - all_covered_vars
         self.assertEqual(
-            len(missing_vars), 0, f"Variables in variables.tf not referenced in variables.yaml: {missing_vars}"
+            len(missing_vars),
+            0,
+            f"Variables in variables.tf not referenced in variables.yaml or preset: {missing_vars}",
         )
 
-    def test_sensitive_variables_not_in_required_or_defaults(self) -> None:
+    def test_sensitive_variables_not_in_required(self) -> None:
         sensitive_vars = set()
         for var_name, var_config in self.TF_VARIABLES.items():
             if var_config.get("sensitive") is True:
                 sensitive_vars.add(var_name)
 
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
 
-        sensitive_in_required = sensitive_vars.intersection(required_vars)
-        sensitive_in_defaults = sensitive_vars.intersection(defaults_vars)
-
-        self.assertEqual(
-            len(sensitive_in_required), 0, f"Sensitive variables found in 'required' section: {sensitive_in_required}"
-        )
-        self.assertEqual(
-            len(sensitive_in_defaults), 0, f"Sensitive variables found in 'defaults' section: {sensitive_in_defaults}"
-        )
+        overlap = sensitive_vars.intersection(required_vars)
+        self.assertEqual(len(overlap), 0, f"Sensitive variables should not be in 'required' section: {overlap}")
 
     def test_required_sensitive_variables_are_marked_sensitive_in_tf(self) -> None:
         sensitive_vars = set()
@@ -190,13 +128,20 @@ class TestVariablesYaml(unittest.TestCase):
             f"Variables in 'required_sensitive' not marked as sensitive in variables.tf: {not_marked_sensitive}",
         )
 
+    def test_no_overlap_between_required_and_preset(self) -> None:
+        required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        overlap = required_vars.intersection(preset_vars)
+        self.assertEqual(len(overlap), 0, f"Required variables should not have defaults in preset: {overlap}")
+
     def test_variables_file_parsable_by_base_project_handler(self) -> None:
         variables_config = base_project_handler.retrieve_variables_config(self.VARIABLES_CONFIG_PATH)
         self.assertIsNotNone(variables_config)
 
     def test_app_image_name_matches_pyproject_version(self) -> None:
         apps_dir = TEMPLATE_PATH / "applications"
-        defaults = self.VARIABLES_CONFIG["defaults"]
+        preset_defaults = self.DEFAULTS_ALL_TFVARS
 
         for app_dir in apps_dir.iterdir():
             if not app_dir.is_dir():
@@ -215,38 +160,10 @@ class TestVariablesYaml(unittest.TestCase):
             version = pyproject["project"]["version"]
             expected_image_name = f"{app_name}-v{version}"
 
-            self.assertIn(image_name_key, defaults, f"Missing default for {image_name_key}")
+            self.assertIn(image_name_key, preset_defaults, f"Missing default for {image_name_key}")
             self.assertEqual(
-                defaults[image_name_key],
+                preset_defaults[image_name_key],
                 expected_image_name,
-                f"{image_name_key} default '{defaults[image_name_key]}' does not match "
-                f"pyproject.toml version: expected '{expected_image_name}'",
-            )
-
-    def test_app_image_name_preset_matches_pyproject_version(self) -> None:
-        apps_dir = TEMPLATE_PATH / "applications"
-
-        for app_dir in apps_dir.iterdir():
-            if not app_dir.is_dir():
-                continue
-
-            pyproject_path = app_dir / "pyproject.toml"
-            if not pyproject_path.exists():
-                continue
-
-            app_name = app_dir.name
-            image_name_key = f"workspace_app_{app_name}_image_name"
-
-            with open(pyproject_path, "rb") as f:
-                pyproject = tomllib.load(f)
-
-            version = pyproject["project"]["version"]
-            expected_image_name = f"{app_name}-v{version}"
-
-            self.assertIn(image_name_key, self.DEFAULTS_ALL_TFVARS, f"Missing preset for {image_name_key}")
-            self.assertEqual(
-                self.DEFAULTS_ALL_TFVARS[image_name_key],
-                expected_image_name,
-                f"{image_name_key} in defaults-all.tfvars '{self.DEFAULTS_ALL_TFVARS[image_name_key]}' "
-                f"does not match pyproject.toml version: expected '{expected_image_name}'",
+                f"Image name mismatch for {app_name}: expected '{expected_image_name}', "
+                f"got '{preset_defaults[image_name_key]}'",
             )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
@@ -167,3 +167,65 @@ class TestVariablesYaml(unittest.TestCase):
                 f"Image name mismatch for {app_name}: expected '{expected_image_name}', "
                 f"got '{preset_defaults[image_name_key]}'",
             )
+
+    def test_commented_overrides_match_preset_keys(self) -> None:
+        """All commented-out overrides in variables.yaml should exist in the preset."""
+        commented_vars = self._parse_commented_overrides()
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        missing = set(commented_vars.keys()) - preset_vars
+        self.assertEqual(len(missing), 0, f"Commented overrides not found in preset: {missing}")
+
+    def test_commented_overrides_values_match_preset(self) -> None:
+        """Commented-out override values should match the preset defaults."""
+        commented_vars = self._parse_commented_overrides()
+
+        for var_name, var_value in commented_vars.items():
+            if var_name not in self.DEFAULTS_ALL_TFVARS:
+                continue
+            preset_value = self.DEFAULTS_ALL_TFVARS[var_name]
+            self.assertEqual(
+                var_value,
+                preset_value,
+                f"Commented override '{var_name}' has value {var_value!r} "
+                f"but preset has {preset_value!r}",
+            )
+
+    def test_all_preset_vars_appear_as_commented_overrides(self) -> None:
+        """Every variable in the preset should appear as a commented override in variables.yaml."""
+        commented_vars = self._parse_commented_overrides()
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        missing = preset_vars - set(commented_vars.keys())
+        self.assertEqual(
+            len(missing), 0, f"Preset variables missing from commented overrides: {missing}"
+        )
+
+    @classmethod
+    def _parse_commented_overrides(cls) -> dict:
+        """Parse commented-out key-value pairs from the overrides section of variables.yaml."""
+        with open(cls.VARIABLES_CONFIG_PATH) as f:
+            lines = f.readlines()
+
+        in_overrides = False
+        commented_yaml_lines: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("overrides:"):
+                in_overrides = True
+                continue
+            if in_overrides and not stripped.startswith("#") and stripped:
+                if not line.startswith(" "):
+                    break
+            if in_overrides and stripped.startswith("# "):
+                content_after_hash = stripped[2:]
+                if content_after_hash.startswith("uncomment"):
+                    continue
+                commented_yaml_lines.append(content_after_hash)
+
+        if not commented_yaml_lines:
+            return {}
+
+        combined = "\n".join(commented_yaml_lines)
+        result = yaml.safe_load(combined)
+        return result if isinstance(result, dict) else {}

--- a/libs/jupyter-deploy/jupyter_deploy/constants.py
+++ b/libs/jupyter-deploy/jupyter_deploy/constants.py
@@ -1,5 +1,6 @@
 MANIFEST_FILENAME = "manifest.yaml"
 VARIABLES_FILENAME = "variables.yaml"
+VARIABLES_DEFAULTS_FILENAME = "variables-defaults.yaml"
 HISTORY_DIR = ".jd-history"
 JD_DIR = ".jd"
 STORE_CONFIG_FILENAME = "store.yaml"

--- a/libs/jupyter-deploy/jupyter_deploy/engine/engine_variables.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/engine_variables.py
@@ -12,10 +12,12 @@ from jupyter_deploy.exceptions import InvalidVariablesDotYamlError
 from jupyter_deploy.handlers import base_project_handler
 from jupyter_deploy.manifest import JupyterDeployManifest
 from jupyter_deploy.variables_config import (
-    VARIABLES_CONFIG_V1_COMMENTS,
-    VARIABLES_CONFIG_V1_KEYS_ORDER,
+    VARIABLES_CONFIG_V2_COMMENTS,
+    VARIABLES_CONFIG_V2_KEYS_ORDER,
     JupyterDeployVariablesConfig,
     JupyterDeployVariablesConfigV1,
+    JupyterDeployVariablesConfigV2,
+    migrate_variables_dot_yaml_to_latest,
 )
 
 
@@ -36,36 +38,43 @@ class EngineVariablesHandler(ABC):
         self.project_path = project_path
         self.project_manifest = project_manifest
         self.display_manager = display_manager
-        self._variables_config: JupyterDeployVariablesConfig | None = None
+        self._variables_config: JupyterDeployVariablesConfigV2 | None = None
 
     def get_variables_config_path(self) -> Path:
         return self.project_path / constants.VARIABLES_FILENAME
 
-    def _get_reset_variables_config(self) -> JupyterDeployVariablesConfig:
+    def get_defaults_reference_path(self) -> Path:
+        return self.project_path / constants.JD_DIR / constants.VARIABLES_DEFAULTS_FILENAME
+
+    def _get_reset_variables_config(self) -> JupyterDeployVariablesConfigV2:
         """Retrieve the template variables, return reset variables config."""
         vardefs = self.get_template_variables()
 
         required: dict[str, Any] = {k: None for k, v in vardefs.items() if not v.has_default and not v.sensitive}
         sensitive: dict[str, Any] = {k: None for k, v in vardefs.items() if v.sensitive}
-        defaults: dict[str, Any] = {k: v.default for k, v in vardefs.items() if v.has_default}
-        return JupyterDeployVariablesConfigV1(
-            schema_version=1,
+        return JupyterDeployVariablesConfigV2(
+            schema_version=2,
             required=required,
             required_sensitive=sensitive,
             overrides={},
-            defaults=defaults,
         )
 
+    def _load_and_migrate(self, variables_config: JupyterDeployVariablesConfig) -> JupyterDeployVariablesConfigV2:
+        """Ensure config is V2. Migrate from V1 if needed."""
+        if isinstance(variables_config, JupyterDeployVariablesConfigV1):
+            return migrate_variables_dot_yaml_to_latest(variables_config)
+        return variables_config
+
     @property
-    def variables_config(self) -> JupyterDeployVariablesConfig:
+    def variables_config(self) -> JupyterDeployVariablesConfigV2:
         if self._variables_config:
             return self._variables_config
 
         variables_config_path = self.project_path / constants.VARIABLES_FILENAME
         try:
             variables_config = base_project_handler.retrieve_variables_config(variables_config_path)
-            self._variables_config = variables_config
-            return variables_config
+            self._variables_config = self._load_and_migrate(variables_config)
+            return self._variables_config
         except FileNotFoundError:
             # the user has deleted their variables.yaml, reset it to a fallback
             if self.display_manager:
@@ -114,12 +123,12 @@ class EngineVariablesHandler(ABC):
         """
         pass
 
-    def sync_engine_varfiles_with_project_variables_config(self) -> None:
-        """Update engine specific variable files from the variables config.
+    def _collect_varvalues_from_config(self) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Collect non-sensitive and sensitive variable values from the config.
 
-        Bypass all variables set to `null`.
+        Returns:
+            Tuple of (varvalues, sensitive_varvalues) with None/masked entries excluded.
         """
-
         required = self.variables_config.required
         sensitive = self.variables_config.required_sensitive
         overrides = self.variables_config.overrides
@@ -141,30 +150,61 @@ class EngineVariablesHandler(ABC):
                 continue
             sensitive_varvalues[sensitive_var_name] = sensitive_var_value
 
+        return varvalues, sensitive_varvalues
+
+    def sync_engine_varfiles_with_project_variables_config(self) -> None:
+        """Update engine specific variable files from the variables config.
+
+        Bypass all variables set to `null`.
+        """
+        varvalues, sensitive_varvalues = self._collect_varvalues_from_config()
         self.update_variable_records(varvalues)
         self.update_variable_records(sensitive_varvalues, sensitive=True)
+
+    def _get_defaults_for_comments(self) -> dict[str, Any]:
+        """Get default values for writing as comments in variables.yaml."""
+        defaults_path = self.get_defaults_reference_path()
+        defaults = fs_utils.read_yaml_reference_file(defaults_path)
+        if defaults:
+            return defaults
+        # Fallback: derive from template variables
+        vardefs = self.get_template_variables()
+        return {k: v.default for k, v in vardefs.items() if v.has_default}
+
+    def _write_variables_config(self, config: JupyterDeployVariablesConfigV2) -> None:
+        """Write a V2 variables config to disk."""
+        variables_config_path = self.get_variables_config_path()
+        defaults_for_comments = self._get_defaults_for_comments()
+        fs_utils.write_yaml_file_with_comments(
+            file_path=variables_config_path,
+            content=config.model_dump(),
+            key_order=VARIABLES_CONFIG_V2_KEYS_ORDER,
+            comments=VARIABLES_CONFIG_V2_COMMENTS,
+            commented_entries={"overrides": defaults_for_comments},
+        )
+        self._variables_config = config
+
+    def generate_defaults_reference_file(self) -> None:
+        """Generate (or regenerate) the .jd/variables-defaults.yaml file from template definitions."""
+        vardefs = self.get_template_variables()
+        defaults = {k: v.default for k, v in vardefs.items() if v.has_default}
+        defaults_path = self.get_defaults_reference_path()
+        fs_utils.write_yaml_reference_file(
+            defaults_path, defaults, header="auto-generated by jupyter-deploy — do not edit"
+        )
 
     def mask_secrets(self) -> None:
         """Rewrite variables.yaml replacing all required_sensitive values with the mask."""
         curr_vars = self.variables_config
         masked_sensitive = {k: MASKED_SECRET_VALUE for k in curr_vars.required_sensitive}
 
-        new_variables_config = JupyterDeployVariablesConfigV1(
-            schema_version=1,
+        new_variables_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
             required=curr_vars.required,
             required_sensitive=masked_sensitive,
             overrides=curr_vars.overrides,
-            defaults=curr_vars.defaults,
         )
-
-        variables_config_path = self.project_path / constants.VARIABLES_FILENAME
-        fs_utils.write_yaml_file_with_comments(
-            variables_config_path,
-            new_variables_config.model_dump(),
-            key_order=VARIABLES_CONFIG_V1_KEYS_ORDER,
-            comments=VARIABLES_CONFIG_V1_COMMENTS,
-        )
-        self._variables_config = new_variables_config
+        self._write_variables_config(new_variables_config)
 
     def get_variable_names_assigned_in_config(self) -> list[str]:
         """Return the variable names for which the user specified a value in `variables.yaml`."""
@@ -193,22 +233,13 @@ class EngineVariablesHandler(ABC):
             elif var_value is not None:  # only pass non-None values for overrides
                 new_overrides_dict[var_name] = var_value
 
-        new_variables_config = JupyterDeployVariablesConfigV1(
-            schema_version=1,
+        new_variables_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
             required=new_required_dict,
             required_sensitive=new_sensitive_dict,
             overrides=new_overrides_dict,
-            defaults=curr_vars.defaults,
         )
-
-        variables_config_path = self.project_path / constants.VARIABLES_FILENAME
-        fs_utils.write_yaml_file_with_comments(
-            variables_config_path,
-            new_variables_config.model_dump(),
-            key_order=VARIABLES_CONFIG_V1_KEYS_ORDER,
-            comments=VARIABLES_CONFIG_V1_COMMENTS,
-        )
-        self._variables_config = new_variables_config
+        self._write_variables_config(new_variables_config)
 
     def reset_recorded_variables(self) -> bool:
         """Reset non-sensitive variables to their original values.
@@ -216,22 +247,13 @@ class EngineVariablesHandler(ABC):
         Returns:
             bool: False (this method modifies config but doesn't delete files)
         """
-        new_variables_config = JupyterDeployVariablesConfigV1(
-            schema_version=1,
+        new_variables_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
             required={k: None for k in self.variables_config.required},
             required_sensitive={k: None for k in self.variables_config.required_sensitive},
             overrides={},
-            defaults=self.variables_config.defaults,
         )
-
-        variables_config_path = self.project_path / constants.VARIABLES_FILENAME
-        fs_utils.write_yaml_file_with_comments(
-            variables_config_path,
-            new_variables_config.model_dump(),
-            key_order=VARIABLES_CONFIG_V1_KEYS_ORDER,
-            comments=VARIABLES_CONFIG_V1_COMMENTS,
-        )
-        self._variables_config = new_variables_config
+        self._write_variables_config(new_variables_config)
         return False
 
     def reset_recorded_secrets(self) -> bool:
@@ -241,20 +263,11 @@ class EngineVariablesHandler(ABC):
             bool: False (this method modifies config but doesn't delete files)
         """
         variables_config = self.variables_config
-        new_variables_config = JupyterDeployVariablesConfigV1(
-            schema_version=1,
+        new_variables_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
             required=variables_config.required,
             required_sensitive={k: None for k in variables_config.required_sensitive},
             overrides=variables_config.overrides,
-            defaults=variables_config.defaults,
         )
-
-        variables_config_path = self.project_path / constants.VARIABLES_FILENAME
-        fs_utils.write_yaml_file_with_comments(
-            variables_config_path,
-            new_variables_config.model_dump(),
-            key_order=VARIABLES_CONFIG_V1_KEYS_ORDER,
-            comments=VARIABLES_CONFIG_V1_COMMENTS,
-        )
-        self._variables_config = new_variables_config
+        self._write_variables_config(new_variables_config)
         return False

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_config.py
@@ -150,14 +150,29 @@ class TerraformConfigHandler(EngineConfigHandler):
                 message="Error initializing Terraform project.",
             )
 
+        # 1b/ generate the defaults reference file (.jd/variables-defaults.yaml)
+        # from template variable definitions — used by the v2 YAML writer
+        self.tf_variables_handler.generate_defaults_reference_file()
+
         # 2/ prepare to run terraform plan and save output with ``terraform plan PATH``
         plan_cmds = TF_PLAN_CMD.copy()
 
         # 2.1/ output plan to disk
         plan_cmds.append(f"-out={self.plan_out_path.absolute()}")
 
-        # 2.2/ sync variables.yaml -> tfvars and create the .tfvars files if necessary
-        self.variables_handler.sync_engine_varfiles_with_project_variables_config()
+        # 2.2/ sync variables.yaml -> staging tfvars (not the recorded file)
+        # This ensures a failed plan doesn't poison the last-known-good recorded state.
+        self.tf_variables_handler.sync_engine_varfiles_to_staging()
+
+        # Include the staging var-file so terraform plan picks up the new values.
+        # Terraform uses last-wins semantics, so staging overlays recorded.
+        staging_vars_path = self.tf_variables_handler.get_staging_variables_filepath()
+        if staging_vars_path.exists():
+            plan_cmds.append(f"-var-file={staging_vars_path.absolute()}")
+
+        staging_secrets_path = self.tf_variables_handler.get_staging_secrets_filepath()
+        if staging_secrets_path.exists():
+            plan_cmds.append(f"-var-file={staging_secrets_path.absolute()}")
 
         # 2.3/ using preset
         if preset_name:
@@ -180,6 +195,13 @@ class TerraformConfigHandler(EngineConfigHandler):
 
         # 2.4/ pass variable overrides
         if variable_overrides:
+            # Persist CLI --variable values to variables.yaml BEFORE running plan.
+            # This ensures user input survives even if terraform plan fails — the user
+            # can then fix the bad value and re-run without re-entering everything.
+            # The .tfvars (recorded state) stays protected by the staging pattern above.
+            cli_values: dict[str, Any] = {name: var_def.assigned_value for name, var_def in variable_overrides.items()}
+            self.variables_handler.sync_project_variables_config(cli_values)
+
             for var_def in variable_overrides.values():
                 var_option = tf_vardefs.to_tf_var_option(var_def)
                 plan_cmds.extend(var_option)
@@ -204,6 +226,8 @@ class TerraformConfigHandler(EngineConfigHandler):
 
         plan_retcode = plan_executor.execute(plan_cmds)
         if plan_retcode != 0:
+            # Plan failed — discard staging so the next run uses last-known-good state
+            self.tf_variables_handler.discard_staging()
             raise SupervisedExecutionError(
                 command="config",
                 retcode=plan_retcode,
@@ -268,6 +292,10 @@ class TerraformConfigHandler(EngineConfigHandler):
         secrets_file_lines.append("# do NOT commit this file\n")
         secrets_file_lines.extend(tf_plan.format_plan_variables(secrets))
         fs_utils.write_inline_file_content(secrets_file_path, secrets_file_lines)
+
+        # Promote staging files now that we've successfully recorded from the plan.
+        # This merges any staging values into the recorded files and removes staging.
+        self.tf_variables_handler.discard_staging()
 
         # Sync non-secret variables back to variables.yaml.
         # Secrets are not synced — they will be masked separately.

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_constants.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_constants.py
@@ -24,6 +24,8 @@ TF_DEFAULT_PLAN_FILENAME = "jdout-tfplan"
 TF_PLAN_METADATA_FILENAME = "jdout-tfplan.meta.json"
 TF_RECORDED_VARS_FILENAME = "jdinputs.auto.tfvars"
 TF_RECORDED_SECRETS_FILENAME = "jdinputs.secrets.auto.tfvars"
+TF_STAGING_VARS_FILENAME = "jdinputs.staging.auto.tfvars"
+TF_STAGING_SECRETS_FILENAME = "jdinputs.staging.secrets.auto.tfvars"
 TF_CUSTOM_PRESET_FILENAME = "jdinputs.preset.override.tfvars"
 TF_DESTROY_PRESET_FILENAME = "destroy.tfvars"
 TF_VARIABLES_FILENAME = "variables.tf"
@@ -56,6 +58,8 @@ __all__ = [
     "TF_PLAN_METADATA_FILENAME",
     "TF_RECORDED_VARS_FILENAME",
     "TF_RECORDED_SECRETS_FILENAME",
+    "TF_STAGING_VARS_FILENAME",
+    "TF_STAGING_SECRETS_FILENAME",
     "TF_CUSTOM_PRESET_FILENAME",
     "TF_DESTROY_PRESET_FILENAME",
     "TF_VARIABLES_FILENAME",

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_varfiles.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_varfiles.py
@@ -162,6 +162,14 @@ def parse_and_update_dot_tfvars_content(
     return tf_plan.format_values_for_dot_tfvars(saved_values)
 
 
+def parse_dot_tfvars_to_dict(content: str) -> dict[str, Any]:
+    """Parse a .tfvars file content and return as a plain dict of variable-name→value."""
+    if not content or not content.strip():
+        return {}
+    result: dict[str, Any] = strip_hcl2_quotes(hcl2.loads(content))
+    return result
+
+
 def parse_and_remove_overridden_variables_from_content(
     content: str,
     varnames_to_remove: list[str],

--- a/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_variables.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/terraform/tf_variables.py
@@ -11,6 +11,8 @@ from jupyter_deploy.engine.terraform.tf_constants import (
     TF_PRESETS_DIR,
     TF_RECORDED_SECRETS_FILENAME,
     TF_RECORDED_VARS_FILENAME,
+    TF_STAGING_SECRETS_FILENAME,
+    TF_STAGING_VARS_FILENAME,
     TF_VARIABLES_FILENAME,
     get_preset_filename,
 )
@@ -36,6 +38,12 @@ class TerraformVariablesHandler(EngineVariablesHandler):
 
     def get_recorded_secrets_filepath(self) -> Path:
         return self.engine_dir_path / TF_RECORDED_SECRETS_FILENAME
+
+    def get_staging_variables_filepath(self) -> Path:
+        return self.engine_dir_path / TF_STAGING_VARS_FILENAME
+
+    def get_staging_secrets_filepath(self) -> Path:
+        return self.engine_dir_path / TF_STAGING_SECRETS_FILENAME
 
     def is_template_directory(self) -> bool:
         return fs_utils.file_exists(self.engine_dir_path / TF_VARIABLES_FILENAME)
@@ -100,6 +108,95 @@ class TerraformVariablesHandler(EngineVariablesHandler):
         if updated_tfvars_lines:
             fs_utils.write_inline_file_content(tfvars_path, updated_tfvars_lines)
 
+    def sync_engine_varfiles_to_staging(self) -> None:
+        """Sync variables.yaml values to staging .tfvars files instead of recorded files.
+
+        Used during `jd config` so that a failed terraform plan doesn't corrupt
+        the last-known-good recorded state.
+        """
+        varvalues, sensitive_varvalues = self._collect_varvalues_from_config()
+        self.update_variable_records_staging(varvalues)
+        self.update_variable_records_staging(sensitive_varvalues, sensitive=True)
+
+    def update_variable_records_staging(self, varvalues: dict[str, Any], sensitive: bool = False) -> None:
+        """Write variable values to staging .tfvars files (not the recorded files).
+
+        Staging files overlay the recorded files during terraform plan. They are
+        promoted to recorded files on success, or discarded on failure.
+        """
+        if not varvalues:
+            return
+
+        template_vars = self.get_template_variables()
+
+        updated_vals: dict[str, Any] = {}
+        for varname, varvalue in varvalues.items():
+            existing_vardef = template_vars.get(varname)
+            if not existing_vardef:
+                raise KeyError(f"Variable not found: {varname}")
+            converted_value = existing_vardef.validate_value(varvalue)
+            updated_vals[varname] = converted_value
+
+        for varname in varvalues:
+            existing_vardef = template_vars[varname]
+            existing_vardef.assigned_value = updated_vals[varname]
+
+        file_name = TF_STAGING_VARS_FILENAME if not sensitive else TF_STAGING_SECRETS_FILENAME
+        tfvars_path = self.engine_dir_path / file_name
+        previous_tfvars_content: str = ""
+        if fs_utils.file_exists(tfvars_path):
+            previous_tfvars_content = fs_utils.read_short_file(tfvars_path)
+
+        updated_tfvars_lines = tf_varfiles.parse_and_update_dot_tfvars_content(previous_tfvars_content, varvalues)
+
+        if updated_tfvars_lines:
+            fs_utils.write_inline_file_content(tfvars_path, updated_tfvars_lines)
+
+    def promote_staging_to_recorded(self) -> None:
+        """Promote staging .tfvars files to become the recorded files.
+
+        Called after a successful terraform plan + record cycle. Merges staging
+        content into the recorded files, then removes staging files.
+        """
+        self._merge_staging_file(
+            staging_path=self.get_staging_variables_filepath(),
+            recorded_path=self.get_recorded_variables_filepath(),
+        )
+        self._merge_staging_file(
+            staging_path=self.get_staging_secrets_filepath(),
+            recorded_path=self.get_recorded_secrets_filepath(),
+        )
+
+    def discard_staging(self) -> None:
+        """Remove staging .tfvars files without promoting them."""
+        fs_utils.delete_file_if_exists(self.get_staging_variables_filepath())
+        fs_utils.delete_file_if_exists(self.get_staging_secrets_filepath())
+
+    def _merge_staging_file(self, staging_path: Path, recorded_path: Path) -> None:
+        """Merge a staging file's content into the recorded file, then delete staging."""
+        if not staging_path.exists():
+            return
+
+        staging_content = fs_utils.read_short_file(staging_path)
+        if not staging_content.strip():
+            fs_utils.delete_file_if_exists(staging_path)
+            return
+
+        # Read existing recorded content (may not exist yet)
+        recorded_content: str = ""
+        if fs_utils.file_exists(recorded_path):
+            recorded_content = fs_utils.read_short_file(recorded_path)
+
+        # Parse staging to get the variable values
+        staging_vars = tf_varfiles.parse_dot_tfvars_to_dict(staging_content)
+
+        # Merge into recorded
+        updated_lines = tf_varfiles.parse_and_update_dot_tfvars_content(recorded_content, staging_vars)
+        if updated_lines:
+            fs_utils.write_inline_file_content(recorded_path, updated_lines)
+
+        fs_utils.delete_file_if_exists(staging_path)
+
     def create_filtered_preset_file(self, base_preset_path: Path) -> Path:
         """Read the base preset, override values, write in a new preset file and return its path."""
         filtered_tfvars_file_path = self.project_path / TF_ENGINE_DIR / TF_CUSTOM_PRESET_FILENAME
@@ -126,6 +223,9 @@ class TerraformVariablesHandler(EngineVariablesHandler):
         path = self.get_recorded_variables_filepath()
         tfvars_deleted = fs_utils.delete_file_if_exists(path)
 
+        # Also clean up any leftover staging files
+        fs_utils.delete_file_if_exists(self.get_staging_variables_filepath())
+
         return parent_deleted or tfvars_deleted
 
     def reset_recorded_secrets(self) -> bool:
@@ -138,5 +238,8 @@ class TerraformVariablesHandler(EngineVariablesHandler):
 
         path = self.get_recorded_secrets_filepath()
         tfvars_deleted = fs_utils.delete_file_if_exists(path)
+
+        # Also clean up any leftover staging files
+        fs_utils.delete_file_if_exists(self.get_staging_secrets_filepath())
 
         return parent_deleted or tfvars_deleted

--- a/libs/jupyter-deploy/jupyter_deploy/fs_utils.py
+++ b/libs/jupyter-deploy/jupyter_deploy/fs_utils.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import stat
 from pathlib import Path
+from typing import Any
 
 import pathspec
 import yaml
@@ -207,9 +208,23 @@ def read_short_file(file_path: Path, max_size_mb: float = 1.0) -> str:
 
 
 def write_yaml_file_with_comments(
-    file_path: Path, content: dict, key_order: list[str] | None = None, comments: dict[str, list[str]] | None = None
+    file_path: Path,
+    content: dict,
+    key_order: list[str] | None = None,
+    comments: dict[str, list[str]] | None = None,
+    commented_entries: dict[str, dict[str, Any]] | None = None,
 ) -> None:
-    """Write dict content to disk."""
+    """Write dict content to disk with optional header comments and commented-out entries.
+
+    Args:
+        file_path: Target file path.
+        content: Dict to serialize as YAML.
+        key_order: Optional ordering for top-level keys.
+        comments: Header comment lines to insert after a top-level key line.
+        commented_entries: Dict of {section_key: {var: value}} rendered as
+            commented-out YAML lines at the end of the section. Entries whose
+            key already appears in the section's active content are skipped.
+    """
     ordered_dict: dict = {}
 
     # First add keys in specified order
@@ -223,25 +238,104 @@ def write_yaml_file_with_comments(
         if key not in ordered_dict:
             ordered_dict[key] = content[key]
 
-    # write to file
-    with open(file_path, "w+") as f:
-        yaml.dump(ordered_dict, f, indent=2, sort_keys=False, default_flow_style=False)
+    # Dump to string, then inject comments in a single pass before writing to disk
+    raw_yaml = yaml.dump(ordered_dict, indent=2, sort_keys=False, default_flow_style=False)
 
-    # add back comments if any
-    if comments:
-        with open(file_path) as f:
-            lines = f.readlines()
-
-        modified_lines: list[str] = []
-        for line in lines:
-            modified_lines.append(line)
-            for key, comment_lines in comments.items():
-                if line.strip() == f"{key}:":
-                    for comment in comment_lines:
-                        modified_lines.append(f"{comment}\n")
-
+    if not comments and not commented_entries:
         with open(file_path, "w") as f:
-            f.writelines(modified_lines)
+            f.write(raw_yaml)
+        return
+
+    # Walk the YAML lines and inject comments in a single pass.
+    # Commented entries (inactive defaults) are appended AFTER the section's
+    # active content so that user-set values stay at the top of each section.
+    modified_lines: list[str] = []
+    top_level_keys: set[str] = set(ordered_dict.keys())
+    pending_commented_section: str | None = None
+
+    def _match_top_level_key(stripped_line: str) -> str | None:
+        """Return the matching top-level key if this line starts a new YAML section."""
+        for key in top_level_keys:
+            if stripped_line == f"{key}:" or stripped_line.startswith(f"{key}: "):
+                return key
+        return None
+
+    def _flush_pending_comments() -> None:
+        # `nonlocal` allows this nested function to reassign the enclosing
+        # scope's variable (without it, assignment would create a new local).
+        nonlocal pending_commented_section
+        if pending_commented_section and commented_entries:
+            entries = commented_entries.get(pending_commented_section, {})
+            # Skip entries that are already active (uncommented) in the section
+            active_keys = set((content.get(pending_commented_section) or {}).keys())
+            inactive = {k: v for k, v in entries.items() if k not in active_keys}
+            if inactive:
+                modified_lines.extend(_render_commented_yaml_entries(inactive))
+        pending_commented_section = None
+
+    for line in raw_yaml.splitlines(keepends=True):
+        stripped = line.strip()
+        matched_key = _match_top_level_key(stripped)
+
+        if matched_key:
+            # We're entering a new section — flush any pending commented entries
+            # from the previous section (they trail after the active content).
+            _flush_pending_comments()
+
+            # Blank line between top-level sections for readability
+            if modified_lines:
+                modified_lines.append("\n")
+
+            modified_lines.append(line)
+
+            # Header comments (e.g. "# fill in values below...")
+            if comments and matched_key in comments:
+                for comment in comments[matched_key]:
+                    modified_lines.append(f"{comment}\n")
+
+            # Remember this section so we can append commented entries at its end
+            if commented_entries and matched_key in commented_entries:
+                pending_commented_section = matched_key
+        else:
+            modified_lines.append(line)
+
+    # Flush commented entries for the final section (no next section triggers the flush)
+    _flush_pending_comments()
+
+    with open(file_path, "w") as f:
+        f.writelines(modified_lines)
+
+
+def _render_commented_yaml_entries(entries: dict[str, Any]) -> list[str]:
+    """Render dict entries as commented-out multi-line YAML with 2-space indent."""
+    lines: list[str] = []
+    for var_name, var_value in entries.items():
+        single_entry = {var_name: var_value}
+        raw = yaml.dump(single_entry, indent=2, sort_keys=False, default_flow_style=False)
+        for raw_line in raw.splitlines():
+            lines.append(f"  # {raw_line}\n")
+    return lines
+
+
+def write_yaml_reference_file(file_path: Path, content: dict[str, Any], header: str | None = None) -> None:
+    """Write a simple YAML reference file with an optional header comment."""
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(file_path, "w") as f:
+        if header:
+            f.write(f"# {header}\n")
+        if content:
+            yaml.dump(content, f, indent=2, sort_keys=False, default_flow_style=False)
+
+
+def read_yaml_reference_file(file_path: Path) -> dict[str, Any]:
+    """Read a YAML reference file. Returns empty dict if file doesn't exist or is invalid."""
+    if not file_path.exists():
+        return {}
+    with open(file_path) as f:
+        result = yaml.safe_load(f)
+    if not isinstance(result, dict):
+        return {}
+    return result
 
 
 def walk_local_files_with_gitignore_rules(local_path: Path, gitignore_path: Path | None = None) -> list[Path]:

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/base_project_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/base_project_handler.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import yaml
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
 
@@ -154,7 +154,12 @@ def retrieve_variables_config(variables_config_path: Path) -> variables_config.J
             "Invalid variables config file: jupyter-deploy variables config is not a dict."
         )
 
-    return variables_config.JupyterDeployVariablesConfig(**content)
+    # JupyterDeployVariablesConfig is a type alias (discriminated union), not a class —
+    # TypeAdapter is required to validate data against it and route to V1 or V2.
+    adapter: TypeAdapter[variables_config.JupyterDeployVariablesConfig] = TypeAdapter(
+        variables_config.JupyterDeployVariablesConfig
+    )
+    return adapter.validate_python(content)  # type: ignore[return-value]
 
 
 def retrieve_store_config(project_path: Path) -> store_config.JupyterDeployStoreConfig | None:

--- a/libs/jupyter-deploy/jupyter_deploy/provider/store/store_manager.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/store/store_manager.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 from yaml.parser import ParserError
 from yaml.scanner import ScannerError
 
@@ -14,7 +14,11 @@ from jupyter_deploy.constants import MASKED_SECRET_VALUE
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import StoreType
 from jupyter_deploy.manifest import JupyterDeployManifest
-from jupyter_deploy.variables_config import JupyterDeployVariablesConfigV1
+from jupyter_deploy.variables_config import (
+    JupyterDeployVariablesConfig,
+    JupyterDeployVariablesConfigV1,
+    JupyterDeployVariablesConfigV2,
+)
 
 
 class StoreInfo(BaseModel):
@@ -143,6 +147,7 @@ class StoreManager(ABC):
         """Parse variables YAML and return a flat dict of variable names to values.
 
         Sensitive values are masked. Returns None if the content cannot be parsed.
+        Handles both V1 and V2 formats.
         """
         try:
             data = yaml.safe_load(content)
@@ -153,7 +158,8 @@ class StoreManager(ABC):
             return None
 
         try:
-            config = JupyterDeployVariablesConfigV1(**data)
+            adapter: TypeAdapter[JupyterDeployVariablesConfig] = TypeAdapter(JupyterDeployVariablesConfig)
+            config = adapter.validate_python(data)
         except ValidationError:
             return None
 
@@ -161,7 +167,13 @@ class StoreManager(ABC):
         variables.update(config.required)
         for key in config.required_sensitive:
             variables[key] = MASKED_SECRET_VALUE
-        # Overrides take precedence over defaults
-        for key, value in config.defaults.items():
-            variables[key] = config.overrides.get(key, value)
+
+        if isinstance(config, JupyterDeployVariablesConfigV1):
+            # V1: overrides take precedence over defaults
+            for key, value in config.defaults.items():
+                variables[key] = config.overrides.get(key, value)
+        elif isinstance(config, JupyterDeployVariablesConfigV2):
+            # V2: just include overrides (no defaults section)
+            variables.update(config.overrides)
+
         return variables

--- a/libs/jupyter-deploy/jupyter_deploy/variables_config.py
+++ b/libs/jupyter-deploy/jupyter_deploy/variables_config.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator, model_validator
 
 VARIABLES_CONFIG_V1_KEYS_ORDER = [
     "schema_version",
@@ -24,6 +24,26 @@ VARIABLES_CONFIG_V1_COMMENTS: dict[str, list[str]] = {
     "defaults": [
         "  # read-only: do not modify this section",
         "  # instead add overrides in the override section",
+    ],
+}
+
+VARIABLES_CONFIG_V2_KEYS_ORDER = [
+    "schema_version",
+    "required",
+    "required_sensitive",
+    "overrides",
+]
+
+VARIABLES_CONFIG_V2_COMMENTS: dict[str, list[str]] = {
+    "required": [
+        "  # fill in values below, or run 'jd config' for the interactive experience",
+    ],
+    "required_sensitive": [
+        "  # fill in values below, or run 'jd config' for the interactive experience",
+        "  # values entered here will be masked after running 'jd config'",
+    ],
+    "overrides": [
+        "  # uncomment and change a value to override the default",
     ],
 }
 
@@ -78,5 +98,59 @@ class JupyterDeployVariablesConfigV1(BaseModel):
         return self
 
 
+class JupyterDeployVariablesConfigV2(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    schema_version: Literal[2]
+    required: dict[str, Any] = Field(default_factory=dict)
+    required_sensitive: dict[str, Any] = Field(default_factory=dict)
+    overrides: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("required", "required_sensitive", "overrides", mode="before")
+    @classmethod
+    def ensure_dict(cls, v: Any) -> dict[str, Any]:
+        return {} if v is None else v
+
+    @model_validator(mode="after")
+    def check_no_var_name_repeat(self) -> "JupyterDeployVariablesConfigV2":
+        """Ensure that all variables are declared at most once across sections."""
+        required_var_names: set[str] = set(self.required.keys())
+        sensitive_var_names: set[str] = set(self.required_sensitive.keys())
+        override_var_names: set[str] = set(self.overrides.keys())
+
+        req_sensitive_overlap = required_var_names.intersection(sensitive_var_names)
+        req_override_overlap = required_var_names.intersection(override_var_names)
+        sensitive_override_overlap = sensitive_var_names.intersection(override_var_names)
+
+        if req_sensitive_overlap:
+            raise ValueError(f"Variables definition conflict: {req_sensitive_overlap}")
+        if req_override_overlap:
+            raise ValueError(f"Variables definition conflict: {req_override_overlap}")
+        if sensitive_override_overlap:
+            raise ValueError(f"Variables definition conflict: {sensitive_override_overlap}")
+
+        return self
+
+
+def migrate_variables_dot_yaml_to_latest(v1: JupyterDeployVariablesConfigV1) -> JupyterDeployVariablesConfigV2:
+    """Migrate a V1 variables config to V2 format.
+
+    Drops the `defaults` section entirely — defaults come from template definitions.
+    """
+    return JupyterDeployVariablesConfigV2(
+        schema_version=2,
+        required=v1.required.copy(),
+        required_sensitive=v1.required_sensitive.copy(),
+        overrides=v1.overrides.copy(),
+    )
+
+
+def _variables_config_discriminator(v: Any) -> str:
+    version = v.get("schema_version", 1) if isinstance(v, dict) else getattr(v, "schema_version", 1)
+    return str(version)
+
+
 # Combined type using discriminated union
-JupyterDeployVariablesConfig = Annotated[JupyterDeployVariablesConfigV1, "schema_version"]
+JupyterDeployVariablesConfig = Annotated[
+    Annotated[JupyterDeployVariablesConfigV1, Tag("1")] | Annotated[JupyterDeployVariablesConfigV2, Tag("2")],
+    Discriminator(_variables_config_discriminator),
+]

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_config.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_config.py
@@ -42,9 +42,12 @@ class TestTerraformConfigHandler(unittest.TestCase):
         mock_handler = Mock()
         mock_get_recorded_variables_filepath = Mock()
         mock_get_recorded_secrets_filepath = Mock()
+        mock_get_staging_variables_filepath = Mock()
+        mock_get_staging_secrets_filepath = Mock()
         mock_reset_recorded_variables = Mock()
         mock_reset_recorded_secrets = Mock()
-        mock_sync_engine_varfiles = Mock()
+        mock_sync_engine_varfiles_to_staging = Mock()
+        mock_discard_staging = Mock()
         mock_sync_variables_config = Mock()
         mock_get_template_variables = Mock()
         mock_update_variable_records = Mock()
@@ -52,9 +55,12 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         mock_handler.get_recorded_variables_filepath = mock_get_recorded_variables_filepath
         mock_handler.get_recorded_secrets_filepath = mock_get_recorded_secrets_filepath
+        mock_handler.get_staging_variables_filepath = mock_get_staging_variables_filepath
+        mock_handler.get_staging_secrets_filepath = mock_get_staging_secrets_filepath
         mock_handler.reset_recorded_variables = mock_reset_recorded_variables
         mock_handler.reset_recorded_secrets = mock_reset_recorded_secrets
-        mock_handler.sync_engine_varfiles_with_project_variables_config = mock_sync_engine_varfiles
+        mock_handler.sync_engine_varfiles_to_staging = mock_sync_engine_varfiles_to_staging
+        mock_handler.discard_staging = mock_discard_staging
         mock_handler.sync_project_variables_config = mock_sync_variables_config
         mock_handler.get_template_variables = mock_get_template_variables
         mock_handler.update_variable_records = mock_update_variable_records
@@ -62,14 +68,20 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         mock_get_recorded_variables_filepath.return_value = TestTerraformConfigHandler.MOCK_RECORD_VARS_PATH
         mock_get_recorded_secrets_filepath.return_value = TestTerraformConfigHandler.MOCK_RECORD_SECRETS_PATH
+        # Staging paths return non-existent paths by default (no staging file to add as -var-file)
+        mock_get_staging_variables_filepath.return_value = Path("/tmp/nonexistent-staging-vars.tfvars")
+        mock_get_staging_secrets_filepath.return_value = Path("/tmp/nonexistent-staging-secrets.tfvars")
         mock_create_filtered_preset_file.return_value = TestTerraformConfigHandler.MOCK_OVERRIDE_PRESET_PATH
 
         return mock_handler, {
             "get_recorded_variables_filepath": mock_get_recorded_variables_filepath,
             "get_recorded_secrets_filepath": mock_get_recorded_secrets_filepath,
+            "get_staging_variables_filepath": mock_get_staging_variables_filepath,
+            "get_staging_secrets_filepath": mock_get_staging_secrets_filepath,
             "reset_recorded_variables": mock_reset_recorded_variables,
             "reset_recorded_secrets": mock_reset_recorded_secrets,
-            "sync_engine_varfiles_with_project_variables_config": mock_sync_engine_varfiles,
+            "sync_engine_varfiles_to_staging": mock_sync_engine_varfiles_to_staging,
+            "discard_staging": mock_discard_staging,
             "sync_project_variables_config": mock_sync_variables_config,
             "get_template_variables": mock_get_template_variables,
             "update_variables_record": mock_update_variable_records,
@@ -308,7 +320,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         # Assert - configure completed successfully (no exception raised)
         self.assertEqual(mock_create_executor.call_count, 2)  # Init and plan
         self.assertEqual(mock_executor.execute.call_count, 2)
-        mock_vars_fns["sync_engine_varfiles_with_project_variables_config"].assert_called_once()
+        mock_vars_fns["sync_engine_varfiles_to_staging"].assert_called_once()
 
     @patch("jupyter_deploy.engine.terraform.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
@@ -337,7 +349,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         # Verify preset file was created
         expect_called_path = path / TF_ENGINE_DIR / TF_PRESETS_DIR / "defaults-all.tfvars"
-        mock_vars_fns["sync_engine_varfiles_with_project_variables_config"].assert_called_once()
+        mock_vars_fns["sync_engine_varfiles_to_staging"].assert_called_once()
         mock_vars_fns["create_filtered_preset_file"].assert_called_once_with(expect_called_path)
 
     @patch("jupyter_deploy.engine.terraform.tf_supervised_executor_factory.create_terraform_executor")
@@ -381,7 +393,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         # Assert - configure completed successfully (no exception raised)
         self.assertEqual(mock_create_executor.call_count, 2)  # Init and plan
-        mock_vars_fns["sync_engine_varfiles_with_project_variables_config"].assert_called_once()
+        mock_vars_fns["sync_engine_varfiles_to_staging"].assert_called_once()
         mock_vars_fns["create_filtered_preset_file"].assert_called_once()
 
         # Verify the executor was called with the plan commands
@@ -429,7 +441,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         self.assertEqual(context.exception.command, "config")
         self.assertEqual(mock_create_executor.call_count, 1)  # Only init should be called
         self.assertEqual(mock_executor.execute.call_count, 1)
-        mock_vars_fns["sync_engine_varfiles_with_project_variables_config"].assert_not_called()
+        mock_vars_fns["sync_engine_varfiles_to_staging"].assert_not_called()
 
     @patch("jupyter_deploy.engine.terraform.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
@@ -453,7 +465,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         self.assertEqual(mock_create_executor.call_count, 1)  # Only init should be called
         self.assertEqual(mock_executor.execute.call_count, 1)
-        mock_vars_fns["sync_engine_varfiles_with_project_variables_config"].assert_not_called()
+        mock_vars_fns["sync_engine_varfiles_to_staging"].assert_not_called()
 
     @patch("jupyter_deploy.engine.terraform.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
@@ -479,7 +491,7 @@ class TestTerraformConfigHandler(unittest.TestCase):
         self.assertEqual(context.exception.command, "config")
         self.assertEqual(mock_create_executor.call_count, 2)  # Both init and plan
         self.assertEqual(mock_executor.execute.call_count, 2)
-        mock_vars_fns["sync_engine_varfiles_with_project_variables_config"].assert_called_once()
+        mock_vars_fns["sync_engine_varfiles_to_staging"].assert_called_once()
 
     @patch("jupyter_deploy.engine.terraform.tf_supervised_executor_factory.create_terraform_executor")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
@@ -503,7 +515,45 @@ class TestTerraformConfigHandler(unittest.TestCase):
 
         self.assertEqual(mock_create_executor.call_count, 2)  # Both init and plan
         self.assertEqual(mock_executor.execute.call_count, 2)
-        mock_vars_fns["sync_engine_varfiles_with_project_variables_config"].assert_called_once()
+        mock_vars_fns["sync_engine_varfiles_to_staging"].assert_called_once()
+
+    @patch("jupyter_deploy.engine.terraform.tf_supervised_executor_factory.create_terraform_executor")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    def test_configure_persists_variable_overrides_to_yaml_before_plan(
+        self, mock_variable_handler_cls: Mock, mock_create_executor: Mock
+    ) -> None:
+        """CLI --variable values are written to variables.yaml before plan runs,
+        so they survive even if terraform plan fails."""
+        # Arrange
+        mock_vars_handler, mock_vars_fns = self.get_mock_variable_handler_and_fns()
+        mock_variable_handler_cls.return_value = mock_vars_handler
+
+        # Mock executor: init succeeds, plan fails
+        mock_executor = Mock()
+        mock_executor.execute.side_effect = [0, 1]
+        mock_create_executor.return_value = mock_executor
+
+        # Create variable overrides (simulating --region us-east-1 --instance-type t3.large)
+        region_override = Mock()
+        region_override.assigned_value = "us-east-1"
+        instance_override = Mock()
+        instance_override.assigned_value = "t3.large"
+
+        # to_tf_var_option returns the CLI args for terraform
+        with patch("jupyter_deploy.engine.terraform.tf_vardefs.to_tf_var_option", return_value=["-var=x"]):
+            handler = TerraformConfigHandler(Path("/fake/path"), Mock(), self.get_mock_command_history(), NullDisplay())
+
+            # Act — plan fails, but overrides should still be persisted
+            with self.assertRaises(SupervisedExecutionError):
+                handler.configure(variable_overrides={"region": region_override, "instance_type": instance_override})
+
+        # Assert — sync_project_variables_config was called with the CLI values
+        # BEFORE the plan ran (so they survive the failure)
+        mock_vars_fns["sync_project_variables_config"].assert_called_once_with(
+            {"region": "us-east-1", "instance_type": "t3.large"}
+        )
+        # Staging was discarded after the failed plan
+        mock_vars_fns["discard_staging"].assert_called_once()
 
     @patch("jupyter_deploy.engine.terraform.tf_plan_metadata.save_plan_metadata")
     @patch("jupyter_deploy.engine.terraform.tf_plan.extract_resource_counts_from_plan")

--- a/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_variables.py
+++ b/libs/jupyter-deploy/tests/unit/engine/terraform/test_tf_variables.py
@@ -1,6 +1,6 @@
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.terraform.tf_variables import TerraformVariablesHandler
@@ -534,9 +534,14 @@ class TestResetRecordedVariables(unittest.TestCase):
         # Execute
         handler.reset_recorded_variables()
 
-        # Assert parent method was called and delete_file was called with correct path
+        # Assert parent method was called and delete_file was called for recorded + staging
         mock_parent_reset.assert_called_once()
-        mock_delete_file.assert_called_once_with(project_path / "engine" / "jdinputs.auto.tfvars")
+        expected_calls = [
+            call(project_path / "engine" / "jdinputs.auto.tfvars"),
+            call(project_path / "engine" / "jdinputs.staging.auto.tfvars"),
+        ]
+        mock_delete_file.assert_has_calls(expected_calls, any_order=False)
+        self.assertEqual(mock_delete_file.call_count, 2)
 
     @patch("jupyter_deploy.engine.engine_variables.EngineVariablesHandler.reset_recorded_variables")
     @patch("jupyter_deploy.fs_utils.delete_file_if_exists")
@@ -555,7 +560,6 @@ class TestResetRecordedVariables(unittest.TestCase):
 
         # Assert
         mock_parent_reset.assert_called_once()
-        mock_delete_file.assert_called_once()
         self.assertTrue(result, "Should return True when file was deleted")
 
     @patch("jupyter_deploy.engine.engine_variables.EngineVariablesHandler.reset_recorded_variables")
@@ -576,7 +580,6 @@ class TestResetRecordedVariables(unittest.TestCase):
             handler.reset_recorded_variables()
 
         mock_parent_reset.assert_called_once()
-        mock_delete_file.assert_called_once()
 
 
 class TestResetRecordedSecrets(unittest.TestCase):
@@ -594,9 +597,14 @@ class TestResetRecordedSecrets(unittest.TestCase):
         # Execute
         handler.reset_recorded_secrets()
 
-        # Assert parent method was called and delete_file was called with correct path
+        # Assert parent method was called and delete_file was called for recorded + staging
         mock_parent_reset.assert_called_once()
-        mock_delete_file.assert_called_once_with(project_path / "engine" / "jdinputs.secrets.auto.tfvars")
+        expected_calls = [
+            call(project_path / "engine" / "jdinputs.secrets.auto.tfvars"),
+            call(project_path / "engine" / "jdinputs.staging.secrets.auto.tfvars"),
+        ]
+        mock_delete_file.assert_has_calls(expected_calls, any_order=False)
+        self.assertEqual(mock_delete_file.call_count, 2)
 
     @patch("jupyter_deploy.engine.engine_variables.EngineVariablesHandler.reset_recorded_secrets")
     @patch("jupyter_deploy.fs_utils.delete_file_if_exists")
@@ -615,7 +623,6 @@ class TestResetRecordedSecrets(unittest.TestCase):
 
         # Assert
         mock_parent_reset.assert_called_once()
-        mock_delete_file.assert_called_once()
         self.assertTrue(result, "Should return True when file was deleted")
 
     @patch("jupyter_deploy.engine.engine_variables.EngineVariablesHandler.reset_recorded_secrets")

--- a/libs/jupyter-deploy/tests/unit/engine/test_engine_variables.py
+++ b/libs/jupyter-deploy/tests/unit/engine/test_engine_variables.py
@@ -12,10 +12,8 @@ from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
 from jupyter_deploy.exceptions import InvalidVariablesDotYamlError
 from jupyter_deploy.variables_config import (
-    VARIABLES_CONFIG_V1_COMMENTS,
-    VARIABLES_CONFIG_V1_KEYS_ORDER,
     JupyterDeployVariablesConfig,
-    JupyterDeployVariablesConfigV1,
+    JupyterDeployVariablesConfigV2,
 )
 
 
@@ -119,7 +117,7 @@ class TestVariablesConfigProperty(unittest.TestCase):
         result = handler.variables_config
 
         # Verify that a reset config was returned
-        self.assertIsInstance(result, JupyterDeployVariablesConfigV1)
+        self.assertIsInstance(result, JupyterDeployVariablesConfigV2)
         mock_retrieve.assert_called_once()
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_variables_config")
@@ -138,7 +136,7 @@ class TestVariablesConfigProperty(unittest.TestCase):
         result = handler.variables_config
 
         # Verify that a reset config was returned
-        self.assertIsInstance(result, JupyterDeployVariablesConfigV1)
+        self.assertIsInstance(result, JupyterDeployVariablesConfigV2)
         mock_retrieve.assert_called_once()
 
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_variables_config")
@@ -157,7 +155,7 @@ class TestVariablesConfigProperty(unittest.TestCase):
         result = handler.variables_config
 
         # Verify that a reset config was returned
-        self.assertIsInstance(result, JupyterDeployVariablesConfigV1)
+        self.assertIsInstance(result, JupyterDeployVariablesConfigV2)
         mock_retrieve.assert_called_once()
 
 
@@ -395,8 +393,8 @@ class TestGetVariableNamesAssignedInConfig(unittest.TestCase):
 
 
 class TestSyncProjectVariablesConfig(unittest.TestCase):
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
-    def test_handles_required_sensitive_overrides_and_defaults(self, mock_write: Mock) -> None:
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
+    def test_handles_required_sensitive_and_overrides(self, mock_write: Mock) -> None:
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
@@ -404,40 +402,30 @@ class TestSyncProjectVariablesConfig(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {"var1": "value1"}
-        mock_config.required_sensitive = {"var2": "value2"}
-        mock_config.overrides = {}
-        mock_config.defaults = {"var3": "value3", "var4": "value4", "var5": "value5"}
-
-        # Create expected model_dump output
-        expected_model_dump = {
-            "schema_version": 1,
-            "required": {"var1": "new1"},
-            "required_sensitive": {"var2": "new2"},
-            "overrides": {"var3": "new3", "var5": "new5"},
-            "defaults": {"var3": "value3", "var4": "value4", "var5": "value5"},
-        }
-
-        # Create mock for new config
-        mock_new_config = Mock()
-        mock_new_config.model_dump.return_value = expected_model_dump
-
-        # Patch the variables_config property to return our mock
+        # Create a mock variables_config (V2 — no defaults field)
+        mock_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required={"var1": "value1"},
+            required_sensitive={"var2": "value2"},
+            overrides={},
+        )
         handler._variables_config = mock_config
 
-        # Patch write_yaml_file_with_comments and JupyterDeployVariablesConfigV1
         # Execute
         updated_values = {"var1": "new1", "var2": "new2", "var3": "new3", "var5": "new5"}
         handler.sync_project_variables_config(updated_values)
 
-        # Verify that the config was updated with the new values
-        model_dump = mock_write.call_args[0][1]
-        self.assertEqual(model_dump, expected_model_dump)
+        # Verify that _write_variables_config was called with updated V2 config
+        mock_write.assert_called_once()
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
+        self.assertEqual(written_config.schema_version, 2)
+        self.assertEqual(written_config.required["var1"], "new1")
+        self.assertEqual(written_config.required_sensitive["var2"], "new2")
+        self.assertEqual(written_config.overrides["var3"], "new3")
+        self.assertEqual(written_config.overrides["var5"], "new5")
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
-    def test_calls_write_with_comments_and_key_order(self, mock_write: Mock) -> None:
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
+    def test_calls_write_once(self, mock_write: Mock) -> None:
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
@@ -445,36 +433,23 @@ class TestSyncProjectVariablesConfig(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {}
-        mock_config.overrides = {}
-        mock_config.defaults = {"var1": "value1"}
-
-        # Mock JupyterDeployVariablesConfigV1 to return a mock with model_dump method
-        mock_new_config = Mock()
-        mock_new_config.model_dump.return_value = {
-            "schema_version": 1,
-            "required": {},
-            "required_sensitive": {},
-            "overrides": {},
-            "defaults": {"var1": "value1"},
-        }
-
-        # Patch the variables_config property to return our mock
+        mock_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required={},
+            required_sensitive={},
+            overrides={},
+        )
         handler._variables_config = mock_config
 
         # Execute
         handler.sync_project_variables_config({"var1": "value1"})
 
-        # Verify that write_yaml_file_with_comments was called with the correct arguments
+        # Verify write was called once with a V2 config
         mock_write.assert_called_once()
-        self.assertEqual(mock_write.call_args[0][0], project_path / constants.VARIABLES_FILENAME)
-        self.assertEqual(mock_write.call_args[1]["key_order"], VARIABLES_CONFIG_V1_KEYS_ORDER)
-        self.assertEqual(mock_write.call_args[1]["comments"], VARIABLES_CONFIG_V1_COMMENTS)
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
+        self.assertEqual(written_config.schema_version, 2)
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
     def test_raises_when_write_method_raises(self, mock_write: Mock) -> None:
         # Setup
         project_path = Path("/mock/project")
@@ -483,27 +458,14 @@ class TestSyncProjectVariablesConfig(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {}
-        mock_config.overrides = {}
-        mock_config.defaults = {"var1": "value1"}
-
-        # Mock JupyterDeployVariablesConfigV1 to return a mock with model_dump method
-        mock_new_config = Mock()
-        mock_new_config.model_dump.return_value = {
-            "schema_version": 1,
-            "required": {},
-            "required_sensitive": {},
-            "overrides": {},
-            "defaults": {"var1": "value1"},
-        }
-
-        # Patch the variables_config property to return our mock
+        mock_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required={},
+            required_sensitive={},
+            overrides={},
+        )
         handler._variables_config = mock_config
 
-        # Make write_yaml_file_with_comments raise an exception
         mock_write.side_effect = OSError("Write error")
 
         # Execute and verify that the exception propagates
@@ -512,7 +474,7 @@ class TestSyncProjectVariablesConfig(unittest.TestCase):
 
 
 class TestResetRecordedVariables(unittest.TestCase):
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
     def test_calls_write_updating_required_and_overrides_only(self, mock_write: Mock) -> None:
         # Setup
         project_path = Path("/mock/project")
@@ -521,14 +483,12 @@ class TestResetRecordedVariables(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config with some values
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {"var1": "value1", "var2": "value2"}
-        mock_config.required_sensitive = {"var3": "value3"}
-        mock_config.overrides = {"var4": "value4"}
-        mock_config.defaults = {"var6": "value6"}
-
-        # Patch the variables_config property to return our mock
+        mock_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required={"var1": "value1", "var2": "value2"},
+            required_sensitive={"var3": "value3"},
+            overrides={"var4": "value4"},
+        )
         handler._variables_config = mock_config
 
         # Execute
@@ -536,23 +496,23 @@ class TestResetRecordedVariables(unittest.TestCase):
 
         # Verify
         mock_write.assert_called_once()
-        # Get the data that was passed to write_yaml_file_with_comments
-        written_data = mock_write.call_args[0][1]
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
 
-        # Check that all values are None
-        self.assertEqual(list(written_data["required"].keys()), list(mock_config.required.keys()))
-        for val in written_data["required"].values():
+        # Check that all required values are None
+        self.assertEqual(set(written_config.required.keys()), {"var1", "var2"})
+        for val in written_config.required.values():
             self.assertIsNone(val)
 
-        self.assertEqual(list(written_data["required_sensitive"].keys()), list(mock_config.required_sensitive.keys()))
-        for val in written_data["required_sensitive"].values():
+        # Check sensitive values are also None
+        self.assertEqual(set(written_config.required_sensitive.keys()), {"var3"})
+        for val in written_config.required_sensitive.values():
             self.assertIsNone(val)
 
         # Check that overrides is empty
-        self.assertEqual(written_data["overrides"], {})
+        self.assertEqual(written_config.overrides, {})
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
-    def test_calls_write_with_comments_and_key_order(self, mock_write: Mock) -> None:
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
+    def test_writes_v2_config(self, mock_write: Mock) -> None:
         # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
@@ -560,26 +520,18 @@ class TestResetRecordedVariables(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {}
-        mock_config.overrides = {}
-        mock_config.defaults = {}
-
-        # Patch the variables_config property to return our mock
+        mock_config = JupyterDeployVariablesConfigV2(schema_version=2, required={}, required_sensitive={}, overrides={})
         handler._variables_config = mock_config
 
         # Execute
         handler.reset_recorded_variables()
 
-        # Verify that write_yaml_file_with_comments was called with the correct arguments
+        # Verify a V2 config was written
         mock_write.assert_called_once()
-        self.assertEqual(mock_write.call_args[0][0], project_path / constants.VARIABLES_FILENAME)
-        self.assertEqual(mock_write.call_args[1]["key_order"], VARIABLES_CONFIG_V1_KEYS_ORDER)
-        self.assertEqual(mock_write.call_args[1]["comments"], VARIABLES_CONFIG_V1_COMMENTS)
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
+        self.assertEqual(written_config.schema_version, 2)
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
     def test_raises_when_write_method_raises(self, mock_write: Mock) -> None:
         # Setup
         project_path = Path("/mock/project")
@@ -588,26 +540,17 @@ class TestResetRecordedVariables(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {}
-        mock_config.overrides = {}
-        mock_config.defaults = {}
-
-        # Patch the variables_config property to return our mock
+        mock_config = JupyterDeployVariablesConfigV2(schema_version=2, required={}, required_sensitive={}, overrides={})
         handler._variables_config = mock_config
 
-        # Make write_yaml_file_with_comments raise an exception
         mock_write.side_effect = OSError("Write error")
 
-        # Execute and verify that the exception propagates
         with self.assertRaises(OSError):
             handler.reset_recorded_variables()
 
 
 class TestMaskSecrets(unittest.TestCase):
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
     def test_replaces_all_sensitive_values_with_mask(self, mock_write: Mock) -> None:
         project_path = Path("/mock/project")
         manifest = Mock()
@@ -615,28 +558,28 @@ class TestMaskSecrets(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {"var1": "value1"}
-        mock_config.required_sensitive = {"secret1": "real-secret", "secret2": "another-secret"}
-        mock_config.overrides = {"var3": "value3-override"}
-        mock_config.defaults = {"var3": "value3-default"}
+        mock_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required={"var1": "value1"},
+            required_sensitive={"secret1": "real-secret", "secret2": "another-secret"},
+            overrides={"var3": "value3-override"},
+        )
         handler._variables_config = mock_config
 
         handler.mask_secrets()
 
         mock_write.assert_called_once()
-        written_data = mock_write.call_args[0][1]
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
 
         # Sensitive values should be masked
         self.assertEqual(
-            written_data["required_sensitive"], {"secret1": MASKED_SECRET_VALUE, "secret2": MASKED_SECRET_VALUE}
+            written_config.required_sensitive, {"secret1": MASKED_SECRET_VALUE, "secret2": MASKED_SECRET_VALUE}
         )
         # Non-sensitive values should be preserved
-        self.assertEqual(written_data["required"], {"var1": "value1"})
-        self.assertEqual(written_data["overrides"], {"var3": "value3-override"})
-        self.assertEqual(written_data["defaults"], {"var3": "value3-default"})
+        self.assertEqual(written_config.required, {"var1": "value1"})
+        self.assertEqual(written_config.overrides, {"var3": "value3-override"})
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
     def test_masks_none_values_too(self, mock_write: Mock) -> None:
         project_path = Path("/mock/project")
         manifest = Mock()
@@ -644,22 +587,23 @@ class TestMaskSecrets(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {"secret1": None, "secret2": "value"}
-        mock_config.overrides = {}
-        mock_config.defaults = {}
+        mock_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required={},
+            required_sensitive={"secret1": None, "secret2": "value"},
+            overrides={},
+        )
         handler._variables_config = mock_config
 
         handler.mask_secrets()
 
         mock_write.assert_called_once()
-        written_data = mock_write.call_args[0][1]
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
         self.assertEqual(
-            written_data["required_sensitive"], {"secret1": MASKED_SECRET_VALUE, "secret2": MASKED_SECRET_VALUE}
+            written_config.required_sensitive, {"secret1": MASKED_SECRET_VALUE, "secret2": MASKED_SECRET_VALUE}
         )
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
     def test_updates_cached_config(self, mock_write: Mock) -> None:
         project_path = Path("/mock/project")
         manifest = Mock()
@@ -667,12 +611,19 @@ class TestMaskSecrets(unittest.TestCase):
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {"secret1": "real-value"}
-        mock_config.overrides = {}
-        mock_config.defaults = {}
+        mock_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required={},
+            required_sensitive={"secret1": "real-value"},
+            overrides={},
+        )
         handler._variables_config = mock_config
+
+        # Make the mock actually update the cache like the real method does
+        def fake_write(config: JupyterDeployVariablesConfigV2) -> None:
+            handler._variables_config = config
+
+        mock_write.side_effect = fake_write
 
         handler.mask_secrets()
 
@@ -681,125 +632,85 @@ class TestMaskSecrets(unittest.TestCase):
         assert handler._variables_config is not None
         self.assertEqual(handler._variables_config.required_sensitive["secret1"], MASKED_SECRET_VALUE)
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
-    def test_writes_with_comments_and_key_order(self, mock_write: Mock) -> None:
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
+    def test_writes_v2_config(self, mock_write: Mock) -> None:
         project_path = Path("/mock/project")
         manifest = Mock()
         handler = DummyVariablesHandler(
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {}
-        mock_config.overrides = {}
-        mock_config.defaults = {}
+        mock_config = JupyterDeployVariablesConfigV2(schema_version=2, required={}, required_sensitive={}, overrides={})
         handler._variables_config = mock_config
 
         handler.mask_secrets()
 
         mock_write.assert_called_once()
-        self.assertEqual(mock_write.call_args[0][0], project_path / constants.VARIABLES_FILENAME)
-        self.assertEqual(mock_write.call_args[1]["key_order"], VARIABLES_CONFIG_V1_KEYS_ORDER)
-        self.assertEqual(mock_write.call_args[1]["comments"], VARIABLES_CONFIG_V1_COMMENTS)
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
+        self.assertEqual(written_config.schema_version, 2)
 
 
 class TestResetRecordedSecrets(unittest.TestCase):
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
     def test_calls_write_updating_sensitives_only(self, mock_write: Mock) -> None:
-        # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
         handler = DummyVariablesHandler(
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config with some values
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {"var1": "value1", "var2": "value2"}
-        mock_config.required_sensitive = {"var3": "value3", "var4": "value4"}
-        mock_config.overrides = {"var5": "value55"}
-        mock_config.defaults = {"var5": "value5", "var6": "value6"}
-
-        # Create mock for new config with model_dump
-        mock_new_config = Mock()
-        mock_new_config.model_dump.return_value = {
-            "schema_version": 1,
-            "required": {"var1": "value1", "var2": "value2"},
-            "required_sensitive": {"var3": None, "var4": None},
-            "overrides": {"var5": "value55"},
-            "defaults": {"var5": "value5", "var6": "value6"},
-        }
-
-        # Patch the variables_config property to return our mock
+        mock_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required={"var1": "value1", "var2": "value2"},
+            required_sensitive={"var3": "value3", "var4": "value4"},
+            overrides={"var5": "value55"},
+        )
         handler._variables_config = mock_config
 
-        # Execute with patched JupyterDeployVariablesConfigV1
         handler.reset_recorded_secrets()
 
         # Verify
         mock_write.assert_called_once()
-        # Get the data that was passed to write_yaml_file_with_comments
-        written_data = mock_write.call_args[0][1]
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
 
-        # Check the model_dump output was passed to write_yaml_file_with_comments
-        self.assertEqual(written_data, mock_new_config.model_dump.return_value)
-
-        # Check that required_sensitive keys are preserved but values are None
-        self.assertEqual(list(written_data["required_sensitive"].keys()), list(mock_config.required_sensitive.keys()))
-        for val in written_data["required_sensitive"].values():
+        # Required preserved
+        self.assertEqual(written_config.required, {"var1": "value1", "var2": "value2"})
+        # Overrides preserved
+        self.assertEqual(written_config.overrides, {"var5": "value55"})
+        # Sensitive keys preserved but values are None
+        self.assertEqual(set(written_config.required_sensitive.keys()), {"var3", "var4"})
+        for val in written_config.required_sensitive.values():
             self.assertIsNone(val)
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
-    def test_calls_write_with_comments_and_key_order(self, mock_write: Mock) -> None:
-        # Setup
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
+    def test_writes_v2_config(self, mock_write: Mock) -> None:
         project_path = Path("/mock/project")
         manifest = Mock()
         handler = DummyVariablesHandler(
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {}
-        mock_config.overrides = {}
-        mock_config.defaults = {}
-
-        # Patch the variables_config property to return our mock
+        mock_config = JupyterDeployVariablesConfigV2(schema_version=2, required={}, required_sensitive={}, overrides={})
         handler._variables_config = mock_config
 
-        # Execute
         handler.reset_recorded_secrets()
 
-        # Verify that write_yaml_file_with_comments was called with the correct arguments
         mock_write.assert_called_once()
-        self.assertEqual(mock_write.call_args[0][0], project_path / constants.VARIABLES_FILENAME)
-        self.assertEqual(mock_write.call_args[1]["key_order"], VARIABLES_CONFIG_V1_KEYS_ORDER)
-        self.assertEqual(mock_write.call_args[1]["comments"], VARIABLES_CONFIG_V1_COMMENTS)
+        written_config: JupyterDeployVariablesConfigV2 = mock_write.call_args[0][0]
+        self.assertEqual(written_config.schema_version, 2)
 
-    @patch("jupyter_deploy.fs_utils.write_yaml_file_with_comments")
+    @patch.object(DummyVariablesHandler, "_write_variables_config")
     def test_raises_when_write_method_raises(self, mock_write: Mock) -> None:
-        # Setup
         project_path = Path("/mock/project")
         manifest = Mock()
         handler = DummyVariablesHandler(
             project_path=project_path, project_manifest=manifest, display_manager=NullDisplay()
         )
 
-        # Create a mock variables_config
-        mock_config = Mock(spec=JupyterDeployVariablesConfig)
-        mock_config.required = {}
-        mock_config.required_sensitive = {}
-        mock_config.overrides = {}
-        mock_config.defaults = {}
-
-        # Patch the variables_config property to return our mock
+        mock_config = JupyterDeployVariablesConfigV2(schema_version=2, required={}, required_sensitive={}, overrides={})
         handler._variables_config = mock_config
 
-        # Make write_yaml_file_with_comments raise an exception
         mock_write.side_effect = OSError("Write error")
 
-        # Execute and verify that the exception propagates
         with self.assertRaises(OSError):
             handler.reset_recorded_secrets()

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_config_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_config_handler.py
@@ -15,7 +15,7 @@ from jupyter_deploy.handlers.project.config_handler import ConfigHandler
 from jupyter_deploy.manifest import JupyterDeployManifestV1, JupyterDeployProjectStoreV1
 from jupyter_deploy.provider.store.store_manager import StoreInfo
 from jupyter_deploy.store_config import JupyterDeployStoreConfigV1
-from jupyter_deploy.variables_config import JupyterDeployVariablesConfig
+from jupyter_deploy.variables_config import JupyterDeployVariablesConfigV2
 from jupyter_deploy.verify_utils import ToolRequiredError
 
 
@@ -581,8 +581,8 @@ class TestConfigHandler(unittest.TestCase):
         mock_tf_handler.return_value = tf_mock_handler_instance
 
         # Set up variables_handler to return a config with no sensitive vars
-        mock_vars_config = JupyterDeployVariablesConfig(
-            schema_version=1,
+        mock_vars_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
             required={"domain": "example.com"},
             required_sensitive={},
         )
@@ -601,8 +601,8 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_handler_instance, _ = self.get_mock_handler_and_fns()
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        mock_vars_config = JupyterDeployVariablesConfig(
-            schema_version=1,
+        mock_vars_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
             required={},
             required_sensitive={"my_secret": MASKED_SECRET_VALUE},
         )
@@ -647,8 +647,8 @@ class TestConfigHandler(unittest.TestCase):
         tf_mock_handler_instance, _ = self.get_mock_handler_and_fns()
         mock_tf_handler.return_value = tf_mock_handler_instance
 
-        mock_vars_config = JupyterDeployVariablesConfig(
-            schema_version=1,
+        mock_vars_config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
             required={},
             required_sensitive={"oauth_secret": MASKED_SECRET_VALUE},
         )

--- a/libs/jupyter-deploy/tests/unit/handlers/test_base_project_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_base_project_handler.py
@@ -301,9 +301,8 @@ class TestRetrieveVariablesConfig(unittest.TestCase):
         ),
     )
     @patch("yaml.safe_load")
-    @patch("jupyter_deploy.variables_config.JupyterDeployVariablesConfig")
     def test_open_file_call_safe_load_and_parse(
-        self, mock_config_class: Mock, mock_yaml_load: Mock, mock_open_file: Mock, mock_file_exists: Mock
+        self, mock_yaml_load: Mock, mock_open_file: Mock, mock_file_exists: Mock
     ) -> None:
         # Setup
         mock_file_exists.return_value = True
@@ -316,8 +315,6 @@ class TestRetrieveVariablesConfig(unittest.TestCase):
             "defaults": {"var3": "default3"},
         }
         mock_yaml_load.return_value = yaml_content
-        mock_config = Mock()
-        mock_config_class.return_value = mock_config
 
         # Execute
         result = retrieve_variables_config(variables_config_path)
@@ -325,8 +322,8 @@ class TestRetrieveVariablesConfig(unittest.TestCase):
         # Assert
         mock_open_file.assert_called_once_with(variables_config_path)
         mock_yaml_load.assert_called_once()
-        mock_config_class.assert_called_once_with(**yaml_content)
-        self.assertEqual(result, mock_config)
+        self.assertEqual(result.schema_version, 1)
+        self.assertEqual(result.required["var1"], "value1")
 
     @patch("jupyter_deploy.fs_utils.file_exists")
     @patch("builtins.open", new_callable=mock_open)
@@ -362,12 +359,12 @@ class TestRetrieveVariablesConfig(unittest.TestCase):
             # Execute
             result = retrieve_variables_config(variables_config_path)
 
-            # Assert
+            # Assert — V1 parsed successfully
             self.assertEqual(result.schema_version, 1)
             self.assertEqual(result.required["var1"], "value1")
             self.assertEqual(result.required_sensitive["var2"], "value2")
             self.assertEqual(result.overrides["var3"], "value3")
-            self.assertEqual(result.defaults["var3"], "default3")
+            self.assertEqual(result.defaults["var3"], "default3")  # type: ignore[union-attr]
 
     @patch("jupyter_deploy.fs_utils.file_exists")
     @patch("builtins.open")

--- a/libs/jupyter-deploy/tests/unit/mock_variables_v2.yaml
+++ b/libs/jupyter-deploy/tests/unit/mock_variables_v2.yaml
@@ -1,0 +1,21 @@
+schema_version: 2
+
+required:
+  # fill in values below, or run 'jd config' for the interactive experience
+  region: "us-west-2"
+  bucket_name: null
+  storage_region: null
+
+required_sensitive:
+  # fill in values below, or run 'jd config' for the interactive experience
+  # values entered here will be masked after running 'jd config'
+  aws_access_key: "dummy-access-key"
+  aws_secret_key: null
+  api_token: null
+
+overrides:
+  # uncomment and change a value to override the default
+  deployment_type: "t3.large"
+  storage_size: 100
+  # server_name: "jupyter-server"
+  # enable_monitoring: true

--- a/libs/jupyter-deploy/tests/unit/mock_variables_v2_initial.yaml
+++ b/libs/jupyter-deploy/tests/unit/mock_variables_v2_initial.yaml
@@ -1,0 +1,20 @@
+schema_version: 2
+
+required:
+  # fill in values below, or run 'jd config' for the interactive experience
+  region: null
+  bucket_name: null
+  storage_region: null
+
+required_sensitive:
+  # fill in values below, or run 'jd config' for the interactive experience
+  # values entered here will be masked after running 'jd config'
+  aws_secret_key: null
+  api_token: null
+
+overrides:
+  # uncomment and change a value to override the default
+  # deployment_type: "t3.medium"
+  # storage_size: 50
+  # server_name: "jupyter-server"
+  # enable_monitoring: true

--- a/libs/jupyter-deploy/tests/unit/test_fs_utils_for_variables_yaml.py
+++ b/libs/jupyter-deploy/tests/unit/test_fs_utils_for_variables_yaml.py
@@ -1,0 +1,212 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from jupyter_deploy.fs_utils import (
+    read_yaml_reference_file,
+    write_yaml_file_with_comments,
+    write_yaml_reference_file,
+)
+from jupyter_deploy.variables_config import (
+    VARIABLES_CONFIG_V2_COMMENTS,
+    VARIABLES_CONFIG_V2_KEYS_ORDER,
+)
+
+
+class TestWriteYamlFileWithCommentedEntries(unittest.TestCase):
+    def _write_v2(
+        self,
+        path: Path,
+        required: dict,
+        required_sensitive: dict,
+        overrides: dict,
+        defaults_for_comments: dict,
+    ) -> None:
+        content = {
+            "schema_version": 2,
+            "required": required,
+            "required_sensitive": required_sensitive,
+            "overrides": overrides,
+        }
+        write_yaml_file_with_comments(
+            file_path=path,
+            content=content,
+            key_order=VARIABLES_CONFIG_V2_KEYS_ORDER,
+            comments=VARIABLES_CONFIG_V2_COMMENTS,
+            commented_entries={"overrides": defaults_for_comments},
+        )
+
+    def test_write_basic_v2(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variables.yaml"
+            self._write_v2(
+                path=path,
+                required={"domain": "example.com", "email": None},
+                required_sensitive={"secret": "****"},
+                overrides={"region": "eu-west-1"},
+                defaults_for_comments={"region": "us-west-2", "instance_type": "t3.medium"},
+            )
+
+            content = path.read_text()
+            # Verify schema_version
+            self.assertIn("schema_version: 2", content)
+            # Verify required section
+            self.assertIn("domain: example.com", content)
+            self.assertIn("email: null", content)
+            # Verify sensitive section
+            self.assertIn("secret: '****'", content)
+            # Verify active override
+            self.assertIn("  region: eu-west-1", content)
+            # Verify inactive default as comment (region is active, so only instance_type)
+            self.assertIn("  # instance_type: t3.medium", content)
+            # region should NOT appear as a comment (it's an active override)
+            commented_lines = [line for line in content.splitlines() if line.strip().startswith("# region:")]
+            self.assertEqual(len(commented_lines), 0)
+
+    def test_write_empty_overrides_all_commented(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variables.yaml"
+            self._write_v2(
+                path=path,
+                required={"domain": None},
+                required_sensitive={},
+                overrides={},
+                defaults_for_comments={"region": "us-west-2", "size": 30},
+            )
+
+            content = path.read_text()
+            self.assertIn("  # region: us-west-2", content)
+            self.assertIn("  # size: 30", content)
+
+    def test_write_complex_defaults_as_multiline_comments(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variables.yaml"
+            defaults = {
+                "node_groups": [
+                    {"name": "workers", "instance_type": "t3.medium", "size": 2},
+                    {"name": "gpu", "instance_type": "p3.2xlarge", "size": 1},
+                ],
+                "tags": {"env": "prod", "team": "ml"},
+            }
+            self._write_v2(
+                path=path,
+                required={},
+                required_sensitive={},
+                overrides={},
+                defaults_for_comments=defaults,
+            )
+
+            content = path.read_text()
+            # Should have multi-line comments for complex types
+            self.assertIn("  # node_groups:", content)
+            self.assertIn("  # - name: workers", content)
+            self.assertIn("  #   instance_type: t3.medium", content)
+            self.assertIn("  # tags:", content)
+            self.assertIn("  #   env: prod", content)
+
+    def test_write_parseable_as_v2(self) -> None:
+        """Verify the output is valid YAML and parses as schema_version 2."""
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variables.yaml"
+            self._write_v2(
+                path=path,
+                required={"domain": "example.com"},
+                required_sensitive={"secret": None},
+                overrides={"region": "us-west-2"},
+                defaults_for_comments={"region": "us-east-1", "size": 10},
+            )
+
+            with open(path) as f:
+                parsed = yaml.safe_load(f)
+
+            self.assertEqual(parsed["schema_version"], 2)
+            self.assertEqual(parsed["required"]["domain"], "example.com")
+            self.assertEqual(parsed["overrides"]["region"], "us-west-2")
+            # Comments are ignored by YAML parser, so size should not be in overrides
+            self.assertNotIn("size", parsed.get("overrides", {}))
+
+    def test_write_no_defaults_section(self) -> None:
+        """Ensure no 'defaults:' section appears in v2 output."""
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variables.yaml"
+            self._write_v2(
+                path=path,
+                required={"domain": None},
+                required_sensitive={},
+                overrides={},
+                defaults_for_comments={"region": "us-west-2"},
+            )
+
+            content = path.read_text()
+            # Should not have a top-level 'defaults:' key
+            lines = content.splitlines()
+            top_level_defaults = [line for line in lines if line.startswith("defaults:")]
+            self.assertEqual(len(top_level_defaults), 0)
+
+    def test_header_comments_present(self) -> None:
+        """Verify section header comments appear."""
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variables.yaml"
+            self._write_v2(
+                path=path,
+                required={"domain": None},
+                required_sensitive={"secret": None},
+                overrides={},
+                defaults_for_comments={"region": "us-west-2"},
+            )
+
+            content = path.read_text()
+            self.assertIn("# fill in values below", content)
+            self.assertIn("# uncomment and change a value to override the default", content)
+            self.assertIn("# values entered here will be masked", content)
+
+
+class TestYamlReferenceFile(unittest.TestCase):
+    def test_write_and_read(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / ".jd" / "variables-defaults.yaml"
+            defaults = {
+                "region": "us-west-2",
+                "instance_type": "t3.medium",
+                "node_groups": [{"name": "workers", "size": 2}],
+            }
+            write_yaml_reference_file(path, defaults, header="auto-generated")
+            result = read_yaml_reference_file(path)
+
+            self.assertEqual(result["region"], "us-west-2")
+            self.assertEqual(result["instance_type"], "t3.medium")
+            self.assertEqual(result["node_groups"], [{"name": "workers", "size": 2}])
+
+    def test_read_nonexistent_returns_empty(self) -> None:
+        path = Path("/nonexistent/path/variables-defaults.yaml")
+        result = read_yaml_reference_file(path)
+        self.assertEqual(result, {})
+
+    def test_write_creates_parent_dirs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "deep" / "nested" / "variables-defaults.yaml"
+            write_yaml_reference_file(path, {"region": "us-west-2"})
+            self.assertTrue(path.exists())
+
+    def test_write_empty_defaults(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variables-defaults.yaml"
+            write_yaml_reference_file(path, {})
+            result = read_yaml_reference_file(path)
+            self.assertEqual(result, {})
+
+    def test_read_invalid_content_returns_empty(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "variables-defaults.yaml"
+            path.write_text("not a dict\n")
+            result = read_yaml_reference_file(path)
+            self.assertEqual(result, {})
+
+    def test_header_written(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "defaults.yaml"
+            write_yaml_reference_file(path, {"x": 1}, header="do not edit")
+            content = path.read_text()
+            self.assertTrue(content.startswith("# do not edit\n"))

--- a/libs/jupyter-deploy/tests/unit/test_variables_config_v2.py
+++ b/libs/jupyter-deploy/tests/unit/test_variables_config_v2.py
@@ -1,0 +1,171 @@
+import unittest
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from jupyter_deploy.variables_config import (
+    VARIABLES_CONFIG_V2_KEYS_ORDER,
+    JupyterDeployVariablesConfigV1,
+    JupyterDeployVariablesConfigV2,
+    migrate_variables_dot_yaml_to_latest,
+)
+
+
+class TestJupyterDeployVariablesConfigV2(unittest.TestCase):
+    variables_v2_content: str
+    variables_v2_parsed_content: Any
+    variables_v2_initial_content: str
+    variables_v2_initial_parsed_content: Any
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        mock_variables_path = Path(__file__).parent / "mock_variables_v2.yaml"
+        with open(mock_variables_path) as f:
+            cls.variables_v2_content = f.read()
+        cls.variables_v2_parsed_content = yaml.safe_load(cls.variables_v2_content)
+
+        mock_variables_initial_path = Path(__file__).parent / "mock_variables_v2_initial.yaml"
+        with open(mock_variables_initial_path) as f:
+            cls.variables_v2_initial_content = f.read()
+        cls.variables_v2_initial_parsed_content = yaml.safe_load(cls.variables_v2_initial_content)
+
+    def test_can_parse_variables_v2(self) -> None:
+        config = JupyterDeployVariablesConfigV2(**self.variables_v2_parsed_content)
+        self.assertEqual(config.schema_version, 2)
+
+    def test_variables_v2_required(self) -> None:
+        config = JupyterDeployVariablesConfigV2(**self.variables_v2_parsed_content)
+        self.assertEqual(config.required["region"], "us-west-2")
+        self.assertIsNone(config.required["bucket_name"])
+        self.assertIsNone(config.required["storage_region"])
+
+    def test_variables_v2_required_sensitive(self) -> None:
+        config = JupyterDeployVariablesConfigV2(**self.variables_v2_parsed_content)
+        self.assertEqual(config.required_sensitive["aws_access_key"], "dummy-access-key")
+        self.assertIsNone(config.required_sensitive["aws_secret_key"])
+        self.assertIsNone(config.required_sensitive["api_token"])
+
+    def test_variables_v2_overrides(self) -> None:
+        config = JupyterDeployVariablesConfigV2(**self.variables_v2_parsed_content)
+        self.assertEqual(config.overrides["deployment_type"], "t3.large")
+        self.assertEqual(config.overrides["storage_size"], 100)
+
+    def test_variables_v2_no_defaults_field(self) -> None:
+        config = JupyterDeployVariablesConfigV2(**self.variables_v2_parsed_content)
+        self.assertFalse(hasattr(config, "defaults"))
+
+    def test_can_parse_initial_v2(self) -> None:
+        config = JupyterDeployVariablesConfigV2(**self.variables_v2_initial_parsed_content)
+        self.assertEqual(config.schema_version, 2)
+        self.assertEqual(config.overrides, {})
+
+    def test_v2_none_sections_become_empty_dict(self) -> None:
+        config = JupyterDeployVariablesConfigV2(
+            schema_version=2,
+            required=None,  # type: ignore[arg-type]
+            required_sensitive=None,  # type: ignore[arg-type]
+            overrides=None,  # type: ignore[arg-type]
+        )
+        self.assertEqual(config.required, {})
+        self.assertEqual(config.required_sensitive, {})
+        self.assertEqual(config.overrides, {})
+
+    def test_v2_check_no_var_name_repeat_required_sensitive(self) -> None:
+        with self.assertRaises(ValueError) as context:
+            JupyterDeployVariablesConfigV2(
+                schema_version=2,
+                required={"my_var": "value"},
+                required_sensitive={"my_var": "secret"},
+                overrides={},
+            )
+        self.assertIn("Variables definition conflict", str(context.exception))
+        self.assertIn("my_var", str(context.exception))
+
+    def test_v2_check_no_var_name_repeat_required_override(self) -> None:
+        with self.assertRaises(ValueError) as context:
+            JupyterDeployVariablesConfigV2(
+                schema_version=2,
+                required={"my_var": "value"},
+                required_sensitive={},
+                overrides={"my_var": "override"},
+            )
+        self.assertIn("Variables definition conflict", str(context.exception))
+        self.assertIn("my_var", str(context.exception))
+
+    def test_v2_check_no_var_name_repeat_sensitive_override(self) -> None:
+        with self.assertRaises(ValueError) as context:
+            JupyterDeployVariablesConfigV2(
+                schema_version=2,
+                required={},
+                required_sensitive={"my_var": "secret"},
+                overrides={"my_var": "override"},
+            )
+        self.assertIn("Variables definition conflict", str(context.exception))
+        self.assertIn("my_var", str(context.exception))
+
+    def test_keys_order(self) -> None:
+        expected_order = ["schema_version", "required", "required_sensitive", "overrides"]
+        self.assertEqual(VARIABLES_CONFIG_V2_KEYS_ORDER, expected_order)
+
+
+class TestMigrateV1ToV2(unittest.TestCase):
+    def test_basic_migration(self) -> None:
+        v1 = JupyterDeployVariablesConfigV1(
+            schema_version=1,
+            required={"domain": "example.com", "email": None},
+            required_sensitive={"secret": "****"},
+            overrides={"region": "eu-west-1"},
+            defaults={"region": "us-west-2", "instance_type": "t3.medium"},
+        )
+        v2 = migrate_variables_dot_yaml_to_latest(v1)
+
+        self.assertEqual(v2.schema_version, 2)
+        self.assertEqual(v2.required, {"domain": "example.com", "email": None})
+        self.assertEqual(v2.required_sensitive, {"secret": "****"})
+        self.assertEqual(v2.overrides, {"region": "eu-west-1"})
+        self.assertFalse(hasattr(v2, "defaults"))
+
+    def test_migration_empty_overrides(self) -> None:
+        v1 = JupyterDeployVariablesConfigV1(
+            schema_version=1,
+            required={"domain": None},
+            required_sensitive={},
+            overrides={},
+            defaults={"region": "us-west-2"},
+        )
+        v2 = migrate_variables_dot_yaml_to_latest(v1)
+
+        self.assertEqual(v2.overrides, {})
+        self.assertEqual(v2.required, {"domain": None})
+
+    def test_migration_preserves_complex_values(self) -> None:
+        v1 = JupyterDeployVariablesConfigV1(
+            schema_version=1,
+            required={"teams": ["team-a", "team-b"]},
+            required_sensitive={},
+            overrides={"node_groups": [{"name": "workers", "size": 3}]},
+            defaults={"node_groups": [{"name": "workers", "size": 1}], "tags": {}},
+        )
+        v2 = migrate_variables_dot_yaml_to_latest(v1)
+
+        self.assertEqual(v2.required["teams"], ["team-a", "team-b"])
+        self.assertEqual(v2.overrides["node_groups"], [{"name": "workers", "size": 3}])
+
+    def test_migration_does_not_mutate_v1(self) -> None:
+        v1 = JupyterDeployVariablesConfigV1(
+            schema_version=1,
+            required={"domain": "example.com"},
+            required_sensitive={"secret": "value"},
+            overrides={"region": "eu-west-1"},
+            defaults={"region": "us-west-2"},
+        )
+        original_required = v1.required.copy()
+        original_overrides = v1.overrides.copy()
+
+        v2 = migrate_variables_dot_yaml_to_latest(v1)
+        v2.required["domain"] = "changed.com"
+        v2.overrides["region"] = "changed"
+
+        self.assertEqual(v1.required, original_required)
+        self.assertEqual(v1.overrides, original_overrides)

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/variables.yaml
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/variables.yaml
@@ -1,7 +1,7 @@
-schema_version: 1
+schema_version: 2
+
 required:
-  # either assign values below
-  # or run 'jd config' to use the interactive experience
+  # fill in values below, or run 'jd config' for the interactive experience
   github_org: null
   github_repo: null
   github_bot_account_email: null
@@ -12,9 +12,9 @@ required:
   github_oauth_app_4: {}
   github_oauth_app_5: {}
   github_oauth_app_6: {}
+
 required_sensitive:
-  # either assign values below
-  # or run 'jd config' to use the interactive experience
+  # fill in values below, or run 'jd config' for the interactive experience
   # values entered here will be masked after running 'jd config'
   github_bot_account_password: null
   github_bot_account_recovery_codes: null
@@ -25,19 +25,17 @@ required_sensitive:
   github_oauth_app_client_secret_4: null
   github_oauth_app_client_secret_5: null
   github_oauth_app_client_secret_6: null
+
 overrides:
-  # set variable values as <variable-name>: <variable-value>
-  # delete or comment out a line to use the default
-  # github_ci_iam_roles_prefix: my-custom-prefix
-  # iam_managed_policies_e2e: ["AdministratorAccess"]
-defaults:
-  # read-only: do not modify this section
-  # instead add overrides in the override section
-  region: us-east-1
-  secret_name_prefix: jupyter-infra-ci
-  github_ci_iam_roles_prefix: jupyter-infra-ci
-  create_oidc_provider: true
-  iam_managed_policies_e2e: ["AdministratorAccess"]
-  iam_managed_policies_release: ["AdministratorAccess"]
-  maintainer_roles: ["Admin"]
-  test_results_bucket_prefix: jd-ci-e2e-results
+  # uncomment and change a value to override the default
+  # region: us-east-1
+  # secret_name_prefix: jupyter-infra-ci
+  # github_ci_iam_roles_prefix: jupyter-infra-ci
+  # create_oidc_provider: true
+  # iam_managed_policies_e2e:
+  #   - AdministratorAccess
+  # iam_managed_policies_release:
+  #   - AdministratorAccess
+  # maintainer_roles:
+  #   - Admin
+  # test_results_bucket_prefix: jd-ci-e2e-results

--- a/libs/jupyter-infra-tf-aws-iam-ci/tests/e2e/configurations/base.yaml
+++ b/libs/jupyter-infra-tf-aws-iam-ci/tests/e2e/configurations/base.yaml
@@ -1,4 +1,4 @@
-schema_version: 1
+schema_version: 2
 required:
   github_org: "fake-test-org"
   github_repo: "fake-test-repo"
@@ -44,17 +44,4 @@ required_sensitive:
   github_oauth_app_client_secret_4: "d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0"
   github_oauth_app_client_secret_5: "e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0e0"
   github_oauth_app_client_secret_6: "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
-overrides:
-  # set variable values as <variable-name>: <variable-value>
-  # delete or comment out a line to use the default
-defaults:
-  # read-only: do not modify this section
-  # instead add overrides in the override section
-  region: us-east-1
-  secret_name_prefix: jupyter-infra-ci
-  github_ci_iam_roles_prefix: jupyter-infra-ci
-  create_oidc_provider: true
-  iam_managed_policies_e2e: ["AdministratorAccess"]
-  iam_managed_policies_release: ["AdministratorAccess"]
-  maintainer_roles: ["Admin"]
-  test_results_bucket_prefix: jd-ci-e2e-results
+overrides: {}

--- a/libs/jupyter-infra-tf-aws-iam-ci/tests/unit/test_ci_variables_yaml.py
+++ b/libs/jupyter-infra-tf-aws-iam-ci/tests/unit/test_ci_variables_yaml.py
@@ -143,3 +143,65 @@ class TestVariablesYaml(unittest.TestCase):
     def test_variables_file_parsable_by_base_project_handler(self) -> None:
         variables_config = base_project_handler.retrieve_variables_config(self.VARIABLES_CONFIG_PATH)
         self.assertIsNotNone(variables_config)
+
+    def test_commented_overrides_match_preset_keys(self) -> None:
+        """All commented-out overrides in variables.yaml should exist in the preset."""
+        commented_vars = self._parse_commented_overrides()
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        missing = set(commented_vars.keys()) - preset_vars
+        self.assertEqual(len(missing), 0, f"Commented overrides not found in preset: {missing}")
+
+    def test_commented_overrides_values_match_preset(self) -> None:
+        """Commented-out override values should match the preset defaults."""
+        commented_vars = self._parse_commented_overrides()
+
+        for var_name, var_value in commented_vars.items():
+            if var_name not in self.DEFAULTS_ALL_TFVARS:
+                continue
+            preset_value = self.DEFAULTS_ALL_TFVARS[var_name]
+            self.assertEqual(
+                var_value,
+                preset_value,
+                f"Commented override '{var_name}' has value {var_value!r} "
+                f"but preset has {preset_value!r}",
+            )
+
+    def test_all_preset_vars_appear_as_commented_overrides(self) -> None:
+        """Every variable in the preset should appear as a commented override in variables.yaml."""
+        commented_vars = self._parse_commented_overrides()
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        missing = preset_vars - set(commented_vars.keys())
+        self.assertEqual(
+            len(missing), 0, f"Preset variables missing from commented overrides: {missing}"
+        )
+
+    @classmethod
+    def _parse_commented_overrides(cls) -> dict:
+        """Parse commented-out key-value pairs from the overrides section of variables.yaml."""
+        with open(cls.VARIABLES_CONFIG_PATH) as f:
+            lines = f.readlines()
+
+        in_overrides = False
+        commented_yaml_lines: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("overrides:"):
+                in_overrides = True
+                continue
+            if in_overrides and not stripped.startswith("#") and stripped:
+                if not line.startswith(" "):
+                    break
+            if in_overrides and stripped.startswith("# "):
+                content_after_hash = stripped[2:]
+                if content_after_hash.startswith("uncomment"):
+                    continue
+                commented_yaml_lines.append(content_after_hash)
+
+        if not commented_yaml_lines:
+            return {}
+
+        combined = "\n".join(commented_yaml_lines)
+        result = yaml.safe_load(combined)
+        return result if isinstance(result, dict) else {}

--- a/libs/jupyter-infra-tf-aws-iam-ci/tests/unit/test_ci_variables_yaml.py
+++ b/libs/jupyter-infra-tf-aws-iam-ci/tests/unit/test_ci_variables_yaml.py
@@ -46,31 +46,22 @@ class TestVariablesYaml(unittest.TestCase):
 
             TestVariablesYaml.TF_VARIABLES = tf_variables
 
+    def test_schema_version_is_2(self) -> None:
+        self.assertEqual(self.VARIABLES_CONFIG["schema_version"], 2)
+
     def test_all_keys_are_present(self) -> None:
         self.assertIn("required", self.VARIABLES_CONFIG)
         self.assertIn("required_sensitive", self.VARIABLES_CONFIG)
         self.assertIn("overrides", self.VARIABLES_CONFIG)
-        self.assertIn("defaults", self.VARIABLES_CONFIG)
+
+    def test_no_defaults_section(self) -> None:
+        self.assertNotIn("defaults", self.VARIABLES_CONFIG)
 
     def test_no_overlap_between_required_and_required_sensitive(self) -> None:
         required_vars = set(self.VARIABLES_CONFIG["required"].keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG["required_sensitive"].keys())
 
         overlap = required_vars.intersection(required_sensitive_vars)
-        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
-
-    def test_no_overlap_between_required_and_defaults(self) -> None:
-        required_vars = set(self.VARIABLES_CONFIG["required"].keys())
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-
-        overlap = required_vars.intersection(default_vars)
-        self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
-
-    def test_no_overlap_between_required_sensitive_and_defaults(self) -> None:
-        required_sensitive_vars = set(self.VARIABLES_CONFIG["required_sensitive"].keys())
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-
-        overlap = required_sensitive_vars.intersection(default_vars)
         self.assertEqual(len(overlap), 0, f"Found overlapping variables: {overlap}")
 
     def test_all_required_set_to_none_or_empty_dict(self) -> None:
@@ -91,100 +82,41 @@ class TestVariablesYaml(unittest.TestCase):
             f"Overrides should be empty in default variables.yaml, found: {overrides}",
         )
 
-    def test_all_defaults_varname_exist_in_all_preset(self) -> None:
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
-
-        missing_vars = default_vars - preset_vars
-        self.assertEqual(
-            len(missing_vars), 0, f"Variables in defaults section not found in defaults-all.tfvars: {missing_vars}"
-        )
-
-    def test_defaults_varname_count_equal_varnames_in_all_preset(self) -> None:
-        default_vars = set(self.VARIABLES_CONFIG["defaults"].keys())
-        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
-
-        self.assertEqual(
-            len(default_vars),
-            len(preset_vars),
-            f"Number of variables in defaults ({len(default_vars)}) does not match "
-            f"number in defaults-all.tfvars ({len(preset_vars)})",
-        )
-
-    def test_all_values_in_defaults_match_preset(self) -> None:
-        for var_name, var_value in self.VARIABLES_CONFIG["defaults"].items():
-            self.assertIn(var_name, self.DEFAULTS_ALL_TFVARS)
-
-            if var_value == {}:
-                self.assertEqual(
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    {},
-                    f"Value mismatch for {var_name}: variables.yaml has {var_value}, "
-                    f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                )
-            elif var_value == []:
-                self.assertEqual(
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    [],
-                    f"Value mismatch for {var_name}: variables.yaml has {var_value}, "
-                    f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                )
-            elif var_value is None:
-                self.assertIsNone(
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    f"Value mismatch for {var_name}: variables.yaml has None, "
-                    f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                )
-            else:
-                self.assertEqual(
-                    var_value,
-                    self.DEFAULTS_ALL_TFVARS[var_name],
-                    f"Value mismatch for {var_name}: variables.yaml has {var_value}, "
-                    f"defaults-all.tfvars has {self.DEFAULTS_ALL_TFVARS[var_name]}",
-                )
-
     def test_all_variables_in_yaml_exist_in_tf(self) -> None:
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
 
-        all_yaml_vars = required_vars.union(required_sensitive_vars).union(defaults_vars)
+        all_yaml_vars = required_vars.union(required_sensitive_vars)
         all_tf_vars = set(self.TF_VARIABLES.keys())
 
         missing_vars = all_yaml_vars - all_tf_vars
         self.assertEqual(len(missing_vars), 0, f"Variables in variables.yaml not found in variables.tf: {missing_vars}")
 
-    def test_all_variables_in_tf_are_referenced_in_yaml(self) -> None:
+    def test_all_variables_in_tf_are_referenced_in_yaml_or_preset(self) -> None:
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
         required_sensitive_vars = set(self.VARIABLES_CONFIG.get("required_sensitive", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
 
-        all_yaml_vars = required_vars.union(required_sensitive_vars).union(defaults_vars)
+        all_covered_vars = required_vars.union(required_sensitive_vars).union(preset_vars)
         all_tf_vars = set(self.TF_VARIABLES.keys())
 
-        missing_vars = all_tf_vars - all_yaml_vars
+        missing_vars = all_tf_vars - all_covered_vars
         self.assertEqual(
-            len(missing_vars), 0, f"Variables in variables.tf not referenced in variables.yaml: {missing_vars}"
+            len(missing_vars),
+            0,
+            f"Variables in variables.tf not referenced in variables.yaml or preset: {missing_vars}",
         )
 
-    def test_sensitive_variables_not_in_required_or_defaults(self) -> None:
+    def test_sensitive_variables_not_in_required(self) -> None:
         sensitive_vars = set()
         for var_name, var_config in self.TF_VARIABLES.items():
             if var_config.get("sensitive") is True:
                 sensitive_vars.add(var_name)
 
         required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
-        defaults_vars = set(self.VARIABLES_CONFIG.get("defaults", {}).keys())
 
-        sensitive_in_required = sensitive_vars.intersection(required_vars)
-        sensitive_in_defaults = sensitive_vars.intersection(defaults_vars)
-
-        self.assertEqual(
-            len(sensitive_in_required), 0, f"Sensitive variables found in 'required' section: {sensitive_in_required}"
-        )
-        self.assertEqual(
-            len(sensitive_in_defaults), 0, f"Sensitive variables found in 'defaults' section: {sensitive_in_defaults}"
-        )
+        overlap = sensitive_vars.intersection(required_vars)
+        self.assertEqual(len(overlap), 0, f"Sensitive variables should not be in 'required' section: {overlap}")
 
     def test_required_sensitive_variables_are_marked_sensitive_in_tf(self) -> None:
         sensitive_vars = set()
@@ -200,6 +132,13 @@ class TestVariablesYaml(unittest.TestCase):
             0,
             f"Variables in 'required_sensitive' not marked as sensitive in variables.tf: {not_marked_sensitive}",
         )
+
+    def test_no_overlap_between_required_and_preset(self) -> None:
+        required_vars = set(self.VARIABLES_CONFIG.get("required", {}).keys())
+        preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
+
+        overlap = required_vars.intersection(preset_vars)
+        self.assertEqual(len(overlap), 0, f"Required variables should not have defaults in preset: {overlap}")
 
     def test_variables_file_parsable_by_base_project_handler(self) -> None:
         variables_config = base_project_handler.retrieve_variables_config(self.VARIABLES_CONFIG_PATH)

--- a/libs/jupyter-infra-tf-aws-iam-ci/tests/unit/test_ci_variables_yaml.py
+++ b/libs/jupyter-infra-tf-aws-iam-ci/tests/unit/test_ci_variables_yaml.py
@@ -163,8 +163,7 @@ class TestVariablesYaml(unittest.TestCase):
             self.assertEqual(
                 var_value,
                 preset_value,
-                f"Commented override '{var_name}' has value {var_value!r} "
-                f"but preset has {preset_value!r}",
+                f"Commented override '{var_name}' has value {var_value!r} but preset has {preset_value!r}",
             )
 
     def test_all_preset_vars_appear_as_commented_overrides(self) -> None:
@@ -173,9 +172,7 @@ class TestVariablesYaml(unittest.TestCase):
         preset_vars = set(self.DEFAULTS_ALL_TFVARS.keys())
 
         missing = preset_vars - set(commented_vars.keys())
-        self.assertEqual(
-            len(missing), 0, f"Preset variables missing from commented overrides: {missing}"
-        )
+        self.assertEqual(len(missing), 0, f"Preset variables missing from commented overrides: {missing}")
 
     @classmethod
     def _parse_commented_overrides(cls) -> dict:
@@ -190,9 +187,8 @@ class TestVariablesYaml(unittest.TestCase):
             if stripped.startswith("overrides:"):
                 in_overrides = True
                 continue
-            if in_overrides and not stripped.startswith("#") and stripped:
-                if not line.startswith(" "):
-                    break
+            if in_overrides and not stripped.startswith("#") and stripped and not line.startswith(" "):
+                break
             if in_overrides and stripped.startswith("# "):
                 content_after_hash = stripped[2:]
                 if content_after_hash.startswith("uncomment"):

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/deployment.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/deployment.py
@@ -13,6 +13,8 @@ from jupyter_deploy.manifest import JupyterDeployManifest
 from jupyter_deploy.variables_config import (
     VARIABLES_CONFIG_V1_COMMENTS,
     VARIABLES_CONFIG_V1_KEYS_ORDER,
+    VARIABLES_CONFIG_V2_COMMENTS,
+    VARIABLES_CONFIG_V2_KEYS_ORDER,
     JupyterDeployVariablesConfig,
 )
 
@@ -540,13 +542,22 @@ class EndToEndDeployment:
         # Update the specific key
         config["overrides"][key] = value
 
-        # Write back with comments preserved
-        jd_fs_utils.write_yaml_file_with_comments(
-            variables_yaml,
-            config,
-            key_order=VARIABLES_CONFIG_V1_KEYS_ORDER,
-            comments=VARIABLES_CONFIG_V1_COMMENTS,
-        )
+        # Write back with comments preserved, using the correct format for the schema version
+        schema_version = config.get("schema_version", 1)
+        if schema_version >= 2:
+            jd_fs_utils.write_yaml_file_with_comments(
+                variables_yaml,
+                config,
+                key_order=VARIABLES_CONFIG_V2_KEYS_ORDER,
+                comments=VARIABLES_CONFIG_V2_COMMENTS,
+            )
+        else:
+            jd_fs_utils.write_yaml_file_with_comments(
+                variables_yaml,
+                config,
+                key_order=VARIABLES_CONFIG_V1_KEYS_ORDER,
+                comments=VARIABLES_CONFIG_V1_COMMENTS,
+            )
 
     def ensure_deployed_with(self, config_args: list[str], timeout_seconds: int | None = None) -> None:
         """Ensure the deployment is updated with new configuration.

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/suite_config.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/suite_config.py
@@ -13,8 +13,12 @@ from jupyter_deploy.manifest import JupyterDeployManifest
 from jupyter_deploy.variables_config import (
     VARIABLES_CONFIG_V1_COMMENTS,
     VARIABLES_CONFIG_V1_KEYS_ORDER,
+    VARIABLES_CONFIG_V2_COMMENTS,
+    VARIABLES_CONFIG_V2_KEYS_ORDER,
     JupyterDeployVariablesConfig,
+    JupyterDeployVariablesConfigV2,
 )
+from pydantic import TypeAdapter
 
 from pytest_jupyter_deploy import constants
 
@@ -158,14 +162,22 @@ class SuiteConfig:
         # Determine target directory
         write_dir = target_dir if target_dir is not None else self.project_dir
 
-        # Write resolved configuration to target dir
+        # Write resolved configuration using the correct format for the schema version
         variables_config_path = write_dir / jd_constants.VARIABLES_FILENAME
-        jd_fs_utils.write_yaml_file_with_comments(
-            variables_config_path,
-            resolved_variables.model_dump(),
-            key_order=VARIABLES_CONFIG_V1_KEYS_ORDER,
-            comments=VARIABLES_CONFIG_V1_COMMENTS,
-        )
+        if isinstance(resolved_variables, JupyterDeployVariablesConfigV2):
+            jd_fs_utils.write_yaml_file_with_comments(
+                variables_config_path,
+                resolved_variables.model_dump(),
+                key_order=VARIABLES_CONFIG_V2_KEYS_ORDER,
+                comments=VARIABLES_CONFIG_V2_COMMENTS,
+            )
+        else:
+            jd_fs_utils.write_yaml_file_with_comments(
+                variables_config_path,
+                resolved_variables.model_dump(),
+                key_order=VARIABLES_CONFIG_V1_KEYS_ORDER,
+                comments=VARIABLES_CONFIG_V1_COMMENTS,
+            )
 
     def _load_configuration(self, config_name: str) -> JupyterDeployVariablesConfig:
         """Load a deployment configuration to the target directory.
@@ -201,4 +213,5 @@ class SuiteConfig:
         if not isinstance(data, dict):
             raise ValueError("Invalid variables config file: jupyter-deploy variables config is not a dict.")
 
-        return JupyterDeployVariablesConfig(**data)
+        adapter: TypeAdapter[JupyterDeployVariablesConfig] = TypeAdapter(JupyterDeployVariablesConfig)
+        return adapter.validate_python(data)  # type: ignore[return-value]


### PR DESCRIPTION
This PR improves the state machine that is `jd config` to better handle edge cases, particularly when the user inputs the wrong values.

Closes: #258 

Follow up PR:
- harden pure-terraform interactive experience to capture details: #260

### User experience
- migrate `variables.yaml` to a new format which removes the confusing, read-only `defaults:` dict - instead, comment out `overrides:` section w/ the default values.
```yaml
schema_version: 2

required:
  # fill in values below, or run 'jd config' for the interactive experience
  domain: null
  subdomain: null
  letsencrypt_email: null
  oauth_app_client_id: null
  oauth_allowed_teams: null

required_sensitive:
  # fill in values below, or run 'jd config' for the interactive experience
  # values entered here will be masked after running 'jd config'
  oauth_app_client_secret: null

overrides:
  # uncomment and change a value to override the default
  # cluster_name_prefix: jupyter-deploy-eks
  # region: us-west-2
  # kubernetes_version: "1.35"
  # node_groups:
  #   - name: components
  #     role: components
  #     instance_type: t3.medium
  #     ami_type: default
  #     disk_size_gb: "50"
  #     min_size: "1"
  #     max_size: "3"
  #     desired_size: "2"
```
- after running `jd config`, the CLI updates the `variables.yaml` to the actual defaults it applied.
```yaml
schema_version: 2

required:
  # fill in values below, or run 'jd config' for the interactive experience
  domain: my-domain
  subdomain: my.sub-domain
  letsencrypt_email: my-email@email.com
  oauth_app_client_id: <client-id>
  oauth_allowed_teams:
    - <gh-org>:<gh-team>

required_sensitive:
  # fill in values below, or run 'jd config' for the interactive experience
  # values entered here will be masked after running 'jd config'
  oauth_app_client_secret: ****

overrides:
  # uncomment and change a value to override the default
  cluster_name_prefix: jupyter-deploy-eks
  region: us-west-2
  kubernetes_version: "1.35"
  node_groups:
  - name: components
     role: components
     instance_type: t3.medium
     ami_type: default
     disk_size_gb: "50"
     min_size: "1"
     max_size: "3"
     desired_size: "2"
```
- update the `variables.yaml`, make a mistake; say call `subdomain:` w/ `sub_domain` which is invalid (no `_` in domains); run `jd config` --> it fails with a clear error message, the inputs are saved
- next, user can run `jd config --var-name CORRECT-VAR-VALUE`, and it passes
- even if `jd config --var-name VAR-VALUE` fails, the CLI persists the value to `variables.yaml`
- backward-compatible: the CLI still understands V1 files, but save them as V2 files

### Implementation
- add `JupyterDeployVariablesConfigV2` model
- update `fs_utils.write_yaml_file_with_comments` to read/write `variables.yaml` V2
- capture tentative tf plan as a `jdinputs.staging.auto.tfvars` and `jdinputs.staging.secrets.auto.tfvars` to avoid corrupting the plan state on invalid inputs, delete on plan success
- write to `variables.yaml` when `--var-name VAR-VALUE` get passed to `jd config` to avoid loosing the value on error
- update `provider/store/store_manager` to handle both V1 and V2 formats
- update `variables.yaml` for a/ base template, b/ eks-oidc template, c/ ci template
- update `e2e/configuration/base.yaml` for each template above

### Testing
- added E2E tests for edge cases behaviors, using `variables.yaml`, interactive or cmd line flags `--var-name VAR-VALUE`
- run existing configuration and interactive E2E tests --> no regression
- add E2E tests to base template for backward compatibility 