### PR TITLE
feat: expand health dashboard

### DIFF
--- a/docs/source/reference/project/health.md
+++ b/docs/source/reference/project/health.md
@@ -14,6 +14,7 @@ $ jd health [OPTIONS] COMMAND [ARGS]...
 * `--cluster`: Check only the cluster layer.
 * `--load-balancer`: Check only the load balancer layer.
 * `--components`: Check only the components layer.
+* `--images`: Check only the images layer.
 * `--connection`: Check only the end-to-end connection.
 * `--json`: Output as JSON.
 * `--help`: Show this message and exit.

--- a/docs/source/reference/resource/image.md
+++ b/docs/source/reference/resource/image.md
@@ -16,6 +16,7 @@ $ jd image [OPTIONS] COMMAND [ARGS]...
 
 * `list`: List application images for this project.
 * `show`: Show details of an application image.
+* `status`: Check the status of an application image.
 * `tags`: List available tags for an application image.
 * `vulnerabilities`: List vulnerabilities for an application...
 
@@ -59,6 +60,27 @@ $ jd image show [OPTIONS]
 * `--json`: Output as JSON.
 * `--help`: Show this message and exit.
 
+## `image status`
+
+Check the status of an application image.
+
+Reports whether the image is present in its registry (available) or missing.
+
+Run either from a project directory that you created with <jd init>;
+or pass --path <project-dir>.
+
+**Usage**:
+
+```console
+$ jd image status [OPTIONS]
+```
+
+**Options**:
+
+* `--name TEXT`: Name of the image.
+* `-p, --path PATH`: Directory of the project.
+* `--help`: Show this message and exit.
+
 ## `image tags`
 
 List available tags for an application image.
@@ -86,6 +108,11 @@ List vulnerabilities for an application image.
 
 Shows HIGH and CRITICAL severity vulnerabilities detected by the image scanner.
 If --tag is not specified, uses the current deployed tag.
+
+The EPSS column shows the Exploit Prediction Scoring System probability that a
+CVE will be exploited in the wild within the next 30 days, as a percentage from
+0% to 100% — higher means more urgent. It shows n/a for scanners that do not
+provide it (for example basic registry scanning).
 
 Run either from a project directory that you created with <jd init>;
 or pass --path <project-dir>.

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -487,6 +487,98 @@ commands:
     - api-attribute: container
       source: cli
       source-key: service
+- cmd: component.customresourcewithoutstatus.status
+  sequence:
+  - api-name: k8s.custom.get
+    arguments:
+    - api-attribute: group
+      source: cli
+      source-key: group
+    - api-attribute: version
+      source: cli
+      source-key: version
+    - api-attribute: plural
+      source: cli
+      source-key: plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: component.customresourcewithoutstatus.status.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: component.customresourcewithoutstatus.show
+  sequence:
+  - api-name: k8s.custom.get
+    arguments:
+    - api-attribute: group
+      source: cli
+      source-key: group
+    - api-attribute: version
+      source: cli
+      source-key: version
+    - api-attribute: plural
+      source: cli
+      source-key: plural
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: component.customresourcewithoutstatus.show.name
+    source: result
+    source-key: '[0].Name'
+  - result-name: component.customresourcewithoutstatus.show.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: component.customresourcedefinition.status
+  sequence:
+  - api-name: k8s.custom.get-cluster
+    arguments:
+    - api-attribute: group
+      source: cli
+      source-key: group
+    - api-attribute: version
+      source: cli
+      source-key: version
+    - api-attribute: plural
+      source: cli
+      source-key: plural
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: component.customresourcedefinition.status.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: component.customresourcedefinition.show
+  sequence:
+  - api-name: k8s.custom.get-cluster
+    arguments:
+    - api-attribute: group
+      source: cli
+      source-key: group
+    - api-attribute: version
+      source: cli
+      source-key: version
+    - api-attribute: plural
+      source: cli
+      source-key: plural
+    - api-attribute: name
+      source: cli
+      source-key: name
+  results:
+  - result-name: component.customresourcedefinition.show.name
+    source: result
+    source-key: '[0].Name'
+  - result-name: component.customresourcedefinition.show.resource
+    source: result
+    source-key: '[0].Resource'
 - cmd: component.deployment.status
   sequence:
   - api-name: k8s.apps.get-deployment-status
@@ -631,6 +723,23 @@ commands:
   - result-name: component.cronjob.trigger.job_name
     source: result
     source-key: '[0].JobName'
+- cmd: image.status
+  sequence:
+  - api-name: aws.ecr.describe-image
+    arguments:
+    - api-attribute: repository_name
+      source: cli
+      source-key: repository_name
+    - api-attribute: image_tag
+      source: cli
+      source-key: image_tag
+  results:
+  - result-name: image.status.status
+    source: result
+    source-key: '[0].Status'
+  - result-name: image.status.status_category
+    source: result
+    source-key: '[0].StatusCategory'
 - cmd: image.show
   sequence:
   - api-name: aws.ecr.describe-repository
@@ -697,6 +806,77 @@ commands:
     source: result
     source-key: '[0].ScannerType'
 components:
+  workspace-crd:
+    type: CustomResourceDefinition
+    description: Workspace CRD
+    resource-name: workspaces.workspace.jupyter.org
+    details:
+      path: .spec.versions[0].name
+    verbs:
+      status:
+        method: k8s.custom.get-cluster
+      show:
+        method: k8s.custom.get-cluster
+  workspace-template-crd:
+    type: CustomResourceDefinition
+    description: WorkspaceTemplate CRD
+    resource-name: workspacetemplates.workspace.jupyter.org
+    details:
+      path: .spec.versions[0].name
+    verbs:
+      status:
+        method: k8s.custom.get-cluster
+      show:
+        method: k8s.custom.get-cluster
+  workspace-access-strategy-crd:
+    type: CustomResourceDefinition
+    description: WorkspaceAccessStrategy CRD
+    resource-name: workspaceaccessstrategies.workspace.jupyter.org
+    details:
+      path: .spec.versions[0].name
+    verbs:
+      status:
+        method: k8s.custom.get-cluster
+      show:
+        method: k8s.custom.get-cluster
+  oauth-access-strategy:
+    type: CustomResourceWithoutStatus
+    type-display: WorkspaceAccessStrategy
+    description: Default workspace access strategy
+    scope: workspace_shared_namespace
+    resource-name: oauth-access-strategy
+    crd-group: workspace.jupyter.org
+    crd-version: v1alpha1
+    crd-plural: workspaceaccessstrategies
+    details:
+      path: .metadata.namespace
+    sub-component:
+      label: access-resources
+      count: .spec.accessResourceTemplates
+    verbs:
+      status:
+        method: k8s.custom.get
+      show:
+        method: k8s.custom.get
+  jupyterlab-template:
+    type: CustomResourceWithoutStatus
+    type-display: WorkspaceTemplate
+    description: Default workspace template
+    scope: workspace_shared_namespace
+    resource-name: jupyterlab
+    crd-group: workspace.jupyter.org
+    crd-version: v1alpha1
+    crd-plural: workspacetemplates
+    details:
+      path: .metadata.namespace
+    sub-component:
+      label: access-strategy
+      path: .spec.defaultAccessStrategy.name
+    verbs:
+      status:
+        method: k8s.custom.get
+      show:
+        method: k8s.custom.get
   traefik:
     type: Deployment
     description: Ingress controller and reverse proxy

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
@@ -27,6 +27,22 @@ def _get_cronjob_names(e2e_deployment: EndToEndDeployment) -> list[str]:
     return [name for name, comp in _get_manifest_components(e2e_deployment).items() if comp.type == "CronJob"]
 
 
+def _get_custom_resource_names(e2e_deployment: EndToEndDeployment) -> list[str]:
+    return [
+        name
+        for name, comp in _get_manifest_components(e2e_deployment).items()
+        if comp.type == "CustomResourceWithoutStatus"
+    ]
+
+
+def _get_crd_names(e2e_deployment: EndToEndDeployment) -> list[str]:
+    return [
+        name
+        for name, comp in _get_manifest_components(e2e_deployment).items()
+        if comp.type == "CustomResourceDefinition"
+    ]
+
+
 def _poll_component_status(
     e2e_deployment: EndToEndDeployment, name: str, target_status: str, timeout_s: int = 120, interval_s: int = 5
 ) -> None:
@@ -63,7 +79,12 @@ def _get_component_last_updated(e2e_deployment: EndToEndDeployment, name: str) -
 
 
 def test_component_list(e2e_deployment: EndToEndDeployment) -> None:
-    """Verify list shows table with all components."""
+    """Verify list shows table with all components.
+
+    The table renders at a fixed terminal width, so long names/types may be truncated;
+    exact-name coverage is in the --text and --json variants. Here we assert that a
+    truncation-tolerant prefix of each name and display type appears in the output.
+    """
     e2e_deployment.ensure_deployed()
 
     manifest_components = _get_manifest_components(e2e_deployment)
@@ -71,10 +92,12 @@ def test_component_list(e2e_deployment: EndToEndDeployment) -> None:
     output = result.stdout
 
     for name in manifest_components:
-        assert name in output, f"Expected component '{name}' in list output"
+        assert name[:20] in output, f"Expected component '{name}' in list output"
 
-    for comp_type in {comp.type for comp in manifest_components.values()}:
-        assert comp_type in output, f"Expected type '{comp_type}' in list output"
+    # The Type column shows the display type (type-display when set, else type).
+    for comp in manifest_components.values():
+        display_type = comp.type_display or comp.type
+        assert display_type[:20] in output, f"Expected type '{display_type}' in list output"
 
 
 def test_component_list_json(e2e_deployment: EndToEndDeployment) -> None:
@@ -93,8 +116,10 @@ def test_component_list_json(e2e_deployment: EndToEndDeployment) -> None:
     by_name = {c["name"]: c for c in components}
     for name, comp_def in manifest_components.items():
         assert name in by_name, f"Expected component '{name}' in JSON output"
-        assert by_name[name]["type"] == comp_def.type, (
-            f"Type mismatch for '{name}': expected '{comp_def.type}', got '{by_name[name]['type']}'"
+        # list returns the display type (type-display when set, else the internal type).
+        expected_type = comp_def.type_display or comp_def.type
+        assert by_name[name]["type"] == expected_type, (
+            f"Type mismatch for '{name}': expected '{expected_type}', got '{by_name[name]['type']}'"
         )
         actual_desc = by_name[name]["description"]
         assert actual_desc == comp_def.description, (
@@ -128,6 +153,54 @@ def test_component_status_happy_case(e2e_deployment: EndToEndDeployment) -> None
     for name in _get_all_names(e2e_deployment):
         result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "status", "--name", name])
         assert f"{name} status:" in result.stdout, f"Expected '{name} status:' in output:\n{result.stdout}"
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_custom_resource_component_status_present(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify CustomResourceWithoutStatus components report a present/default verdict via health."""
+    e2e_deployment.ensure_deployed()
+
+    cr_names = _get_custom_resource_names(e2e_deployment)
+    assert cr_names, "Expected CustomResourceWithoutStatus components (oauth-access-strategy, jupyterlab-template)"
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "health", "--components", "--json"])
+    data = json.loads(result.stdout)
+    by_name = {entry["name"]: entry for entry in data["layers"]}
+
+    for name in cr_names:
+        assert name in by_name, f"Expected CR component '{name}' in health output"
+        entry = by_name[name]
+        # Existence-based health: a deployed CR is healthy and reports 'Present'.
+        assert entry["status_category"] == "healthy", f"{name}: {entry}"
+        assert entry["status"] == "Present", f"{name} unexpected status: {entry['status']}"
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_cluster_custom_resource_crd_status_present(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify the Workspace CRDs report present via cluster-scoped existence checks."""
+    e2e_deployment.ensure_deployed()
+
+    crd_names = _get_crd_names(e2e_deployment)
+    assert crd_names, "Expected CustomResourceDefinition components for the Workspace CRDs"
+
+    for name in crd_names:
+        result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "status", "--name", name])
+        assert f"{name} status: Present" in result.stdout, f"Expected '{name}' Present:\n{result.stdout}"
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_cluster_custom_resource_crd_show(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify show returns the CRD object for a cluster-scoped component."""
+    e2e_deployment.ensure_deployed()
+
+    crd_names = _get_crd_names(e2e_deployment)
+    assert crd_names, "Expected CustomResourceDefinition components for the Workspace CRDs"
+
+    name = crd_names[0]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", name, "--json"])
+    data = json.loads(result.stdout)
+    assert "resource" in data, f"Expected 'resource' in JSON response, got: {list(data.keys())}"
+    assert data["resource"]["kind"] == "CustomResourceDefinition"
 
 
 @pytest.mark.usefixtures("kubernetes_cluster_login")
@@ -176,6 +249,21 @@ def test_component_show_job(e2e_deployment: EndToEndDeployment) -> None:
     assert "name" in data, f"Expected 'name' in JSON response, got: {list(data.keys())}"
     assert "resource" in data, f"Expected 'resource' in JSON response, got: {list(data.keys())}"
     assert data["name"] == name
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_component_show_custom_resource(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify show --json returns the resource for a CustomResourceWithoutStatus component."""
+    e2e_deployment.ensure_deployed()
+
+    cr_names = _get_custom_resource_names(e2e_deployment)
+    assert cr_names, "Expected at least one CustomResourceWithoutStatus component"
+
+    name = cr_names[0]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", name, "--json"])
+    data = json.loads(result.stdout)
+    assert "name" in data, f"Expected 'name' in JSON response, got: {list(data.keys())}"
+    assert "resource" in data, f"Expected 'resource' in JSON response, got: {list(data.keys())}"
 
 
 def test_component_show_description(e2e_deployment: EndToEndDeployment) -> None:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
@@ -1,8 +1,12 @@
 """E2E tests for the jd health command on the EKS OIDC template."""
 
 import json
+import re
 
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
+
+# A CR sub-component renders as a non-empty "label: value" pair (e.g. "access-resources: 2").
+_LABELED_VALUE_RE = re.compile(r"^\S.*: \S.*$")
 
 EXPECTED_CRONJOBS = [
     "jwt-rotator",
@@ -16,7 +20,7 @@ def test_health_all_layers(e2e_deployment: EndToEndDeployment) -> None:
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "health"])
     output = result.stdout
 
