### PR TITLE
fix: jupyterlab images, e2e test regression

### DIFF
--- a/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/jupyter_deploy_tf_aws_ec2_base/template/services/jupyter/pyproject.jupyter.toml
@@ -4,6 +4,6 @@ version = "0.5.1"
 description = "A basic image with jupyterlab and server-documents"
 requires-python = ">=3.12"
 dependencies = [
-    "jupyter-server-documents>=0.1.0a0",
+    "jupyter-server-documents>=0.2.4",
     "jupyterlab>=4.4.2",
 ]

--- a/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_show.py
+++ b/libs/jupyter-deploy-tf-aws-ec2-base/tests/e2e/test_show.py
@@ -1,7 +1,9 @@
 """E2E tests for jd show command."""
 
 import pytest
+from jupyter_deploy import constants as jd_constants
 from jupyter_deploy.enum import ValueSource
+from jupyter_deploy.fs_utils import read_yaml_reference_file
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
 from pytest_jupyter_deploy.terraform.utils import (
     get_outputs_dot_tf_path,
@@ -26,13 +28,20 @@ def test_show_variables_list_matches_config(e2e_deployment: EndToEndDeployment) 
     # Read variables config to get all variable names
     variables_config = e2e_deployment.get_variables_config()
 
-    # Collect all variable names from all sections (required, required_sensitive, overrides, defaults)
+    # Collect all variable names from all sections
     # jd show --variables --list shows ALL template variables
     expected_vars: set[str] = set()
     expected_vars.update(variables_config.required.keys())
     expected_vars.update(variables_config.required_sensitive.keys())
     expected_vars.update(variables_config.overrides.keys())
-    expected_vars.update(variables_config.defaults.keys())
+    if variables_config.schema_version == 1:
+        expected_vars.update(variables_config.defaults.keys())
+    else:
+        defaults_path = (
+            e2e_deployment.suite_config.project_dir / jd_constants.JD_DIR / jd_constants.VARIABLES_DEFAULTS_FILENAME
+        )
+        defaults_ref = read_yaml_reference_file(defaults_path)
+        expected_vars.update(defaults_ref.keys())
 
     # Run jd show --variables --list --text
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "show", "--variables", "--list", "--text"])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/jupyter_server_config.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/jupyter_server_config.py
@@ -3,3 +3,10 @@ c = get_config()  # noqa
 
 c.Application.log_level = "INFO"
 c.ServerApp.root_dir = "/home/jovyan"
+c.ServerApp.terminado_settings = {
+    "shell_command": [
+        "bash",
+        "-c",
+        "echo \"This is a UV-managed shell, use 'uv add' or 'uv pip' instead of 'pip'!\"; bash",
+    ]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/applications/jupyterlab/pyproject.toml
@@ -5,4 +5,5 @@ description = "JupyterLab workspace image for jupyter-deploy EKS template"
 requires-python = ">=3.12"
 dependencies = [
     "jupyterlab>=4.4.2",
+    "jupyter-server-documents>=0.2.4",
 ]


### PR DESCRIPTION
This PR a/ adds `jupyter-server-documents` to the `jupyterlab` image of `eks-oidc` template, b/ update the `jupyter-server-documents` version to the latest in `base` template, c/ fix a regression in `base` template E2E test introduced by #261 - detected in E2E test [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/27620381318/job/81670945552) 

### Testing
- pull app locally, ran the updated E2E test