-    for layer in ["cluster", "load-balancer", "components"]:
+    for layer in ["cluster", "load-balancer", "components", "images"]:
         assert layer in output, f"Expected layer '{layer}' in health output"
     assert "Connection" in output, "Expected 'Connection' in health output"
 
@@ -85,17 +89,39 @@ def test_health_components_layer(e2e_deployment: EndToEndDeployment) -> None:
     for name in manifest_components:
         assert name in names, f"Expected component '{name}' in health output"
 
+    # Components whose health is existence-based, keyed by manifest type.
+    crd_names = {n for n, c in manifest_components.items() if c.type == "CustomResourceDefinition"}
+    cr_names = {n for n, c in manifest_components.items() if c.type == "CustomResourceWithoutStatus"}
+    # The eks-oidc template declares the 3 Workspace CRDs + the access-strategy and template CRs.
+    assert len(crd_names) >= 3, f"Expected >= 3 CustomResourceDefinition components, got {sorted(crd_names)}"
+    assert len(cr_names) >= 2, f"Expected >= 2 CustomResourceWithoutStatus components, got {sorted(cr_names)}"
+
     for entry in layers:
         assert entry["layer"] == "components"
-        if entry["name"] in EXPECTED_CRONJOBS:
+        name = entry["name"]
+        if name in EXPECTED_CRONJOBS:
             assert entry["status_category"] in ("healthy", "in-progress"), (
-                f"CronJob '{entry['name']}' unexpected status_category: {entry['status_category']}"
+                f"CronJob '{name}' unexpected status_category: {entry['status_category']}"
             )
         else:
             assert entry["status_category"] == "healthy", (
-                f"Component '{entry['name']}' not healthy: status_category={entry['status_category']}"
+                f"Component '{name}' not healthy: status_category={entry['status_category']}"
             )
         assert entry["status"] != ""
+
+        if name in crd_names:
+            # CRD rows surface the served API version (e.g. v1alpha1) in details.
+            assert entry["status"] == "Present", f"CRD '{name}' status: {entry['status']}"
+            assert entry["detail"] == "v1alpha1", f"CRD '{name}' detail: {entry['detail']}"
+
+        if name in cr_names:
+            # Access-strategy / template rows surface their namespace in details and a labeled
+            # value (access-resources count / access-strategy ref) in the sub-component cell.
+            assert entry["status"] == "Present", f"CR '{name}' status: {entry['status']}"
+            assert entry["detail"] != "", f"CR '{name}' should surface its namespace in detail"
+            assert _LABELED_VALUE_RE.match(entry["sub_component"]), (
+                f"CR '{name}' sub-component should be a 'label: value' pair, got: {entry['sub_component']!r}"
+            )
 
 
 def test_health_load_balancer_layer(e2e_deployment: EndToEndDeployment) -> None:
@@ -111,6 +137,32 @@ def test_health_load_balancer_layer(e2e_deployment: EndToEndDeployment) -> None:
     assert layers[0]["status_category"] == "healthy"
     assert layers[0]["name"] != ""
     assert layers[0]["status"] == "Active"
+
+
+def test_health_images_layer(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify --images reports one row per image, available with its latest tag."""
+    e2e_deployment.ensure_deployed()
+
+    manifest = e2e_deployment.get_manifest()
+    manifest_images = manifest.get_images()
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "health", "--images", "--json"])
+    data = json.loads(result.stdout)
+
+    layers = data["layers"]
+    assert len(layers) == len(manifest_images), f"Expected {len(manifest_images)} images, got {len(layers)}"
+
+    names = {entry["name"] for entry in layers}
+    for name in manifest_images:
+        assert name in names, f"Expected image '{name}' in health output"
+
+    for entry in layers:
+        assert entry["layer"] == "images"
+        # Status reflects ECR presence; a deployed image must be available.
+        assert entry["status"] == "Available"
+        assert entry["status_category"] == "healthy"
+        # Detail is the latest non-'latest' tag.
+        assert entry["detail"] != "latest"
 
 
 def test_health_connection_flag(e2e_deployment: EndToEndDeployment) -> None:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_images.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_images.py
@@ -41,6 +41,27 @@ def test_image_list_text(e2e_deployment: EndToEndDeployment) -> None:
     assert "jupyterlab" in names
 
 
+# ── image status ───────────────────────────────────────────────────────────
+
+
+def test_image_status(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify status reports the image as available."""
+    e2e_deployment.ensure_deployed()
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "image", "status"])
+    assert "jupyterlab status:" in result.stdout
+    assert "Available" in result.stdout
+
+
+def test_image_status_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify status for a non-existent image fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError) as exc_info:
+        e2e_deployment.cli.run_command(["jupyter-deploy", "image", "status", "--name", "nonexistent"])
+    assert "nonexistent" in str(exc_info.value)
+
+
 # ── image show ─────────────────────────────────────────────────────────────
 
 
@@ -137,6 +158,10 @@ def test_image_vulnerabilities_json(e2e_deployment: EndToEndDeployment) -> None:
     assert "critical" in data["summary"]
     assert "high" in data["summary"]
     assert isinstance(data["vulnerabilities"], list)
+    # Each vulnerability carries an EPSS field (float when the scanner provides it, else null).
+    for vuln in data["vulnerabilities"]:
+        assert "epss_score" in vuln
+        assert vuln["epss_score"] is None or isinstance(vuln["epss_score"], int | float)
 
 
 def test_image_vulnerabilities_with_tag(e2e_deployment: EndToEndDeployment) -> None:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
@@ -144,7 +144,7 @@ class TestManifest(unittest.TestCase):
         commands = self.MANIFEST.get("commands", [])
         command_names = [cmd["cmd"] for cmd in commands]
 
-        expected_image_commands = ["image.show", "image.tags", "image.vulnerabilities"]
+        expected_image_commands = ["image.status", "image.show", "image.tags", "image.vulnerabilities"]
         for expected_cmd in expected_image_commands:
             self.assertIn(
                 expected_cmd,
@@ -162,3 +162,52 @@ class TestManifest(unittest.TestCase):
         for cmd in image_commands:
             self.assertIn("results", cmd, f"Command '{cmd['cmd']}' must define results")
             self.assertTrue(len(cmd["results"]) > 0, f"Command '{cmd['cmd']}' must have at least one result")
+
+    def test_custom_resource_definition_components_declared(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        components = self.MANIFEST.get("components", {})
+        crd_components = [c for c in components.values() if c["type"] == "CustomResourceDefinition"]
+
+        # The Workspace, WorkspaceTemplate and WorkspaceAccessStrategy CRDs are surfaced.
+        self.assertGreaterEqual(
+            len(crd_components),
+            3,
+            f"Expected at least 3 CustomResourceDefinition components, got {len(crd_components)}",
+        )
+
+    def test_workspace_custom_resource_components_declared(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        components = self.MANIFEST.get("components", {})
+        cr_kinds = {c.get("type-display") for c in components.values() if c["type"] == "CustomResourceWithoutStatus"}
+
+        # At least one access strategy and one template must be surfaced as components.
+        self.assertIn(
+            "WorkspaceAccessStrategy",
+            cr_kinds,
+            f"Expected a CustomResourceWithoutStatus of kind WorkspaceAccessStrategy, got kinds: {cr_kinds}",
+        )
+        self.assertIn(
+            "WorkspaceTemplate",
+            cr_kinds,
+            f"Expected a CustomResourceWithoutStatus of kind WorkspaceTemplate, got kinds: {cr_kinds}",
+        )
+
+    def test_component_verbs_have_matching_commands(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        command_names = {cmd["cmd"] for cmd in self.MANIFEST.get("commands", [])}
+
+        for name, comp in self.MANIFEST.get("components", {}).items():
+            comp_type = comp["type"].lower()
+            for verb in comp["verbs"]:
+                expected_cmd = f"component.{comp_type}.{verb}"
+                self.assertIn(
+                    expected_cmd,
+                    command_names,
+                    f"Component '{name}' verb '{verb}' requires command '{expected_cmd}' in manifest",
+                )

--- a/libs/jupyter-deploy/jupyter_deploy/api/k8s/custom.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/k8s/custom.py
@@ -24,6 +24,7 @@ def list_namespaced(
     limit: int | None = None,
     _continue: str | None = None,
 ) -> tuple[list[dict[str, Any]], str | None]:
+    """Call list namespaced custom object, return the items and the next page token."""
     kwargs: dict[str, Any] = {
         "group": ref.group,
         "version": ref.version,
@@ -47,6 +48,7 @@ def list_cluster(
     limit: int | None = None,
     _continue: str | None = None,
 ) -> tuple[list[dict[str, Any]], str | None]:
+    """Call list cluster custom object, return the items and the next page token."""
     kwargs: dict[str, Any] = {
         "group": ref.group,
         "version": ref.version,
@@ -64,6 +66,7 @@ def list_cluster(
 
 
 def get_namespaced(api: CustomObjectsApi, ref: CustomResourceRef, namespace: str, name: str) -> CustomObjectResult:
+    """Call get namespaced custom object, return its name and full resource."""
     result: dict[str, Any] = api.get_namespaced_custom_object(
         group=ref.group,
         version=ref.version,
@@ -75,9 +78,22 @@ def get_namespaced(api: CustomObjectsApi, ref: CustomResourceRef, namespace: str
     return CustomObjectResult(name=obj_name, resource=result)
 
 
+def get_cluster(api: CustomObjectsApi, ref: CustomResourceRef, name: str) -> CustomObjectResult:
+    """Call get cluster custom object, return its name and full resource."""
+    result: dict[str, Any] = api.get_cluster_custom_object(
+        group=ref.group,
+        version=ref.version,
+        plural=ref.plural,
+        name=name,
+    )
+    obj_name: str = result.get("metadata", {}).get("name", "")
+    return CustomObjectResult(name=obj_name, resource=result)
+
+
 def patch_namespaced(
     api: CustomObjectsApi, ref: CustomResourceRef, namespace: str, name: str, body: dict[str, Any]
 ) -> CustomObjectResult:
+    """Call patch namespaced custom object, return its name and the updated resource."""
     result: dict[str, Any] = api.patch_namespaced_custom_object(
         group=ref.group,
         version=ref.version,

--- a/libs/jupyter-deploy/jupyter_deploy/cli/health_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/health_app.py
@@ -15,14 +15,16 @@ from jupyter_deploy.handlers.payloads import ConnectionResult, HealthLayer, Heal
 
 
 def _format_sub_component(raw: str) -> str:
-    if not raw or raw == "-":
+    if not raw:
+        return "-"
+    if raw == "-":
         return raw
     try:
         item = json.loads(raw)
     except (json.JSONDecodeError, TypeError):
         return raw
     if not item:
-        return ""
+        return "-"
     return f"{item['name']}: {item['status']}"
 
 
@@ -51,6 +53,10 @@ def health(
         bool,
         typer.Option("--components", help="Check only the components layer."),
     ] = False,
+    images: Annotated[
+        bool,
+        typer.Option("--images", help="Check only the images layer."),
+    ] = False,
     connection: Annotated[
         bool,
         typer.Option("--connection", help="Check only the end-to-end connection."),
@@ -78,6 +84,8 @@ def health(
             requested_layers.append(HealthLayer.LOAD_BALANCER)
         if components:
             requested_layers.append(HealthLayer.COMPONENTS)
+        if images:
+            requested_layers.append(HealthLayer.IMAGES)
 
         has_filter = bool(requested_layers) or connection
         layer_conn: ConnectionResult | None = None
@@ -147,3 +155,12 @@ def health(
                     status_text = f"[indian_red]{r.status_text}[/indian_red]"
                 table.add_row(r.layer.value, r.name, status_text, r.detail, _format_sub_component(r.sub_component))
             console.print(table)
+
+            # Hint when an image has a non-zero vulnerability count (independent of row health).
+            for r in results:
+                if r.layer == HealthLayer.IMAGES and "critical" in r.sub_component:
+                    tag_suffix = f" --tag {r.detail}" if r.detail else ""
+                    console.print(
+                        f"Hint: run `jd image vulnerabilities --name {r.name}{tag_suffix}` for details.",
+                        style="dim",
+                    )

--- a/libs/jupyter-deploy/jupyter_deploy/cli/image_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/image_app.py
@@ -96,6 +96,33 @@ def show(
 
 
 @image_app.command()
+def status(
+    name: Annotated[str | None, typer.Option("--name", help="Name of the image.")] = None,
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+) -> None:
+    """Check the status of an application image.
+
+    Reports whether the image is present in its registry (available) or missing.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = image_handler.ImageHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner("Checking image status..."):
+            result = handler.get_status(name)
+
+        console.print(f"{result.name} status: [bold cyan]{result.status}[/]")
+
+
+@image_app.command()
 def tags(
     name: Annotated[str | None, typer.Option("--name", help="Name of the image.")] = None,
     project_dir: Annotated[
@@ -149,6 +176,11 @@ def vulnerabilities(
 
     Shows HIGH and CRITICAL severity vulnerabilities detected by the image scanner.
     If --tag is not specified, uses the current deployed tag.
+
+    The EPSS column shows the Exploit Prediction Scoring System probability that a
+    CVE will be exploited in the wild within the next 30 days, as a percentage from
+    0% to 100% — higher means more urgent. It shows n/a for scanners that do not
+    provide it (for example basic registry scanning).
 
     Run either from a project directory that you created with <jd init>;
     or pass --path <project-dir>.
@@ -206,16 +238,19 @@ def vulnerabilities(
         table.add_column("Package")
         table.add_column("Severity")
         table.add_column("Score")
+        table.add_column("EPSS")
         table.add_column("Installed")
         table.add_column("Fixed")
         for v in result.vulnerabilities:
             severity_style = "red" if v.severity == "CRITICAL" else "yellow"
+            epss_text = f"{v.epss_score:.0%}" if v.epss_score is not None else "n/a"
             table.add_row(
                 v.cve,
                 v.type,
                 v.package,
                 f"[{severity_style}]{v.severity}[/{severity_style}]",
                 f"{v.score:.1f}" if v.score else "-",
+                epss_text,
                 v.installed_version,
                 v.fixed_version,
             )

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/health_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/health_handler.py
@@ -2,10 +2,15 @@ from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import StatusCategory
 from jupyter_deploy.exceptions import CommandNotImplementedError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
-from jupyter_deploy.handlers.payloads import ConnectionResult, HealthLayer, HealthLayerResult
+from jupyter_deploy.handlers.payloads import ConnectionResult, HealthLayer, HealthLayerResult, ImageVulnerability
 from jupyter_deploy.handlers.project.open_handler import OpenHandler
 from jupyter_deploy.handlers.resource.cluster_handler import ClusterHandler
 from jupyter_deploy.handlers.resource.component_handler import ComponentHandler
+from jupyter_deploy.handlers.resource.image_handler import ImageHandler
+
+# A CRITICAL/HIGH CVE counts toward the health badge when its EPSS probability meets this
+# threshold, or when EPSS is unavailable (e.g. basic registry scanning, which cannot filter).
+HEALTH_EPSS_THRESHOLD = 0.10
 
 
 class HealthHandler(BaseProjectHandler):
@@ -13,6 +18,7 @@ class HealthHandler(BaseProjectHandler):
 
     _cluster_handler: ClusterHandler | None
     _component_handler: ComponentHandler | None
+    _image_handler: ImageHandler | None
     _open_handler: OpenHandler | None
 
     def __init__(self, display_manager: DisplayManager) -> None:
@@ -33,6 +39,17 @@ class HealthHandler(BaseProjectHandler):
         except CommandNotImplementedError:
             self._component_handler = None
 
+        # Require both an images declaration and the image.status command: deployments created
+        # from an older template revision may declare images without supporting status checks.
+        if self.project_manifest.has_command("image.status"):
+            try:
+                self.project_manifest.get_images()
+                self._image_handler = ImageHandler(display_manager=display_manager)
+            except CommandNotImplementedError:
+                self._image_handler = None
+        else:
+            self._image_handler = None
+
         if any(v.name == "open_url" for v in (self.project_manifest.values or [])):
             self._open_handler = OpenHandler()
         else:
@@ -44,6 +61,7 @@ class HealthHandler(BaseProjectHandler):
         results.append(self._check_cluster())
         results.append(self._check_load_balancer())
         results.extend(self._check_components())
+        results.extend(self._check_images())
         connection = self._check_connection()
         return results, connection
 
@@ -55,6 +73,8 @@ class HealthHandler(BaseProjectHandler):
             return [self._check_load_balancer()]
         elif layer == HealthLayer.COMPONENTS:
             return self._check_components()
+        elif layer == HealthLayer.IMAGES:
+            return self._check_images()
         valid = ", ".join(h.value for h in HealthLayer)
         raise ValueError(f"Unknown health layer: '{layer}'. Valid layers: {valid}")
 
@@ -111,6 +131,82 @@ class HealthHandler(BaseProjectHandler):
             )
 
         return results
+
+    @staticmethod
+    def _qualifies(vuln: ImageVulnerability) -> bool:
+        """Return True when a CVE should count toward the health badge.
+
+        EPSS missing (e.g. basic scanning can't filter) is treated as qualifying.
+        """
+        return vuln.epss_score is None or vuln.epss_score >= HEALTH_EPSS_THRESHOLD
+
+    def _check_images(self) -> list[HealthLayerResult]:
+        if not self._image_handler:
+            return [
+                HealthLayerResult(
+                    layer=HealthLayer.IMAGES,
+                    name="",
+                    status_category=StatusCategory.HEALTHY,
+                    status_text="",
+                    detail="",
+                    skipped=True,
+                )
+            ]
+
+        results: list[HealthLayerResult] = []
+        for name in self.project_manifest.get_images():
+            try:
+                status = self._image_handler.get_status(name)
+            except Exception as exc:  # noqa: BLE001 - one bad image must not fail the whole check
+                results.append(
+                    HealthLayerResult(
+                        layer=HealthLayer.IMAGES,
+                        name=name,
+                        status_category=StatusCategory.DEGRADED,
+                        status_text="error",
+                        detail=str(exc),
+                    )
+                )
+                continue
+
+            # Health category comes from ECR presence only; CVE counts are informational.
+            category = (
+                StatusCategory.HEALTHY if status.status_category == StatusCategory.HEALTHY else StatusCategory.DEGRADED
+            )
+            sub_component = ""
+            if status.status == "Available":
+                sub_component = self._summarize_vulnerabilities(name, status.latest_tag)
+
+            results.append(
+                HealthLayerResult(
+                    layer=HealthLayer.IMAGES,
+                    name=name,
+                    status_category=category,
+                    status_text=status.status,
+                    detail=status.latest_tag,
+                    sub_component=sub_component,
+                )
+            )
+
+        return results
+
+    def _summarize_vulnerabilities(self, name: str, tag: str) -> str:
+        """Return an informational CVE-count string for the image's sub-component cell."""
+        if self._image_handler is None:  # unreachable: _check_images guards this
+            return ""
+        try:
+            vulns = self._image_handler.get_vulnerabilities(name, tag)
+        except Exception as exc:  # noqa: BLE001 - fetch is best-effort; surface, but never fail the row
+            return f"scan error: {exc}"
+
+        if not vulns.last_scanned and not vulns.vulnerabilities:
+            return "scan n/a"
+
+        critical = sum(1 for v in vulns.vulnerabilities if v.severity == "CRITICAL" and self._qualifies(v))
+        high = sum(1 for v in vulns.vulnerabilities if v.severity == "HIGH" and self._qualifies(v))
+        if not critical and not high:
+            return ""
+        return f"{critical} critical, {high} high"
 
     def _check_load_balancer(self) -> HealthLayerResult:
         if not self._cluster_handler or not self.project_manifest.has_command("cluster.loadbalancer.health"):

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/payloads.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/payloads.py
@@ -10,6 +10,7 @@ class HealthLayer(str, Enum):
     CLUSTER = "cluster"
     LOAD_BALANCER = "load-balancer"
     COMPONENTS = "components"
+    IMAGES = "images"
 
 
 @dataclass
@@ -64,6 +65,16 @@ class ImageTag:
 
 
 @dataclass
+class ImageStatusResult:
+    """Result of jd image status: whether the image is present in ECR."""
+
+    name: str
+    status: str
+    status_category: str
+    latest_tag: str
+
+
+@dataclass
 class ImageVulnerability:
     """Single vulnerability entry."""
 
@@ -74,6 +85,7 @@ class ImageVulnerability:
     installed_version: str
     fixed_version: str
     score: float
+    epss_score: float | None = None
 
 
 @dataclass

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/component_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/component_handler.py
@@ -7,10 +7,23 @@ from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.exceptions import InvalidComponentVerbError, ResourceNotFoundError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
-from jupyter_deploy.handlers.resource.resource_utils import collect_results
+from jupyter_deploy.handlers.resource.resource_utils import collect_results, render_display_field
 from jupyter_deploy.manifest import JupyterDeployComponentDefinitionV1
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
 from jupyter_deploy.provider.resolved_clidefs import ResolvedCliParameter, StrResolvedCliParameter
+
+# Component types whose health is existence-based: the resource carries no controller-managed
+# status, so a successful get means "Present" and a 404 (ResourceNotFoundError) means "Not Found".
+# CustomResourceDefinition is cluster-scoped (no namespace), fetched via k8s.custom.get-cluster.
+CUSTOM_RESOURCE_WITHOUT_STATUS = "CustomResourceWithoutStatus"
+CUSTOM_RESOURCE_DEFINITION = "CustomResourceDefinition"
+EXISTENCE_COMPONENT_TYPES = frozenset({CUSTOM_RESOURCE_WITHOUT_STATUS, CUSTOM_RESOURCE_DEFINITION})
+
+# CustomResourceDefinition is a well-known cluster-scoped kind: its CRD coordinates are fixed,
+# so components of this type don't declare them.
+CRD_GROUP = "apiextensions.k8s.io"
+CRD_VERSION = "v1"
+CRD_PLURAL = "customresourcedefinitions"
 
 
 class ComponentHandler(BaseProjectHandler):
@@ -33,15 +46,20 @@ class ComponentHandler(BaseProjectHandler):
         else:
             raise NotImplementedError(f"OutputsHandler implementation not found for engine: {self.engine}")
 
-    def _resolve_namespace(self, component: JupyterDeployComponentDefinitionV1) -> str:
+    def _resolve_output_key(self, output_key: str) -> str:
         output_defs = self._output_handler.get_full_project_outputs()
-        ns_key = component.scope
-        if ns_key not in output_defs:
-            raise KeyError(f"Output '{ns_key}' not found for component namespace resolution")
-        ns_def = output_defs[ns_key]
-        if isinstance(ns_def, StrTemplateOutputDefinition) and ns_def.value:
-            return ns_def.value
-        raise ValueError(f"Output '{ns_key}' is not resolved")
+        if output_key not in output_defs:
+            raise KeyError(f"Output '{output_key}' not found for component resolution")
+        output_def = output_defs[output_key]
+        if isinstance(output_def, StrTemplateOutputDefinition) and output_def.value:
+            return output_def.value
+        raise ValueError(f"Output '{output_key}' is not resolved")
+
+    def _resolve_namespace(self, component: JupyterDeployComponentDefinitionV1) -> str | None:
+        # Cluster-scoped components (e.g. CRDs) declare no namespace.
+        if component.scope is None:
+            return None
+        return self._resolve_output_key(component.scope)
 
     def _validate_verb(self, name: str, component: JupyterDeployComponentDefinitionV1, verb: str) -> None:
         if verb not in component.verbs:
@@ -57,24 +75,46 @@ class ComponentHandler(BaseProjectHandler):
         self,
         name: str,
         component: JupyterDeployComponentDefinitionV1,
-        namespace: str,
+        namespace: str | None,
         extra: dict[str, str] | None = None,
     ) -> dict[str, ResolvedCliParameter[Any]]:
         cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {
             "name": StrResolvedCliParameter(parameter_name="name", value=name),
-            "scope": StrResolvedCliParameter(parameter_name="scope", value=namespace),
         }
+        # Cluster-scoped components (namespace is None) omit the scope param.
+        if namespace is not None:
+            cli_paramdefs["scope"] = StrResolvedCliParameter(parameter_name="scope", value=namespace)
         if component.query:
             cli_paramdefs["query"] = StrResolvedCliParameter(parameter_name="query", value=component.query)
+        # CRD coordinates: fixed for the well-known CustomResourceDefinition kind, declared as
+        # literals for generic custom-resource components.
+        crd_coords: dict[str, str | None]
+        if component.type == CUSTOM_RESOURCE_DEFINITION:
+            crd_coords = {"group": CRD_GROUP, "version": CRD_VERSION, "plural": CRD_PLURAL}
+        else:
+            crd_coords = {
+                "group": component.crd_group,
+                "version": component.crd_version,
+                "plural": component.crd_plural,
+            }
+        for param_name, value in crd_coords.items():
+            if value:
+                cli_paramdefs[param_name] = StrResolvedCliParameter(parameter_name=param_name, value=value)
         if extra:
             for k, v in extra.items():
                 cli_paramdefs[k] = StrResolvedCliParameter(parameter_name=k, value=v)
         return cli_paramdefs
 
     def list_components(self) -> list[dict[str, str]]:
-        """Return the list of components with name, type, and description."""
+        """Return the list of components with name, type, and description.
+
+        `type` is the display type (type-display when set, else the internal type).
+        """
         components = self.project_manifest.get_components()
-        return [{"name": name, "type": comp.type, "description": comp.description} for name, comp in components.items()]
+        return [
+            {"name": name, "type": comp.type_display or comp.type, "description": comp.description}
+            for name, comp in components.items()
+        ]
 
     def get_component_description(self, name: str) -> str:
         """Return the description string for a single component."""
@@ -87,21 +127,32 @@ class ComponentHandler(BaseProjectHandler):
         results: list[dict[str, str]] = []
         for name, comp_def in components.items():
             namespace = self._resolve_namespace(comp_def)
+            cmd_name = self._get_command_name(comp_def, "status")
+            command = self.project_manifest.get_command(cmd_name)
+            runner = cmd_runner.ManifestCommandRunner(
+                display_manager=self.display_manager,
+                output_handler=self._output_handler,
+                variable_handler=self._variable_handler,
+            )
+            resource_name = self._get_resource_name(name, comp_def)
+            cli_paramdefs = self._build_cli_paramdefs(resource_name, comp_def, namespace)
             try:
-                cmd_name = self._get_command_name(comp_def, "status")
-                command = self.project_manifest.get_command(cmd_name)
-                runner = cmd_runner.ManifestCommandRunner(
-                    display_manager=self.display_manager,
-                    output_handler=self._output_handler,
-                    variable_handler=self._variable_handler,
-                )
-                resource_name = self._get_resource_name(name, comp_def)
-                cli_paramdefs = self._build_cli_paramdefs(resource_name, comp_def, namespace)
                 runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
-                status = runner.get_result_value(command, f"{cmd_name}.status", str)
-                status_category = runner.get_result_value_with_fallback(command, f"{cmd_name}.status_category", str, "")
-                details = runner.get_result_value_with_fallback(command, f"{cmd_name}.details", str, "")
-                sub_component = runner.get_result_value_with_fallback(command, f"{cmd_name}.sub_component", str, "")
+                if comp_def.type in EXISTENCE_COMPONENT_TYPES:
+                    # No controller status: a successful get means the resource is present.
+                    resource_json = runner.get_result_value_with_fallback(command, f"{cmd_name}.resource", str, "")
+                    status, status_category = "Present", "healthy"
+                    details = render_display_field(resource_json, comp_def.details) if comp_def.details else ""
+                    sub_component = (
+                        render_display_field(resource_json, comp_def.sub_component) if comp_def.sub_component else ""
+                    )
+                else:
+                    status = runner.get_result_value(command, f"{cmd_name}.status", str)
+                    status_category = runner.get_result_value_with_fallback(
+                        command, f"{cmd_name}.status_category", str, ""
+                    )
+                    details = runner.get_result_value_with_fallback(command, f"{cmd_name}.details", str, "")
+                    sub_component = runner.get_result_value_with_fallback(command, f"{cmd_name}.sub_component", str, "")
             except ResourceNotFoundError:
                 status = "Not Found"
                 status_category = "degraded"
@@ -133,6 +184,13 @@ class ComponentHandler(BaseProjectHandler):
             variable_handler=self._variable_handler,
         )
         cli_paramdefs = self._build_cli_paramdefs(resource_name, component, namespace)
+        if component.type in EXISTENCE_COMPONENT_TYPES:
+            # No controller status: a successful get means the resource is present.
+            try:
+                runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+            except ResourceNotFoundError:
+                return "Not Found"
+            return "Present"
         runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
         return runner.get_result_value(command, f"{cmd_name}.status", str)
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/image_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/image_handler.py
@@ -10,6 +10,7 @@ from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
 from jupyter_deploy.handlers.payloads import (
     ImageDetail,
     ImageInfo,
+    ImageStatusResult,
     ImageTag,
     ImageVulnerabilitiesResult,
     ImageVulnerability,
@@ -122,6 +123,49 @@ class ImageHandler(BaseProjectHandler):
         raw_tags = results.get("tags", [])
         return [ImageTag(tag=t["tag"], pushed_at=t.get("pushed_at", ""), digest=t.get("digest", "")) for t in raw_tags]
 
+    @staticmethod
+    def _select_latest_tag(tags: list[ImageTag]) -> str:
+        """Return the most-recently-pushed tag name, excluding the floating 'latest' tag."""
+        real_tags = [t for t in tags if t.tag != "latest"]
+        if not real_tags:
+            return ""
+        # list_tags returns tags sorted by push time (most recent first).
+        return real_tags[0].tag
+
+    def get_status(self, name: str | None = None) -> ImageStatusResult:
+        """Return whether the image is present in ECR, plus its latest non-'latest' tag."""
+        resolved_name = self.resolve_name(name)
+        image_def = self.project_manifest.get_image(resolved_name)
+        repository_name, default_tag = self._resolve_image_outputs(image_def)
+
+        latest_tag = self._select_latest_tag(self.list_tags(resolved_name))
+        probe_tag = latest_tag or default_tag
+
+        cli_paramdefs = self._build_cli_paramdefs(repository_name, probe_tag)
+        command = self.project_manifest.get_command("image.status")
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        try:
+            runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+        except ImageTagNotFoundError:
+            return ImageStatusResult(
+                name=resolved_name,
+                status="Missing",
+                status_category="degraded",
+                latest_tag=latest_tag,
+            )
+        results = collect_results(runner, command)
+
+        return ImageStatusResult(
+            name=resolved_name,
+            status=results.get("status", "Available"),
+            status_category=results.get("status_category", "healthy"),
+            latest_tag=latest_tag,
+        )
+
     def get_vulnerabilities(self, name: str | None = None, tag: str | None = None) -> ImageVulnerabilitiesResult:
         """Return vulnerabilities for an image."""
         resolved_name = self.resolve_name(name)
@@ -152,6 +196,7 @@ class ImageHandler(BaseProjectHandler):
                 installed_version=v.get("installed_version", ""),
                 fixed_version=v.get("fixed_version", ""),
                 score=v.get("score", 0.0),
+                epss_score=v.get("epss_score"),
             )
             for v in raw_vulns
         ]

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/resource_utils.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/resource_utils.py
@@ -3,42 +3,122 @@ import json
 import re
 from typing import Any
 
-from jupyter_deploy.manifest import JupyterDeployStatusRuleV1
+from jupyter_deploy.manifest import JupyterDeployDisplayFieldV1, JupyterDeployStatusRuleV1
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
 
+
+def _resolve_display_field(resource: dict[str, Any], field: JupyterDeployDisplayFieldV1) -> str | None:
+    """Resolve one display field to a string, or None when the value is absent and unlabeled.
+
+    A labeled field always renders its label, falling back to '<label>: -' when the value is
+    absent (missing/typo'd path), so the cell stays self-documenting rather than going blank.
+    """
+    if field.count is not None:
+        node = resolve_node(resource, field.count)
+        value: str | None = str(len(node)) if isinstance(node, list) else None
+    elif field.join is not None:
+        parts = [resolve_node(resource, p) for p in field.join]
+        value = field.separator.join(str(p) for p in parts) if all(p is not None for p in parts) else None
+    elif field.path is not None:
+        node = resolve_node(resource, field.path)
+        value = str(node) if node is not None else None
+    else:
+        value = None
+
+    if field.label:
+        return f"{field.label}: {value if value is not None else '-'}"
+    return value
+
+
+def render_display_field(resource_json: str, field: JupyterDeployDisplayFieldV1) -> str:
+    """Render a single display field to a string from a resource's JSON.
+
+    Returns '' when the source value is absent or the input is unparseable.
+    """
+    try:
+        resource = json.loads(resource_json)
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if not isinstance(resource, dict):
+        return ""
+    return _resolve_display_field(resource, field) or ""
+
+
 _ARRAY_FILTER_RE = re.compile(r"^([^\[]+)\[([^=]+)=([^\]]+)\]$")
+_INDEX_RE = re.compile(r"^([^\[]+)\[(\d+)\]$")
+_MAP_KEY_RE = re.compile(r"^([^\[]+)\[([^\]]+)\]$")
 
 
-def resolve_path(resource: dict[str, Any], path: str) -> str | None:
-    """Resolve a dotted path against a resource dict.
+def _split_segments(path: str) -> list[str]:
+    """Split a dotted path on '.', but never inside [...] (label keys contain dots and slashes)."""
+    segments: list[str] = []
+    current = ""
+    depth = 0
+    for ch in path:
+        if ch == "[":
+            depth += 1
+            current += ch
+        elif ch == "]":
+            depth -= 1
+            current += ch
+        elif ch == "." and depth == 0:
+            if current:
+                segments.append(current)
+            current = ""
+        else:
+            current += ch
+    if current:
+        segments.append(current)
+    return segments
 
-    Supports two segment forms:
+
+def resolve_node(resource: dict[str, Any], path: str) -> Any:
+    """Resolve a dotted path against a resource dict, returning the raw node (any type) or None.
+
+    Supports four segment forms:
       - Simple key: .spec.desiredStatus
       - Array filter: .status.conditions[type=Degraded].status
+      - List index: .spec.versions[0].name
+      - Map-key lookup: .metadata.labels[workspace.jupyter.org/default-template]
+        (use brackets for keys that contain dots or slashes)
     """
-    segments = [s for s in path.split(".") if s]
+    segments = _split_segments(path)
     current: Any = resource
     for segment in segments:
-        if not isinstance(current, dict):
-            return None
-        match = _ARRAY_FILTER_RE.match(segment)
-        if match:
-            array_key, filter_key, filter_val = match.group(1), match.group(2), match.group(3)
-            items = current.get(array_key)
+        filter_match = _ARRAY_FILTER_RE.match(segment)
+        index_match = _INDEX_RE.match(segment)
+        map_key_match = _MAP_KEY_RE.match(segment)
+        if filter_match:
+            array_key, filter_key, filter_val = filter_match.group(1), filter_match.group(2), filter_match.group(3)
+            items = current.get(array_key) if isinstance(current, dict) else None
             if not isinstance(items, list):
                 return None
             current = next(
                 (item for item in items if isinstance(item, dict) and item.get(filter_key) == filter_val), None
             )
-            if current is None:
+        elif index_match:
+            list_key, index = index_match.group(1), int(index_match.group(2))
+            items = current.get(list_key) if isinstance(current, dict) else None
+            if not isinstance(items, list) or index >= len(items):
                 return None
+            current = items[index]
+        elif map_key_match:
+            map_key, lookup_key = map_key_match.group(1), map_key_match.group(2)
+            container = current.get(map_key) if isinstance(current, dict) else None
+            if not isinstance(container, dict):
+                return None
+            current = container.get(lookup_key)
         else:
-            current = current.get(segment)
-            if current is None:
-                return None
-    if isinstance(current, str):
-        return current
-    return None
+            current = current.get(segment) if isinstance(current, dict) else None
+        if current is None:
+            return None
+    return current
+
+
+def resolve_path(resource: dict[str, Any], path: str) -> str | None:
+    """Resolve a dotted path against a resource dict, returning a string leaf or None."""
+    value = resolve_node(resource, path)
+    return value if isinstance(value, str) else None
 
 
 def evaluate_status_rules(resource_json: str, rules: list[JupyterDeployStatusRuleV1]) -> str:

--- a/libs/jupyter-deploy/jupyter_deploy/manifest.py
+++ b/libs/jupyter-deploy/jupyter_deploy/manifest.py
@@ -272,13 +272,37 @@ class JupyterDeployComponentVerbV1(BaseModel):
     method: str
 
 
+class JupyterDeployDisplayFieldV1(BaseModel):
+    """A single rendered value extracted from a resource's JSON for the health dashboard.
+
+    Exactly one of `path`, `count`, or `join` should be set:
+      - path: dotted path to a scalar (e.g. .metadata.namespace)
+      - count: dotted path to a list; renders its length
+      - join: list of dotted paths; renders the parts joined by `separator`
+    A `label` prefixes the value (e.g. "app-type: jupyterlab").
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    label: str = ""
+    path: str | None = None
+    count: str | None = None
+    join: list[str] | None = None
+    separator: str = "/"
+
+
 class JupyterDeployComponentDefinitionV1(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
     type: str
+    type_display: str | None = Field(alias="type-display", default=None)
     description: str = ""
     resource_name: str | None = Field(alias="resource-name", default=None)
-    scope: str
+    crd_group: str | None = Field(alias="crd-group", default=None)
+    crd_version: str | None = Field(alias="crd-version", default=None)
+    crd_plural: str | None = Field(alias="crd-plural", default=None)
+    scope: str | None = None
     query: str = ""
+    details: JupyterDeployDisplayFieldV1 | None = None
+    sub_component: JupyterDeployDisplayFieldV1 | None = Field(alias="sub-component", default=None)
     verbs: dict[str, JupyterDeployComponentVerbV1]
 
 

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ecr_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_ecr_runner.py
@@ -6,7 +6,7 @@ from mypy_boto3_ecr.client import ECRClient
 
 from jupyter_deploy.api.aws.ecr import ecr_repository
 from jupyter_deploy.engine.supervised_execution import DisplayManager
-from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.exceptions import ImageTagNotFoundError, InstructionNotFoundError
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
 from jupyter_deploy.provider.resolved_argdefs import (
     ResolvedInstructionArgument,
@@ -23,6 +23,7 @@ class AwsEcrInstruction(str, Enum):
     """AWS ECR instructions accessible from manifest.commands[].sequence[].api-name."""
 
     DESCRIBE_REPOSITORY = "describe-repository"
+    DESCRIBE_IMAGE = "describe-image"
     LIST_IMAGE_TAGS = "list-image-tags"
 
 
@@ -51,6 +52,26 @@ class AwsEcrRunner(InstructionRunner):
             "RepositoryName": StrResolvedInstructionResult(
                 result_name="RepositoryName", value=repo.get("repositoryName", "")
             ),
+        }
+
+    def _describe_image(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        repository_name_arg = require_arg(resolved_arguments, "repository_name", StrResolvedInstructionArgument)
+        image_tag_arg = require_arg(resolved_arguments, "image_tag", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Describing image: {repository_name_arg.value}:{image_tag_arg.value}")
+        try:
+            ecr_repository.describe_image(
+                self.client, repository_name=repository_name_arg.value, image_tag=image_tag_arg.value
+            )
+        except self.client.exceptions.ImageNotFoundException:
+            raise ImageTagNotFoundError(repository_name_arg.value, image_tag_arg.value) from None
+
+        # Presence in ECR is the health signal: a successful describe means the image is available.
+        return {
+            "Status": StrResolvedInstructionResult(result_name="Status", value="Available"),
+            "StatusCategory": StrResolvedInstructionResult(result_name="StatusCategory", value="healthy"),
         }
 
     def _list_image_tags(
@@ -90,6 +111,8 @@ class AwsEcrRunner(InstructionRunner):
 
         if instruction == AwsEcrInstruction.DESCRIBE_REPOSITORY:
             return self._describe_repository(resolved_arguments)
+        elif instruction == AwsEcrInstruction.DESCRIBE_IMAGE:
+            return self._describe_image(resolved_arguments)
         elif instruction == AwsEcrInstruction.LIST_IMAGE_TAGS:
             return self._list_image_tags(resolved_arguments)
 

--- a/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_inspector_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/aws/aws_inspector_runner.py
@@ -88,6 +88,10 @@ class AwsInspectorRunner(InstructionRunner):
             score = finding.get("inspectorScore", 0.0)
             package_manager = vulnerable_packages[0].get("packageManager", "") if vulnerable_packages else ""
 
+            # EPSS (Exploit Prediction Scoring System) probability, 0.0-1.0; absent on some findings.
+            epss_details = finding.get("epss") or {}
+            epss_score = epss_details.get("score")
+
             raw_title = finding.get("title", "")
             cve = raw_title.split(" - ")[0].strip() if " - " in raw_title else raw_title
 
@@ -100,6 +104,7 @@ class AwsInspectorRunner(InstructionRunner):
                     "installed_version": installed_version,
                     "fixed_version": fixed_version,
                     "score": score,
+                    "epss_score": epss_score,
                 }
             )
 
@@ -151,6 +156,7 @@ class AwsInspectorRunner(InstructionRunner):
                     "installed_version": installed_version,
                     "fixed_version": fixed_version,
                     "score": score,
+                    "epss_score": None,  # ECR basic scanning does not provide EPSS.
                 }
             )
 

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_custom_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_custom_runner.py
@@ -26,6 +26,7 @@ class K8sCustomInstruction(str, Enum):
 
     LIST = "list"
     GET = "get"
+    GET_CLUSTER = "get-cluster"
     PATCH = "patch"
     LIST_CLUSTER = "list-cluster"
 
@@ -79,6 +80,20 @@ class K8sCustomRunner(InstructionRunner):
 
         self.display_manager.info(f"Getting {ref.plural}/{name_arg.value}")
         result = k8s_custom.get_namespaced(self.custom_api, ref=ref, namespace=scope_arg.value, name=name_arg.value)
+
+        return {
+            "Name": StrResolvedInstructionResult(result_name="Name", value=result.name),
+            "Resource": StrResolvedInstructionResult(result_name="Resource", value=json.dumps(result.resource)),
+        }
+
+    def _get_cluster(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        ref = self._extract_ref(resolved_arguments)
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Getting cluster-scoped {ref.plural}/{name_arg.value}")
+        result = k8s_custom.get_cluster(self.custom_api, ref=ref, name=name_arg.value)
 
         return {
             "Name": StrResolvedInstructionResult(result_name="Name", value=result.name),
@@ -143,6 +158,8 @@ class K8sCustomRunner(InstructionRunner):
             return self._list(resolved_arguments)
         elif instruction == K8sCustomInstruction.GET:
             return self._get(resolved_arguments)
+        elif instruction == K8sCustomInstruction.GET_CLUSTER:
+            return self._get_cluster(resolved_arguments)
         elif instruction == K8sCustomInstruction.PATCH:
             return self._patch(resolved_arguments)
         elif instruction == K8sCustomInstruction.LIST_CLUSTER:

--- a/libs/jupyter-deploy/tests/unit/api/k8s/test_custom.py
+++ b/libs/jupyter-deploy/tests/unit/api/k8s/test_custom.py
@@ -6,6 +6,7 @@ from kubernetes.client.exceptions import ApiException
 
 from jupyter_deploy.api.k8s.custom import (
     CustomResourceRef,
+    get_cluster,
     get_namespaced,
     list_cluster,
     list_namespaced,
@@ -129,6 +130,45 @@ class TestGetNamespaced(unittest.TestCase):
 
         with self.assertRaises(ApiException):
             get_namespaced(mock_api, ref=REF, namespace="default", name="nonexistent")
+
+
+class TestGetCluster(unittest.TestCase):
+    CRD_REF = CustomResourceRef(group="apiextensions.k8s.io", version="v1", plural="customresourcedefinitions")
+
+    def test_returns_name_and_resource(self) -> None:
+        mock_api: Mock = Mock(spec=CustomObjectsApi)
+        resource = {
+            "metadata": {"name": "workspaces.workspace.jupyter.org"},
+            "spec": {"group": "workspace.jupyter.org"},
+        }
+        mock_api.get_cluster_custom_object.return_value = resource
+
+        result = get_cluster(mock_api, ref=self.CRD_REF, name="workspaces.workspace.jupyter.org")
+
+        self.assertEqual(result.name, "workspaces.workspace.jupyter.org")
+        self.assertEqual(result.resource["spec"]["group"], "workspace.jupyter.org")
+        mock_api.get_cluster_custom_object.assert_called_once_with(
+            group="apiextensions.k8s.io",
+            version="v1",
+            plural="customresourcedefinitions",
+            name="workspaces.workspace.jupyter.org",
+        )
+
+    def test_returns_empty_name_when_metadata_absent(self) -> None:
+        mock_api: Mock = Mock(spec=CustomObjectsApi)
+        mock_api.get_cluster_custom_object.return_value = {}
+
+        result = get_cluster(mock_api, ref=self.CRD_REF, name="workspaces.workspace.jupyter.org")
+
+        self.assertEqual(result.name, "")
+        self.assertEqual(result.resource, {})
+
+    def test_raises_on_api_error(self) -> None:
+        mock_api: Mock = Mock(spec=CustomObjectsApi)
+        mock_api.get_cluster_custom_object.side_effect = _NOT_FOUND
+
+        with self.assertRaises(ApiException):
+            get_cluster(mock_api, ref=self.CRD_REF, name="nonexistent")
 
 
 class TestPatchNamespaced(unittest.TestCase):

--- a/libs/jupyter-deploy/tests/unit/cli/test_health_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_health_app.py
@@ -5,9 +5,26 @@ from unittest.mock import Mock, patch
 
 from typer.testing import CliRunner
 
-from jupyter_deploy.cli.health_app import health_app
+from jupyter_deploy.cli.health_app import _format_sub_component, health_app
 from jupyter_deploy.enum import StatusCategory
 from jupyter_deploy.handlers.payloads import ConnectionResult, HealthLayer, HealthLayerResult
+
+
+class TestFormatSubComponent(unittest.TestCase):
+    def test_empty_renders_dash(self) -> None:
+        self.assertEqual(_format_sub_component(""), "-")
+
+    def test_dash_passthrough(self) -> None:
+        self.assertEqual(_format_sub_component("-"), "-")
+
+    def test_plain_text_passthrough(self) -> None:
+        self.assertEqual(_format_sub_component("1 critical, 1 high"), "1 critical, 1 high")
+
+    def test_empty_json_renders_dash(self) -> None:
+        self.assertEqual(_format_sub_component("{}"), "-")
+
+    def test_json_item_formatted(self) -> None:
+        self.assertEqual(_format_sub_component('{"name": "pod", "status": "Running"}'), "pod: Running")
 
 
 class TestHealthApp(unittest.TestCase):
@@ -192,6 +209,119 @@ class TestHealthApp(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_handler.check_layer.assert_called_once_with(HealthLayer.LOAD_BALANCER)
         self.assertIn("load-balancer", result.stdout)
+
+    @patch("jupyter_deploy.handlers.health_handler.HealthHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_health_images_flag(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.check_layer.return_value = [
+            HealthLayerResult(
+                layer=HealthLayer.IMAGES,
+                name="jupyterlab",
+                status_category=StatusCategory.HEALTHY,
+                status_text="Available",
+                detail="v1",
+                sub_component="1 critical, 1 high",
+            )
+        ]
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(health_app, ["--images"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.check_layer.assert_called_once_with(HealthLayer.IMAGES)
+        self.assertIn("images", result.stdout)
+        self.assertIn("Available", result.stdout)
+        # A non-zero vulnerability count surfaces the drill-down hint.
+        self.assertIn("Hint:", result.stdout)
+        self.assertIn("jd image vulnerabilities --name jupyterlab --tag v1", result.stdout)
+
+    @patch("jupyter_deploy.handlers.health_handler.HealthHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_health_images_clean_has_no_hint(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.check_layer.return_value = [
+            HealthLayerResult(
+                layer=HealthLayer.IMAGES,
+                name="jupyterlab",
+                status_category=StatusCategory.HEALTHY,
+                status_text="Available",
+                detail="v1",
+                sub_component="",
+            )
+        ]
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(health_app, ["--images"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn("Hint:", result.stdout)
+
+    @patch("jupyter_deploy.handlers.health_handler.HealthHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_health_renders_custom_resource_components(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.check_all.return_value = (
+            [
+                HealthLayerResult(
+                    layer=HealthLayer.COMPONENTS,
+                    name="workspace-crd",
+                    status_category=StatusCategory.HEALTHY,
+                    status_text="Present",
+                    detail="v1alpha1",
+                ),
+                HealthLayerResult(
+                    layer=HealthLayer.COMPONENTS,
+                    name="oauth-access-strategy",
+                    status_category=StatusCategory.HEALTHY,
+                    status_text="Present",
+                    detail="jupyter-k8s-shared",
+                    sub_component="access-resources: 2",
+                ),
+                HealthLayerResult(
+                    layer=HealthLayer.COMPONENTS,
+                    name="jupyterlab-template",
+                    status_category=StatusCategory.HEALTHY,
+                    status_text="Present",
+                    detail="jupyter-k8s-shared",
+                    sub_component="access-strategy: oauth-access-strategy",
+                ),
+                HealthLayerResult(
+                    layer=HealthLayer.IMAGES,
+                    name="jupyterlab",
+                    status_category=StatusCategory.HEALTHY,
+                    status_text="Available",
+                    detail="v1",
+                    sub_component="1 critical, 1 high",
+                ),
+            ],
+            ConnectionResult(status_category=StatusCategory.HEALTHY, detail="", skipped=True),
+        )
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(health_app, [], env={"COLUMNS": "200"})
+
+        self.assertEqual(result.exit_code, 0)
+        for token in [
+            "workspace-crd",
+            "v1alpha1",
+            "oauth-access-strategy",
+            "access-resources: 2",
+            "jupyterlab-template",
+            "Present",
+            "Available",
+        ]:
+            self.assertIn(token, result.stdout)
+        self.assertIn("Hint:", result.stdout)
 
     @patch("jupyter_deploy.handlers.health_handler.HealthHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")

--- a/libs/jupyter-deploy/tests/unit/cli/test_image_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_image_app.py
@@ -10,6 +10,7 @@ from jupyter_deploy.exceptions import ImageNotFoundError, ImageTagNotFoundError
 from jupyter_deploy.handlers.payloads import (
     ImageDetail,
     ImageInfo,
+    ImageStatusResult,
     ImageTag,
     ImageVulnerabilitiesResult,
     ImageVulnerability,
@@ -121,6 +122,89 @@ class TestImageListCommand(unittest.TestCase):
         result = runner.invoke(image_app, ["list"])
 
         self.assertNotEqual(result.exit_code, 0)
+
+
+class TestImageStatusCommand(unittest.TestCase):
+    def get_mock_image_handler(self, status: str = "Available") -> tuple[Mock, dict[str, Mock]]:
+        mock_get_status = Mock()
+        mock_handler = Mock()
+        mock_handler.get_status = mock_get_status
+        mock_get_status.return_value = ImageStatusResult(
+            name="jupyterlab",
+            status=status,
+            status_category="healthy" if status == "Available" else "degraded",
+            latest_tag="v2",
+        )
+        return mock_handler, {"get_status": mock_get_status}
+
+    @patch("jupyter_deploy.handlers.resource.image_handler.ImageHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_renders_available_one_liner(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_handler, mock_fns = self.get_mock_image_handler()
+        mock_handler_class.return_value = mock_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(image_app, ["status", "--name", "jupyterlab"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_fns["get_status"].assert_called_once_with("jupyterlab")
+        self.assertIn("jupyterlab status:", result.stdout)
+        self.assertIn("Available", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.image_handler.ImageHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_renders_missing(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_handler, _ = self.get_mock_image_handler(status="Missing")
+        mock_handler_class.return_value = mock_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(image_app, ["status"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Missing", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.image_handler.ImageHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_image_not_found_error(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_handler = Mock()
+        mock_handler.get_status.side_effect = ImageNotFoundError("bad", ["jupyterlab"])
+        mock_handler_class.return_value = mock_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(image_app, ["status", "--name", "bad"])
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("bad", result.stdout)
+        self.assertIn("jupyterlab", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.image_handler.ImageHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_raises_when_handler_raises(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_handler = Mock()
+        mock_handler.get_status.side_effect = Exception("Test error")
+        mock_handler_class.return_value = mock_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(image_app, ["status"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+    @patch("jupyter_deploy.handlers.resource.image_handler.ImageHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_status_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_handler, _ = self.get_mock_image_handler()
+        mock_handler_class.return_value = mock_handler
+        mock_project_dir.return_value.__enter__.return_value = None
+
+        runner = CliRunner()
+        result = runner.invoke(image_app, ["status", "--path", "/my/project"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/my/project"))
 
 
 class TestImageShowCommand(unittest.TestCase):
@@ -325,6 +409,7 @@ class TestImageVulnerabilitiesCommand(unittest.TestCase):
                     installed_version="3.0.18",
                     fixed_version="3.0.19",
                     score=8.3,
+                    epss_score=0.42,
                 ),
                 ImageVulnerability(
                     cve="CVE-2026-5678",
@@ -334,6 +419,7 @@ class TestImageVulnerabilitiesCommand(unittest.TestCase):
                     installed_version="5.36.0",
                     fixed_version="",
                     score=7.5,
+                    epss_score=None,
                 ),
                 ImageVulnerability(
                     cve="CVE-2026-9999",
@@ -343,6 +429,7 @@ class TestImageVulnerabilitiesCommand(unittest.TestCase):
                     installed_version="7.88.0",
                     fixed_version="7.88.1",
                     score=6.1,
+                    epss_score=0.01,
                 ),
             ],
         )
@@ -361,7 +448,7 @@ class TestImageVulnerabilitiesCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__.return_value = None
 
         runner = CliRunner()
-        result = runner.invoke(image_app, ["vulnerabilities"])
+        result = runner.invoke(image_app, ["vulnerabilities"], env={"COLUMNS": "200"})
 
         self.assertEqual(result.exit_code, 0)
         mock_handler_class.assert_called_once()
@@ -370,6 +457,9 @@ class TestImageVulnerabilitiesCommand(unittest.TestCase):
         self.assertIn("CVE-2026-1234", result.stdout)
         self.assertIn("openssl", result.stdout)
         self.assertIn("Inspector Enhanced", result.stdout)
+        # EPSS column: percentage when present, n/a when absent.
+        self.assertIn("42%", result.stdout)
+        self.assertIn("n/a", result.stdout)
 
     @patch("jupyter_deploy.handlers.resource.image_handler.ImageHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_component_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_component_handler.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
-from jupyter_deploy.exceptions import ComponentNotFoundError, InvalidComponentVerbError
+from jupyter_deploy.exceptions import ComponentNotFoundError, InvalidComponentVerbError, ResourceNotFoundError
 from jupyter_deploy.handlers.resource.component_handler import ComponentHandler
 from jupyter_deploy.manifest import JupyterDeployComponentDefinitionV1, JupyterDeployComponentVerbV1
 
@@ -34,10 +34,42 @@ def _mock_component_cronjob() -> JupyterDeployComponentDefinitionV1:
     )
 
 
+def _mock_component_custom_resource() -> JupyterDeployComponentDefinitionV1:
+    return JupyterDeployComponentDefinitionV1(
+        **{  # type: ignore[arg-type]
+            "type": "CustomResourceWithoutStatus",
+            "scope": "workspace_shared_namespace",
+            "resource-name": "jupyterlab",
+            "crd-group": "workspace.jupyter.org",
+            "crd-version": "v1alpha1",
+            "crd-plural": "workspacetemplates",
+            "verbs": {"status": {"method": "k8s.custom.get"}, "show": {"method": "k8s.custom.get"}},
+        }
+    )
+
+
+def _mock_component_crd() -> JupyterDeployComponentDefinitionV1:
+    # No crd-group/version/plural: the handler supplies them for the well-known CRD kind.
+    return JupyterDeployComponentDefinitionV1(
+        **{  # type: ignore[arg-type]
+            "type": "CustomResourceDefinition",
+            "resource-name": "workspaces.workspace.jupyter.org",
+            "details": {"path": ".spec.versions[0].name"},
+            "verbs": {"status": {"method": "k8s.custom.get-cluster"}, "show": {"method": "k8s.custom.get-cluster"}},
+        }
+    )
+
+
 _NS_OUTPUTS = {
     "workspace_router_namespace": StrTemplateOutputDefinition(
         output_name="workspace_router_namespace", value="router-ns"
     )
+}
+
+_CR_OUTPUTS = {
+    "workspace_shared_namespace": StrTemplateOutputDefinition(
+        output_name="workspace_shared_namespace", value="shared-ns"
+    ),
 }
 
 
@@ -131,6 +163,35 @@ class TestComponentHandlerGetComponentStatus(unittest.TestCase):
 
         self.assertEqual(ctx.exception.component_name, "unknown")
         self.assertIn("traefik", ctx.exception.valid_components)
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerListComponents(unittest.TestCase):
+    def test_uses_type_display_when_set_else_type(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        cr = JupyterDeployComponentDefinitionV1(
+            **{  # type: ignore[arg-type]
+                "type": "CustomResourceWithoutStatus",
+                "type-display": "WorkspaceTemplate",
+                "scope": "ns",
+                "verbs": {"status": {"method": "k8s.custom.get"}},
+            }
+        )
+        manifest.get_components.return_value = {"jupyterlab-template": cr, "traefik": _mock_component_deployment()}
+        mock_manifest_fn.return_value = manifest
+
+        handler = ComponentHandler(display_manager=Mock())
+        components = handler.list_components()
+
+        by_name = {c["name"]: c for c in components}
+        self.assertEqual(by_name["jupyterlab-template"]["type"], "WorkspaceTemplate")
+        self.assertEqual(by_name["traefik"]["type"], "Deployment")  # falls back to type
 
 
 @patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
@@ -232,6 +293,205 @@ class TestComponentHandlerGetAllStatus(unittest.TestCase):
 
             with self.assertRaises(RuntimeError):
                 handler.get_all_status()
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerCustomResourceWithoutStatus(unittest.TestCase):
+    def _setup(self, manifest_fn: Mock, outputs: Mock, component: JupyterDeployComponentDefinitionV1) -> Mock:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_components.return_value = {"default-template": component}
+        manifest_fn.return_value = manifest
+        outputs.return_value.get_full_project_outputs.return_value = _CR_OUTPUTS
+        return manifest
+
+    def test_present_when_get_succeeds(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest = self._setup(mock_manifest_fn, mock_outputs, _mock_component_custom_resource())
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value_with_fallback.return_value = ""
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+            handler = ComponentHandler(display_manager=Mock())
+            results = handler.get_all_status()
+
+        self.assertEqual(results[0]["status"], "Present")
+        self.assertEqual(results[0]["status_category"], "healthy")
+        manifest.get_command.assert_called_with("component.customresourcewithoutstatus.status")
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["name"].value, "jupyterlab")
+        self.assertEqual(cli_paramdefs["group"].value, "workspace.jupyter.org")
+        self.assertEqual(cli_paramdefs["version"].value, "v1alpha1")
+        self.assertEqual(cli_paramdefs["plural"].value, "workspacetemplates")
+        self.assertEqual(cli_paramdefs["scope"].value, "shared-ns")
+
+    def test_renders_details_and_sub_component_from_resource(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        component = JupyterDeployComponentDefinitionV1(
+            **{  # type: ignore[arg-type]
+                "type": "CustomResourceWithoutStatus",
+                "scope": "workspace_shared_namespace",
+                "resource-name": "jupyterlab",
+                "crd-group": "workspace.jupyter.org",
+                "crd-version": "v1alpha1",
+                "crd-plural": "workspacetemplates",
+                "details": {"path": ".metadata.namespace"},
+                "sub-component": {"label": "access-strategy", "path": ".spec.defaultAccessStrategy.name"},
+                "verbs": {"status": {"method": "k8s.custom.get"}},
+            }
+        )
+        manifest = self._setup(mock_manifest_fn, mock_outputs, component)
+
+        mock_runner: Mock = Mock()
+        resource_json = (
+            '{"metadata": {"namespace": "jupyter-k8s-shared"},'
+            ' "spec": {"appType": "jupyterlab", "defaultAccessStrategy": {"name": "oauth-access-strategy"}}}'
+        )
+        mock_runner.get_result_value_with_fallback.return_value = resource_json
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+            handler = ComponentHandler(display_manager=Mock())
+            results = handler.get_all_status()
+
+        self.assertEqual(results[0]["details"], "jupyter-k8s-shared")
+        self.assertEqual(results[0]["sub_component"], "access-strategy: oauth-access-strategy")
+
+    def test_missing_when_resource_not_found(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest = self._setup(mock_manifest_fn, mock_outputs, _mock_component_custom_resource())
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = ResourceNotFoundError(
+                resource_kind="WorkspaceTemplate", resource_name="jupyterlab", original_message="not found"
+            )
+            manifest.get_command.return_value = Mock()
+            handler = ComponentHandler(display_manager=Mock())
+            results = handler.get_all_status()
+
+        self.assertEqual(results[0]["status"], "Not Found")
+        self.assertEqual(results[0]["status_category"], "degraded")
+
+    def test_get_component_status_present(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest = self._setup(mock_manifest_fn, mock_outputs, _mock_component_custom_resource())
+        manifest.get_component.return_value = _mock_component_custom_resource()
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value_with_fallback.return_value = ""
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+            handler = ComponentHandler(display_manager=Mock())
+            status = handler.get_component_status("default-template")
+
+        self.assertEqual(status, "Present")
+
+    def test_get_component_status_missing(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest = self._setup(mock_manifest_fn, mock_outputs, _mock_component_custom_resource())
+        manifest.get_component.return_value = _mock_component_custom_resource()
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = ResourceNotFoundError(
+                resource_kind="WorkspaceTemplate", resource_name="jupyterlab", original_message="not found"
+            )
+            manifest.get_command.return_value = Mock()
+            handler = ComponentHandler(display_manager=Mock())
+            status = handler.get_component_status("default-template")
+
+        self.assertEqual(status, "Not Found")
+
+    def test_show_component_returns_resource(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest = self._setup(mock_manifest_fn, mock_outputs, _mock_component_custom_resource())
+        manifest.get_component.return_value = _mock_component_custom_resource()
+
+        mock_runner: Mock = Mock()
+        mock_command = Mock()
+        mock_command.cmd = "component.customresourcewithoutstatus.show"
+        mock_command.results = []
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = mock_command
+            handler = ComponentHandler(display_manager=Mock())
+            handler.show_component("default-template")
+
+        manifest.get_command.assert_called_with("component.customresourcewithoutstatus.show")
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertEqual(cli_paramdefs["name"].value, "jupyterlab")
+        self.assertEqual(cli_paramdefs["plural"].value, "workspacetemplates")
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerCustomResourceDefinition(unittest.TestCase):
+    def _setup(self, manifest_fn: Mock, outputs: Mock) -> Mock:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        component = _mock_component_crd()
+        manifest.get_components.return_value = {"workspace-crd": component}
+        manifest.get_component.return_value = component
+        manifest_fn.return_value = manifest
+        # Cluster-scoped components resolve no namespace output.
+        outputs.return_value.get_full_project_outputs.return_value = {}
+        return manifest
+
+    def test_present_omits_scope_and_renders_details(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest = self._setup(mock_manifest_fn, mock_outputs)
+
+        mock_runner: Mock = Mock()
+        resource_json = '{"spec": {"group": "workspace.jupyter.org", "versions": [{"name": "v1alpha1"}]}}'
+        mock_runner.get_result_value_with_fallback.return_value = resource_json
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+            handler = ComponentHandler(display_manager=Mock())
+            results = handler.get_all_status()
+
+        self.assertEqual(results[0]["status"], "Present")
+        self.assertEqual(results[0]["status_category"], "healthy")
+        self.assertEqual(results[0]["details"], "v1alpha1")
+        manifest.get_command.assert_called_with("component.customresourcedefinition.status")
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        self.assertNotIn("scope", cli_paramdefs)
+        self.assertEqual(cli_paramdefs["name"].value, "workspaces.workspace.jupyter.org")
+        self.assertEqual(cli_paramdefs["group"].value, "apiextensions.k8s.io")
+        self.assertEqual(cli_paramdefs["plural"].value, "customresourcedefinitions")
+
+    def test_not_found_when_crd_missing(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest = self._setup(mock_manifest_fn, mock_outputs)
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = ResourceNotFoundError(
+                resource_kind="CustomResourceDefinition",
+                resource_name="workspaces.workspace.jupyter.org",
+                original_message="not found",
+            )
+            manifest.get_command.return_value = Mock()
+            handler = ComponentHandler(display_manager=Mock())
+            results = handler.get_all_status()
+
+        self.assertEqual(results[0]["status"], "Not Found")
+        self.assertEqual(results[0]["status_category"], "degraded")
 
 
 @patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_image_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_image_handler.py
@@ -310,6 +310,74 @@ class TestImageHandler(unittest.TestCase):
     @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
     @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
     @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_get_status_available(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+        mock_retrieve_manifest.return_value = self.mock_full_manifest
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+
+        # list_tags reads ".tags"; image.status reads ".status"/".status_category".
+        def fallback(command: Mock, key: str, _type: type, default: str) -> str:
+            if key.endswith(".tags"):
+                return (
+                    '[{"tag": "v2", "pushed_at": "", "digest": ""}, {"tag": "latest", "pushed_at": "", "digest": ""}]'
+                )
+            if key.endswith(".status"):
+                return "Available"
+            if key.endswith(".status_category"):
+                return "healthy"
+            return default
+
+        mock_cmd_runner_fns["get_result_value_with_fallback"].side_effect = fallback
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ImageHandler(display_manager=NullDisplay())
+        result = handler.get_status("jupyterlab")
+
+        self.assertEqual(result.name, "jupyterlab")
+        self.assertEqual(result.status, "Available")
+        self.assertEqual(result.status_category, "healthy")
+        self.assertEqual(result.latest_tag, "v2")  # 'latest' excluded
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
+    def test_get_status_missing(
+        self,
+        mock_cmd_runner_class: Mock,
+        mock_tf_variables_handler: Mock,
+        mock_tf_outputs_handler: Mock,
+        mock_retrieve_manifest: Mock,
+    ) -> None:
+        mock_tf_outputs_handler.return_value = self.get_mock_outputs_handler_and_fns()[0]
+        mock_tf_variables_handler.return_value = Mock()
+        mock_retrieve_manifest.return_value = self.mock_full_manifest
+
+        mock_cmd_runner, mock_cmd_runner_fns = self.get_mock_manifest_cmd_runner_and_fns()
+        mock_cmd_runner_fns["get_result_value_with_fallback"].return_value = "[]"
+
+        # list_tags succeeds (empty), then image.status raises ImageTagNotFoundError.
+        mock_cmd_runner_fns["run_command_sequence"].side_effect = [None, ImageTagNotFoundError("repo", "v1")]
+        mock_cmd_runner_class.return_value = mock_cmd_runner
+
+        handler = ImageHandler(display_manager=NullDisplay())
+        result = handler.get_status("jupyterlab")
+
+        self.assertEqual(result.status, "Missing")
+        self.assertEqual(result.status_category, "degraded")
+
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("jupyter_deploy.engine.terraform.tf_outputs.TerraformOutputsHandler")
+    @patch("jupyter_deploy.engine.terraform.tf_variables.TerraformVariablesHandler")
+    @patch("jupyter_deploy.provider.manifest_command_runner.ManifestCommandRunner")
     def test_list_tags_runs_command(
         self,
         mock_cmd_runner_class: Mock,
@@ -357,3 +425,9 @@ class TestImageHandler(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             handler.list_tags("jupyterlab")
+
+        with self.assertRaises(RuntimeError):
+            handler.get_vulnerabilities("jupyterlab")
+
+        with self.assertRaises(RuntimeError):
+            handler.get_status("jupyterlab")

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_resource_utils.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_resource_utils.py
@@ -2,8 +2,18 @@ import json
 import unittest
 from unittest.mock import Mock
 
-from jupyter_deploy.handlers.resource.resource_utils import collect_results, evaluate_status_rules, resolve_path
-from jupyter_deploy.manifest import JupyterDeployStatusRuleMatchV1, JupyterDeployStatusRuleV1
+from jupyter_deploy.handlers.resource.resource_utils import (
+    collect_results,
+    evaluate_status_rules,
+    render_display_field,
+    resolve_node,
+    resolve_path,
+)
+from jupyter_deploy.manifest import (
+    JupyterDeployDisplayFieldV1,
+    JupyterDeployStatusRuleMatchV1,
+    JupyterDeployStatusRuleV1,
+)
 
 
 class TestResolvePath(unittest.TestCase):
@@ -28,6 +38,74 @@ class TestResolvePath(unittest.TestCase):
 
     def test_non_dict_root(self) -> None:
         self.assertIsNone(resolve_path({"status": "a string"}, ".status.field"))
+
+    def test_map_key_lookup_with_dotted_key(self) -> None:
+        resource = {"metadata": {"labels": {"workspace.jupyter.org/default-template": "true"}}}
+        self.assertEqual(resolve_path(resource, ".metadata.labels[workspace.jupyter.org/default-template]"), "true")
+
+    def test_map_key_lookup_missing_key(self) -> None:
+        resource = {"metadata": {"labels": {"other": "x"}}}
+        self.assertIsNone(resolve_path(resource, ".metadata.labels[workspace.jupyter.org/default-template]"))
+
+    def test_map_key_lookup_missing_container(self) -> None:
+        self.assertIsNone(resolve_path({"metadata": {}}, ".metadata.labels[some.key]"))
+
+
+class TestResolveNode(unittest.TestCase):
+    def test_list_index(self) -> None:
+        resource = {"spec": {"versions": [{"name": "v1alpha1"}, {"name": "v1beta1"}]}}
+        self.assertEqual(resolve_node(resource, ".spec.versions[0].name"), "v1alpha1")
+        self.assertEqual(resolve_node(resource, ".spec.versions[1].name"), "v1beta1")
+
+    def test_list_index_out_of_range(self) -> None:
+        resource = {"spec": {"versions": [{"name": "v1alpha1"}]}}
+        self.assertIsNone(resolve_node(resource, ".spec.versions[5].name"))
+
+    def test_returns_raw_list(self) -> None:
+        resource = {"spec": {"items": [1, 2, 3]}}
+        self.assertEqual(resolve_node(resource, ".spec.items"), [1, 2, 3])
+
+
+class TestRenderDisplayField(unittest.TestCase):
+    def test_path_field_with_label(self) -> None:
+        resource = json.dumps({"metadata": {"namespace": "shared"}})
+        field = JupyterDeployDisplayFieldV1(label="namespace", path=".metadata.namespace")
+        self.assertEqual(render_display_field(resource, field), "namespace: shared")
+
+    def test_count_field(self) -> None:
+        resource = json.dumps({"spec": {"accessResourceTemplates": [{"a": 1}, {"b": 2}]}})
+        field = JupyterDeployDisplayFieldV1(label="access-resources", count=".spec.accessResourceTemplates")
+        self.assertEqual(render_display_field(resource, field), "access-resources: 2")
+
+    def test_join_field(self) -> None:
+        resource = json.dumps({"spec": {"group": "workspace.jupyter.org", "versions": [{"name": "v1alpha1"}]}})
+        field = JupyterDeployDisplayFieldV1(label="apiVersion", join=[".spec.group", ".spec.versions[0].name"])
+        self.assertEqual(render_display_field(resource, field), "apiVersion: workspace.jupyter.org/v1alpha1")
+
+    def test_labeled_absent_field_renders_label_with_dash(self) -> None:
+        # A missing or typo'd path keeps the label so the cell stays self-documenting.
+        resource = json.dumps({"spec": {}})
+        field = JupyterDeployDisplayFieldV1(label="app-type", path=".spec.appType")
+        self.assertEqual(render_display_field(resource, field), "app-type: -")
+
+    def test_labeled_absent_count_renders_label_with_dash(self) -> None:
+        resource = json.dumps({"spec": {}})
+        field = JupyterDeployDisplayFieldV1(label="access-resources", count=".spec.absentList")
+        self.assertEqual(render_display_field(resource, field), "access-resources: -")
+
+    def test_unlabeled_absent_field_returns_empty(self) -> None:
+        resource = json.dumps({"spec": {}})
+        field = JupyterDeployDisplayFieldV1(path=".spec.appType")
+        self.assertEqual(render_display_field(resource, field), "")
+
+    def test_unparseable_json_returns_empty(self) -> None:
+        field = JupyterDeployDisplayFieldV1(label="x", path=".a")
+        self.assertEqual(render_display_field("not-json", field), "")
+
+    def test_field_without_label(self) -> None:
+        resource = json.dumps({"metadata": {"namespace": "shared"}})
+        field = JupyterDeployDisplayFieldV1(path=".metadata.namespace")
+        self.assertEqual(render_display_field(resource, field), "shared")
 
 
 class TestEvaluateStatusRules(unittest.TestCase):

--- a/libs/jupyter-deploy/tests/unit/handlers/test_health_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_health_handler.py
@@ -3,7 +3,13 @@ from unittest.mock import Mock, patch
 
 from jupyter_deploy.enum import StatusCategory
 from jupyter_deploy.handlers.health_handler import HealthHandler
-from jupyter_deploy.handlers.payloads import HealthLayer, HealthLayerResult
+from jupyter_deploy.handlers.payloads import (
+    HealthLayer,
+    HealthLayerResult,
+    ImageStatusResult,
+    ImageVulnerabilitiesResult,
+    ImageVulnerability,
+)
 from jupyter_deploy.handlers.project.open_handler import OpenHealthResult
 
 
@@ -12,6 +18,7 @@ def _make_handler(
     has_components: bool = True,
     has_lb: bool = True,
     has_open: bool = True,
+    has_images: bool = True,
 ) -> tuple[HealthHandler, Mock, Mock, Mock, Mock]:
     with patch.object(HealthHandler, "__init__", lambda self, **kwargs: None):
         handler = HealthHandler.__new__(HealthHandler)
@@ -19,16 +26,22 @@ def _make_handler(
     mock_cluster_handler: Mock = Mock()
     mock_component_handler: Mock = Mock()
     mock_open_handler: Mock = Mock()
+    mock_image_handler: Mock = Mock()
 
     handler.display_manager = Mock()
     handler.project_manifest = mock_manifest  # type: ignore[assignment]
     handler._cluster_handler = mock_cluster_handler if has_cluster else None  # type: ignore[assignment]
     handler._component_handler = mock_component_handler if has_components else None  # type: ignore[assignment]
+    handler._image_handler = mock_image_handler if has_images else None  # type: ignore[assignment]
     handler._open_handler = mock_open_handler if has_open else None  # type: ignore[assignment]
     mock_manifest.has_command.side_effect = lambda cmd: cmd == "cluster.loadbalancer.health" and has_lb
     mock_manifest.health = None
 
     return handler, mock_manifest, mock_cluster_handler, mock_component_handler, mock_open_handler
+
+
+def _image_handler_of(handler: HealthHandler) -> Mock:
+    return handler._image_handler  # type: ignore[return-value]
 
 
 class TestHealthHandlerCheckCluster(unittest.TestCase):
@@ -80,6 +93,135 @@ class TestHealthHandlerCheckComponents(unittest.TestCase):
         self.assertEqual(results[0].status_category, StatusCategory.HEALTHY)
         self.assertEqual(results[1].name, "dex")
         self.assertEqual(results[1].status_category, StatusCategory.DEGRADED)
+
+
+def _vuln(severity: str, epss: float | None) -> ImageVulnerability:
+    return ImageVulnerability(
+        cve="CVE-X",
+        type="OS",
+        package="pkg",
+        severity=severity,
+        installed_version="1",
+        fixed_version="2",
+        score=7.0,
+        epss_score=epss,
+    )
+
+
+def _vulns_result(
+    vulns: list[ImageVulnerability], last_scanned: str = "2026-06-18T00:00:00+00:00"
+) -> ImageVulnerabilitiesResult:
+    return ImageVulnerabilitiesResult(
+        name="jupyterlab",
+        tag="v2",
+        last_scanned=last_scanned,
+        scanner_type="Inspector Enhanced",
+        critical_count=sum(1 for v in vulns if v.severity == "CRITICAL"),
+        high_count=sum(1 for v in vulns if v.severity == "HIGH"),
+        vulnerabilities=vulns,
+    )
+
+
+class TestHealthHandlerCheckImages(unittest.TestCase):
+    def test_images_skipped_when_no_handler(self) -> None:
+        handler, _, _, _, _ = _make_handler(has_images=False)
+
+        results = handler._check_images()
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].skipped)
+
+    def test_image_available_and_clean(self) -> None:
+        handler, manifest, _, _, _ = _make_handler()
+        manifest.get_images.return_value = {"jupyterlab": Mock()}
+        img = _image_handler_of(handler)
+        img.get_status.return_value = ImageStatusResult(
+            name="jupyterlab", status="Available", status_category="healthy", latest_tag="v2"
+        )
+        img.get_vulnerabilities.return_value = _vulns_result([])
+
+        results = handler._check_images()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status_text, "Available")
+        self.assertEqual(results[0].status_category, StatusCategory.HEALTHY)
+        self.assertEqual(results[0].detail, "v2")
+        self.assertEqual(results[0].sub_component, "")
+
+    def test_image_counts_only_qualifying_cves(self) -> None:
+        handler, manifest, _, _, _ = _make_handler()
+        manifest.get_images.return_value = {"jupyterlab": Mock()}
+        img = _image_handler_of(handler)
+        img.get_status.return_value = ImageStatusResult(
+            name="jupyterlab", status="Available", status_category="healthy", latest_tag="v2"
+        )
+        img.get_vulnerabilities.return_value = _vulns_result(
+            [
+                _vuln("CRITICAL", 0.5),  # qualifies
+                _vuln("HIGH", 0.02),  # below threshold, excluded
+                _vuln("HIGH", None),  # EPSS unavailable -> qualifies
+            ]
+        )
+
+        results = handler._check_images()
+
+        # 1 critical (0.5) + 1 high (None) qualify; the 0.02 high is excluded.
+        self.assertEqual(results[0].sub_component, "1 critical, 1 high")
+        self.assertEqual(results[0].status_category, StatusCategory.HEALTHY)  # CVEs never downgrade
+
+    def test_image_missing(self) -> None:
+        handler, manifest, _, _, _ = _make_handler()
+        manifest.get_images.return_value = {"jupyterlab": Mock()}
+        img = _image_handler_of(handler)
+        img.get_status.return_value = ImageStatusResult(
+            name="jupyterlab", status="Missing", status_category="degraded", latest_tag=""
+        )
+
+        results = handler._check_images()
+
+        self.assertEqual(results[0].status_text, "Missing")
+        self.assertEqual(results[0].status_category, StatusCategory.DEGRADED)
+        img.get_vulnerabilities.assert_not_called()
+
+    def test_image_scan_unavailable(self) -> None:
+        handler, manifest, _, _, _ = _make_handler()
+        manifest.get_images.return_value = {"jupyterlab": Mock()}
+        img = _image_handler_of(handler)
+        img.get_status.return_value = ImageStatusResult(
+            name="jupyterlab", status="Available", status_category="healthy", latest_tag="v2"
+        )
+        img.get_vulnerabilities.return_value = _vulns_result([], last_scanned="")
+
+        results = handler._check_images()
+
+        self.assertEqual(results[0].sub_component, "scan n/a")
+
+    def test_image_error_does_not_fail_check(self) -> None:
+        handler, manifest, _, _, _ = _make_handler()
+        manifest.get_images.return_value = {"jupyterlab": Mock()}
+        img = _image_handler_of(handler)
+        img.get_status.side_effect = RuntimeError("boom")
+
+        results = handler._check_images()
+
+        self.assertEqual(results[0].status_category, StatusCategory.DEGRADED)
+        self.assertEqual(results[0].status_text, "error")
+
+    def test_vulnerability_fetch_error_surfaces_in_sub_component(self) -> None:
+        handler, manifest, _, _, _ = _make_handler()
+        manifest.get_images.return_value = {"jupyterlab": Mock()}
+        img = _image_handler_of(handler)
+        img.get_status.return_value = ImageStatusResult(
+            name="jupyterlab", status="Available", status_category="healthy", latest_tag="v2"
+        )
+        img.get_vulnerabilities.side_effect = RuntimeError("access denied")
+
+        results = handler._check_images()
+
+        # A failed vuln fetch surfaces in the sub-component, but the image stays available/healthy.
+        self.assertEqual(results[0].status_text, "Available")
+        self.assertEqual(results[0].status_category, StatusCategory.HEALTHY)
+        self.assertEqual(results[0].sub_component, "scan error: access denied")
 
 
 class TestHealthHandlerCheckLoadBalancer(unittest.TestCase):

--- a/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
+++ b/libs/jupyter-deploy/tests/unit/mock_manifest.yaml
@@ -620,6 +620,23 @@ commands:
       - result-name: image.show.scan_status
         source: result
         source-key: '[1].ScanStatus'
+  - cmd: image.status
+    sequence:
+      - api-name: aws.ecr.describe-image
+        arguments:
+          - api-attribute: repository_name
+            source: cli
+            source-key: repository_name
+          - api-attribute: image_tag
+            source: cli
+            source-key: image_tag
+    results:
+      - result-name: image.status.status
+        source: result
+        source-key: '[0].Status'
+      - result-name: image.status.status_category
+        source: result
+        source-key: '[0].StatusCategory'
   - cmd: image.tags
     sequence:
       - api-name: aws.ecr.list-image-tags

--- a/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ecr_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_ecr_runner.py
@@ -3,8 +3,10 @@ import unittest
 from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
+import botocore.exceptions
+
 from jupyter_deploy.engine.supervised_execution import NullDisplay
-from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.exceptions import ImageTagNotFoundError, InstructionNotFoundError
 from jupyter_deploy.provider.aws.aws_ecr_runner import AwsEcrRunner
 from jupyter_deploy.provider.resolved_argdefs import ResolvedInstructionArgument, StrResolvedInstructionArgument
 
@@ -62,6 +64,63 @@ class TestDescribeRepository(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             runner._describe_repository(resolved_arguments=resolved_args)
+
+
+class TestDescribeImage(unittest.TestCase):
+    def _resolved_args(self) -> dict[str, ResolvedInstructionArgument]:
+        return {
+            "repository_name": StrResolvedInstructionArgument(
+                argument_name="repository_name", value="my-app/jupyterlab"
+            ),
+            "image_tag": StrResolvedInstructionArgument(argument_name="image_tag", value="v1"),
+        }
+
+    @patch("jupyter_deploy.api.aws.ecr.ecr_repository.describe_image")
+    def test_emits_available_on_success(self, mock_describe: Mock) -> None:
+        runner = AwsEcrRunner(NullDisplay(), region_name="us-west-2")
+        mock_describe.return_value = {"imageTags": ["v1"]}
+
+        result = runner._describe_image(resolved_arguments=self._resolved_args())
+
+        mock_describe.assert_called_once_with(runner.client, repository_name="my-app/jupyterlab", image_tag="v1")
+        self.assertEqual(result["Status"].value, "Available")
+        self.assertEqual(result["StatusCategory"].value, "healthy")
+
+    def test_raises_image_tag_not_found_when_image_missing(self) -> None:
+        runner = AwsEcrRunner(NullDisplay(), region_name="us-west-2")
+
+        class FakeImageNotFound(Exception):
+            pass
+
+        runner.client = Mock()
+        runner.client.exceptions.ImageNotFoundException = FakeImageNotFound
+
+        with (
+            patch("jupyter_deploy.api.aws.ecr.ecr_repository.describe_image", side_effect=FakeImageNotFound()),
+            self.assertRaises(ImageTagNotFoundError),
+        ):
+            runner._describe_image(resolved_arguments=self._resolved_args())
+
+    def test_other_errors_bubble_up(self) -> None:
+        runner = AwsEcrRunner(NullDisplay(), region_name="us-west-2")
+
+        class FakeImageNotFound(Exception):
+            pass
+
+        # Only ImageNotFoundException is translated; any other error (e.g. permission denied)
+        # propagates unchanged rather than being mistaken for a missing tag.
+        runner.client = Mock()
+        runner.client.exceptions.ImageNotFoundException = FakeImageNotFound
+
+        access_denied = botocore.exceptions.ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "not authorized"}},
+            "DescribeImages",
+        )
+        with (
+            patch("jupyter_deploy.api.aws.ecr.ecr_repository.describe_image", side_effect=access_denied),
+            self.assertRaises(botocore.exceptions.ClientError),
+        ):
+            runner._describe_image(resolved_arguments=self._resolved_args())
 
 
 class TestListImageTags(unittest.TestCase):
@@ -145,3 +204,16 @@ class TestExecuteInstruction(unittest.TestCase):
 
         runner.execute_instruction("list-image-tags", resolved_args)
         mock_list.assert_called_once()
+
+    @patch("jupyter_deploy.api.aws.ecr.ecr_repository.describe_image")
+    def test_routes_describe_image(self, mock_describe: Mock) -> None:
+        runner = AwsEcrRunner(NullDisplay(), region_name="us-west-2")
+        mock_describe.return_value = {"imageTags": ["v1"]}
+
+        resolved_args: dict[str, ResolvedInstructionArgument] = {
+            "repository_name": StrResolvedInstructionArgument(argument_name="repository_name", value="repo"),
+            "image_tag": StrResolvedInstructionArgument(argument_name="image_tag", value="v1"),
+        }
+
+        runner.execute_instruction("describe-image", resolved_args)
+        mock_describe.assert_called_once()

--- a/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_inspector_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/aws/test_aws_inspector_runner.py
@@ -69,6 +69,7 @@ class TestListVulnerabilitiesInspector(unittest.TestCase):
                 "title": "CVE-2026-1234 - openssl vulnerability",
                 "severity": "CRITICAL",
                 "inspectorScore": 9.8,
+                "epss": {"score": 0.42},
                 "lastObservedAt": datetime(2026, 6, 18, 16, 0, 0, tzinfo=UTC),
                 "packageVulnerabilityDetails": {
                     "vulnerablePackages": [
@@ -107,6 +108,9 @@ class TestListVulnerabilitiesInspector(unittest.TestCase):
         self.assertEqual(vulns[1]["cve"], "CVE-2026-5678")
         self.assertEqual(vulns[1]["type"], "NODE")
         self.assertEqual(vulns[1]["score"], 7.3)
+        # EPSS is plumbed when present and None when the finding omits it.
+        self.assertEqual(vulns[0]["epss_score"], 0.42)
+        self.assertIsNone(vulns[1]["epss_score"])
         self.assertEqual(result["CriticalCount"].value, "1")
         self.assertEqual(result["HighCount"].value, "1")
         self.assertEqual(result["ScannerType"].value, "Inspector Enhanced")
@@ -150,6 +154,7 @@ class TestListVulnerabilitiesEcrBasicFallback(unittest.TestCase):
         self.assertEqual(vulns[0]["cve"], "CVE-2026-9999")
         self.assertEqual(vulns[0]["package"], "glibc")
         self.assertEqual(vulns[0]["score"], 7.5)
+        self.assertIsNone(vulns[0]["epss_score"])  # ECR basic has no EPSS.
         self.assertEqual(result["ScannerType"].value, "ECR Basic")
         self.assertEqual(result["LastScanned"].value, "2026-06-18T15:49:33+00:00")
 

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_custom_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_custom_runner.py
@@ -2,6 +2,8 @@ import json
 import unittest
 from unittest.mock import Mock, patch
 
+from kubernetes.client.exceptions import ApiException
+
 from jupyter_deploy.api.k8s.custom import CustomObjectResult, CustomResourceRef
 from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.exceptions import InstructionNotFoundError
@@ -65,6 +67,30 @@ class TestK8sCustomRunner(unittest.TestCase):
         )
 
     @patch("jupyter_deploy.provider.k8s.k8s_custom_runner.k8s_custom")
+    def test_get_cluster_returns_resource(self, mock_k8s_custom: Mock) -> None:
+        runner = self._make_runner()
+        crd_ref = CustomResourceRef(group="apiextensions.k8s.io", version="v1", plural="customresourcedefinitions")
+        resource = {"metadata": {"name": "workspaces.workspace.jupyter.org"}}
+        mock_k8s_custom.get_cluster.return_value = CustomObjectResult(
+            name="workspaces.workspace.jupyter.org", resource=resource
+        )
+
+        args: dict[str, ResolvedInstructionArgument] = {
+            "group": StrResolvedInstructionArgument(argument_name="group", value=crd_ref.group),
+            "version": StrResolvedInstructionArgument(argument_name="version", value=crd_ref.version),
+            "plural": StrResolvedInstructionArgument(argument_name="plural", value=crd_ref.plural),
+            "name": StrResolvedInstructionArgument(argument_name="name", value="workspaces.workspace.jupyter.org"),
+        }
+
+        result = runner.execute_instruction(instruction_name="get-cluster", resolved_arguments=args)
+
+        self.assertEqual(result["Name"].value, "workspaces.workspace.jupyter.org")
+        self.assertEqual(json.loads(result["Resource"].value), resource)
+        mock_k8s_custom.get_cluster.assert_called_once_with(
+            runner.custom_api, ref=crd_ref, name="workspaces.workspace.jupyter.org"
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_custom_runner.k8s_custom")
     def test_patch_parses_body_json(self, mock_k8s_custom: Mock) -> None:
         runner = self._make_runner()
         patch_body = {"spec": {"replicas": 2}}
@@ -103,3 +129,35 @@ class TestK8sCustomRunner(unittest.TestCase):
 
         with self.assertRaises(InstructionNotFoundError):
             runner.execute_instruction(instruction_name="unknown", resolved_arguments={})
+
+    @patch("jupyter_deploy.provider.k8s.k8s_custom_runner.k8s_custom")
+    def test_get_bubbles_up_api_exception(self, mock_k8s_custom: Mock) -> None:
+        # The runner does not catch K8s API errors; translation happens at the API-runner level,
+        # so the raw ApiException must propagate unchanged.
+        runner = self._make_runner()
+        mock_k8s_custom.get_namespaced.side_effect = ApiException(status=403, reason="Forbidden")
+
+        args = _crd_args()
+        args["name"] = StrResolvedInstructionArgument(argument_name="name", value="ws-1")
+
+        with self.assertRaises(ApiException):
+            runner.execute_instruction(instruction_name="get", resolved_arguments=args)
+
+    @patch("jupyter_deploy.provider.k8s.k8s_custom_runner.k8s_custom")
+    def test_get_cluster_bubbles_up_api_exception(self, mock_k8s_custom: Mock) -> None:
+        runner = self._make_runner()
+        mock_k8s_custom.get_cluster.side_effect = ApiException(status=404, reason="Not Found")
+
+        args = _crd_args(scope="")
+        args["name"] = StrResolvedInstructionArgument(argument_name="name", value="workspaces.workspace.jupyter.org")
+
+        with self.assertRaises(ApiException):
+            runner.execute_instruction(instruction_name="get-cluster", resolved_arguments=args)
+
+    @patch("jupyter_deploy.provider.k8s.k8s_custom_runner.k8s_custom")
+    def test_list_bubbles_up_api_exception(self, mock_k8s_custom: Mock) -> None:
+        runner = self._make_runner()
+        mock_k8s_custom.list_namespaced.side_effect = ApiException(status=401, reason="Unauthorized")
+
+        with self.assertRaises(ApiException):
+            runner.execute_instruction(instruction_name="list", resolved_arguments=_crd_args())

--- a/libs/jupyter-deploy/tests/unit/test_manifest.py
+++ b/libs/jupyter-deploy/tests/unit/test_manifest.py
@@ -273,6 +273,72 @@ class TestJupyterDeployManifestV1Components(unittest.TestCase):
         self.assertEqual(ctx.exception.component_name, "unknown")
         self.assertIn("traefik", ctx.exception.valid_components)
 
+    def test_parses_custom_resource_fields_and_aliases(self) -> None:
+        manifest = self._make_manifest(
+            components={
+                "oauth-access-strategy": {
+                    "type": "CustomResourceWithoutStatus",
+                    "type-display": "WorkspaceAccessStrategy",
+                    "scope": "workspace_shared_namespace",
+                    "resource-name": "oauth-access-strategy",
+                    "crd-group": "workspace.jupyter.org",
+                    "crd-version": "v1alpha1",
+                    "crd-plural": "workspaceaccessstrategies",
+                    "details": {"path": ".metadata.namespace"},
+                    "sub-component": {"label": "access-resources", "count": ".spec.accessResourceTemplates"},
+                    "verbs": {"status": {"method": "k8s.custom.get"}},
+                },
+            }
+        )
+        component = manifest.get_component("oauth-access-strategy")
+
+        self.assertEqual(component.type, "CustomResourceWithoutStatus")
+        self.assertEqual(component.type_display, "WorkspaceAccessStrategy")
+        self.assertEqual(component.resource_name, "oauth-access-strategy")
+        self.assertEqual(component.crd_group, "workspace.jupyter.org")
+        self.assertEqual(component.crd_version, "v1alpha1")
+        self.assertEqual(component.crd_plural, "workspaceaccessstrategies")
+        assert component.details is not None
+        self.assertEqual(component.details.path, ".metadata.namespace")
+        assert component.sub_component is not None
+        self.assertEqual(component.sub_component.label, "access-resources")
+        self.assertEqual(component.sub_component.count, ".spec.accessResourceTemplates")
+
+    def test_parses_cluster_scoped_component_without_scope(self) -> None:
+        manifest = self._make_manifest(
+            components={
+                "workspace-crd": {
+                    "type": "CustomResourceDefinition",
+                    "resource-name": "workspaces.workspace.jupyter.org",
+                    "details": {"label": "apiVersion", "join": [".spec.group", ".spec.versions[0].name"]},
+                    "verbs": {"status": {"method": "k8s.custom.get-cluster"}},
+                },
+            }
+        )
+        component = manifest.get_component("workspace-crd")
+
+        # Cluster-scoped components declare no namespace; scope defaults to None.
+        self.assertIsNone(component.scope)
+        assert component.details is not None
+        self.assertEqual(component.details.join, [".spec.group", ".spec.versions[0].name"])
+
+    def test_optional_fields_default_to_none(self) -> None:
+        manifest = self._make_manifest(
+            components={
+                "traefik": {
+                    "type": "Deployment",
+                    "scope": "router_namespace",
+                    "verbs": {"status": {"method": "k8s.apps.get-deployment-status"}},
+                },
+            }
+        )
+        component = manifest.get_component("traefik")
+
+        self.assertIsNone(component.type_display)
+        self.assertIsNone(component.crd_group)
+        self.assertIsNone(component.details)
+        self.assertIsNone(component.sub_component)
+
     def test_get_components_raises_when_none(self) -> None:
         manifest = self._make_manifest()
 


### PR DESCRIPTION
This PR closes several fast-follows from the release of `eks-oidc:0.1.0`: a/ surface application images to `jd health` (w/ vulnerability digest), b/ surface the 3 CRDs as components, c/ surface default access strategy and template as components, d/ surface Exploit Prediction Scoring System "EPSS" in `jd image vulnerabilities`.

Closes: #275

Partially addresses: #272 (not addressing tolerate mechanism)

### User experience
- `jd health` shows CRD, helm chart's access strategy and default template, images (w/ vulnerability digest)
- `jd health --images` shows only image info
- `jd image status` shows image availability in ECR
- `jd component list` shows detailed type for CustomResource as declared in the manifest
- `jd image vulnerabilities` shows EPSS score (when available)

### Implementation
- add ECR describe handling in `<jd>/api/aws/ecr`
- add custom resources (namespaced and cluster-wide) handling in `<jd>/api/k8s`
- add CRD resource handling in `<jd>/api/k8s`
- wire up aws and k8s providers in `<jd>/providers`
- add manifest fields to parametrize custom resource components (field to retrieve, labels, etc)
- update `ImageHandler`, `HealthHandler` and `ComponentHandler` in `<jd>/handlers/resource`
- update CLI handling in `health_app`, `component_app` and `image_app` in `<jd>/cli`
- declare CRD, access strategy, default template as `components:` in the `eks-oidc` template manifest
- declare command handling for `eks-oidc`

### Testing
- added E2E tests, tested against live cluster
- added `eks-oidc` unit tests for consistency of CRD, manifest declaration

### Screenshots
**jd health**
<img width="869" height="353" alt="Screenshot 2026-06-24 at 4 17 24 PM" src="https://github.com/user-attachments/assets/3c78bbc2-cfbb-48ab-83cc-c005aa13f411" />

**jd health --image**
<img width="544" height="101" alt="Screenshot 2026-06-24 at 4 17 50 PM" src="https://github.com/user-attachments/assets/9ff6c5f4-600e-4027-b3fb-17f65478313d" />

**jd component list**
<img width="708" height="252" alt="Screenshot 2026-06-24 at 4 18 33 PM" src="https://github.com/user-attachments/assets/28377308-0d01-49e1-b199-5c96ca2c8a7a" />

**jd component status --name workspace-crd**
<img width="485" height="32" alt="Screenshot 2026-06-24 at 4 20 26 PM" src="https://github.com/user-attachments/assets/352bffeb-1398-49f6-b772-8f094197a55d" />

**jd image status**
<img width="411" height="32" alt="Screenshot 2026-06-24 at 4 18 57 PM" src="https://github.com/user-attachments/assets/e264c255-be64-4d74-af40-dbee9cebfa58" />

**jd image vulnerabilities**
<img width="750" height="368" alt="Screenshot 2026-06-24 at 4 19 26 PM" src="https://github.com/user-attachments/assets/6eb8214e-b096-4357-8417-8f8b463fe23d" />


