### PR TITLE
fix: persist project to store even on up failure

### DIFF
--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -26,9 +26,18 @@ from jupyter_deploy.cli.teams_app import teams_app
 from jupyter_deploy.cli.users_app import users_app
 from jupyter_deploy.cli.variables_decorator import with_project_variables
 from jupyter_deploy.engine.enum import EngineType
+from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.vardefs import TemplateVariableDefinition
 from jupyter_deploy.enum import StoreType
-from jupyter_deploy.exceptions import LogCleanupError, OpenWebBrowserError, UrlNotAvailableError
+from jupyter_deploy.exceptions import (
+    LocalStateNotPersistedError,
+    LogCleanupError,
+    OpenWebBrowserError,
+    ProjectIdNotAvailableError,
+    ProjectStoreAccessConfigurationError,
+    ProjectStoreNotFoundError,
+    UrlNotAvailableError,
+)
 from jupyter_deploy.handlers.init_handler import InitHandler
 from jupyter_deploy.handlers.project import config_handler
 from jupyter_deploy.handlers.project.down_handler import DownHandler
@@ -472,6 +481,16 @@ def config(
                 console.print(":bulb: To apply the changes, run: [bold cyan]jd up[/]")
 
 
+def _push_to_store(console: Console, display_manager: DisplayManager, handler: UpHandler, verbose: bool) -> None:
+    """Push the project to the remote store, with verbose/spinner display."""
+    if verbose:
+        console.print("Saving configuration to the remote store")
+        handler.push_to_store()
+    else:
+        with display_manager.spinner("Saving configuration to the remote store..."):
+            handler.push_to_store()
+
+
 @runner.app.command()
 def up(
     project_dir: Annotated[
@@ -516,12 +535,47 @@ def up(
         if verbose:
             console.rule("[bold]jupyter-deploy:[/] applying infrastructure changes")
         completion_context = None
+        local_state_error: LocalStateNotPersistedError | None = None
         with display_manager:
             try:
                 completion_context = handler.apply(config_file_path, auto_approve)
             except LogCleanupError as e:
                 # Log cleanup failed, but main operation succeeded - warn and continue
                 console.print(f":warning: log clean up failed: {e}", style="yellow")
+            except LocalStateNotPersistedError as e:
+                # The apply failed before the remote backend was configured, so the
+                # engine state (and any resources it tracks) is still local.
+                #
+                # We only stash the error here and handle it AFTER the `with` block:
+                # ProgressDisplayManager runs a Rich `Live` for the duration of this
+                # block, and the rescue push below calls `_push_to_store()`, which (in
+                # non-verbose mode) opens a `console.status` spinner — itself a `Live`.
+                # Rich allows only one active `Live` at a time, so pushing here would
+                # raise `LiveError`. Deferring until the block exits also mirrors the
+                # success path, which calls `_push_to_store()` after this same block.
+                local_state_error = e
+
+        if local_state_error is not None:
+            # Reached only when apply failed with the state still local (see above).
+            # Push regardless to migrate the local state to the remote backend and
+            # upload the project snapshot, so the partial deployment is recoverable.
+            # Warn (don't fail) on store-resolution problems, then re-raise the
+            # original apply error so the exit code and UX are unchanged.
+            console.line()
+            try:
+                _push_to_store(console, display_manager, handler, verbose)
+                console.print(
+                    ":white_check_mark: Saved partial deployment to the remote store; "
+                    "recover it with [bold cyan]jd init --restore-project[/].",
+                    style="green",
+                )
+            except (ProjectIdNotAvailableError, ProjectStoreNotFoundError, ProjectStoreAccessConfigurationError) as e:
+                console.print(
+                    f":warning: Could not save the partial deployment to the remote store: {e}",
+                    style="yellow",
+                )
+            # Surface the genuine apply failure now that the rescue push is done.
+            raise local_state_error.original_error
 
         # Display completion summary if available
         # Verbose mode prints everything, so no need to add a summary
@@ -533,12 +587,7 @@ def up(
                 print(line)
             console.line()
 
-        if verbose:
-            console.print("Saving configuration to the remote store")
-            handler.push_to_store()
-        else:
-            with display_manager.spinner("Saving configuration to the remote store..."):
-                handler.push_to_store()
+        _push_to_store(console, display_manager, handler, verbose)
 
         console.print("Infrastructure changes applied successfully.", style="green")
         console.line()

--- a/libs/jupyter-deploy/jupyter_deploy/exceptions.py
+++ b/libs/jupyter-deploy/jupyter_deploy/exceptions.py
@@ -211,6 +211,29 @@ class SupervisedExecutionError(JupyterDeployError, Exception):
         super().__init__(message)
 
 
+class LocalStateNotPersistedError(SupervisedExecutionError):
+    """Raised when a supervised apply fails while the engine state is still local.
+
+    The remote backend is configured only after a successful first apply, so a failure
+    before that leaves the state on local disk only. On an ephemeral runner (CI,
+    sandbox) that state — and any cloud resources it tracks — is lost when the process
+    exits. The caller is expected to catch this, push the project to the store (which
+    migrates the local state to the remote backend), then re-raise `original_error`.
+
+    This is a control-flow signal carrying the underlying apply failure: the caller
+    surfaces `original_error` (the genuine error) once the rescue push is done.
+    Subclassing SupervisedExecutionError is defense-in-depth — if a caller forgets to
+    unwrap, the original command and exit code are still available for a graceful exit.
+
+    Attributes:
+        original_error: The underlying apply failure to surface after the rescue push.
+    """
+
+    def __init__(self, original_error: SupervisedExecutionError) -> None:
+        self.original_error = original_error
+        super().__init__(original_error.command, original_error.retcode, str(original_error))
+
+
 # ============================================================================
 # Instruction execution errors
 # ============================================================================

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/project/up_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/project/up_handler.py
@@ -9,7 +9,11 @@ from jupyter_deploy.engine.terraform import tf_up
 from jupyter_deploy.engine.terraform.tf_constants import TF_ENGINE_DIR
 from jupyter_deploy.engine.terraform.tf_outputs import TerraformOutputsHandler
 from jupyter_deploy.engine.terraform.tf_store_access import TerraformStoreAccessManager
-from jupyter_deploy.exceptions import ProjectIdNotAvailableError
+from jupyter_deploy.exceptions import (
+    LocalStateNotPersistedError,
+    ProjectIdNotAvailableError,
+    SupervisedExecutionError,
+)
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler, write_store_config
 from jupyter_deploy.provider.store.store_manager_factory import StoreManagerFactory
 
@@ -72,8 +76,24 @@ class UpHandler(BaseProjectHandler):
 
         Returns:
             CompletionContext with completion summary, or None if not available.
+
+        Raises:
+            LocalStateNotPersistedError: If the apply fails while the engine state is
+                still local (no remote backend configured yet). The caller MUST push
+                to the store to migrate the local state, then let the error propagate.
+            SupervisedExecutionError: If the apply fails with the state already on the
+                remote backend (nothing to rescue).
         """
-        return self._handler.apply(config_file_path, auto_approve)
+        try:
+            return self._handler.apply(config_file_path, auto_approve)
+        except SupervisedExecutionError as e:
+            # If the remote backend is already configured, the state is safe on the
+            # remote store and there is nothing to rescue — let the error propagate.
+            if self._store_access_manager.is_configured():
+                raise
+            # State is still local: signal the caller to persist it before exiting.
+            # The signal carries the original error so the caller can re-raise it.
+            raise LocalStateNotPersistedError(e) from e
 
     def push_to_store(self) -> None:
         """Push the project to the remote store.

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_up.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_up.py
@@ -8,7 +8,12 @@ from typer.testing import CliRunner
 
 from jupyter_deploy.cli.app import runner as app_runner
 from jupyter_deploy.cli.simple_display import SimpleDisplayManager
-from jupyter_deploy.exceptions import LogCleanupError
+from jupyter_deploy.exceptions import (
+    LocalStateNotPersistedError,
+    LogCleanupError,
+    ProjectIdNotAvailableError,
+    SupervisedExecutionError,
+)
 
 
 class TestUpCommand(unittest.TestCase):
@@ -200,3 +205,45 @@ class TestUpCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(call_order, ["apply", "push_to_store"])
+
+    @patch("jupyter_deploy.cli.app.UpHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_up_pushes_to_store_when_local_state_not_persisted(
+        self, mock_project_ctx_manager: Mock, mock_up_handler_cls: Mock
+    ) -> None:
+        mock_project_ctx_manager.side_effect = TestUpCommand.mock_project_dir
+
+        mock_up_handler_instance, mock_up_fns = self.get_mock_up_handler(config_file_exists=True)
+        mock_up_handler_cls.return_value = mock_up_handler_instance
+        original_error = SupervisedExecutionError("up", 7, "terraform apply failed")
+        mock_up_fns["apply"].side_effect = LocalStateNotPersistedError(original_error)
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["up"])
+
+        # The genuine apply failure must surface with its original exit code (7, not
+        # a generic 1), confirming the CLI re-raises original_error, not the signal...
+        self.assertEqual(result.exit_code, 7)
+        # ...but push_to_store must run anyway to migrate local state + project files.
+        mock_up_fns["push_to_store"].assert_called_once()
+
+    @patch("jupyter_deploy.cli.app.UpHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_up_apply_failure_surfaces_even_if_rescue_push_fails(
+        self, mock_project_ctx_manager: Mock, mock_up_handler_cls: Mock
+    ) -> None:
+        mock_project_ctx_manager.side_effect = TestUpCommand.mock_project_dir
+
+        mock_up_handler_instance, mock_up_fns = self.get_mock_up_handler(config_file_exists=True)
+        mock_up_handler_cls.return_value = mock_up_handler_instance
+        original_error = SupervisedExecutionError("up", 5, "terraform apply failed")
+        mock_up_fns["apply"].side_effect = LocalStateNotPersistedError(original_error)
+        # The deployment_id may be unresolvable on an early failure; the rescue push
+        # warns and the original apply error still surfaces with its exit code.
+        mock_up_fns["push_to_store"].side_effect = ProjectIdNotAvailableError("deployment_id not available")
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["up"])
+
+        self.assertEqual(result.exit_code, 5)
+        mock_up_fns["push_to_store"].assert_called_once()

--- a/libs/jupyter-deploy/tests/unit/handlers/project/test_up_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/project/test_up_handler.py
@@ -6,9 +6,11 @@ from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
 from jupyter_deploy.engine.supervised_execution import NullDisplay
 from jupyter_deploy.enum import StoreType
 from jupyter_deploy.exceptions import (
+    LocalStateNotPersistedError,
     ProjectIdNotAvailableError,
     ProjectStoreAccessConfigurationError,
     ProjectStoreNotFoundError,
+    SupervisedExecutionError,
 )
 from jupyter_deploy.handlers.project.up_handler import UpHandler
 from jupyter_deploy.manifest import JupyterDeployManifestV1, JupyterDeployProjectStoreV1
@@ -115,6 +117,62 @@ class TestUpHandler(unittest.TestCase):
 
         self.assertEqual(str(context.exception), "Apply failed")
         mock_tf_handler.apply.assert_called_once()
+
+    @patch("jupyter_deploy.engine.terraform.tf_up.TerraformUpHandler")
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("pathlib.Path.cwd")
+    def test_apply_raises_local_state_error_when_backend_not_configured(
+        self, mock_cwd: Mock, mock_retrieve_manifest: Mock, mock_tf_handler_cls: Mock
+    ) -> None:
+        path = Path("/mock/path")
+        mock_cwd.return_value = Path("/mock/cwd")
+        mock_retrieve_manifest.return_value = self.mock_manifest
+        mock_tf_handler = Mock()
+        apply_error = SupervisedExecutionError("up", 3, "terraform apply failed")
+        mock_tf_handler.apply.side_effect = apply_error
+        mock_tf_handler.engine_dir_path = Path("/mock/cwd/engine")
+        mock_tf_handler_cls.return_value = mock_tf_handler
+
+        handler = UpHandler(display_manager=NullDisplay())
+        handler._store_access_manager = Mock()
+        # State is still local — the remote backend was never configured.
+        handler._store_access_manager.is_configured.return_value = False
+
+        with self.assertRaises(LocalStateNotPersistedError) as context:
+            handler.apply(path)
+
+        # The signal carries the genuine apply failure for the caller to re-raise.
+        self.assertIs(context.exception.original_error, apply_error)
+        # The original command and exit code are preserved as defense-in-depth.
+        self.assertEqual(context.exception.command, "up")
+        self.assertEqual(context.exception.retcode, 3)
+
+    @patch("jupyter_deploy.engine.terraform.tf_up.TerraformUpHandler")
+    @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+    @patch("pathlib.Path.cwd")
+    def test_apply_reraises_plain_error_when_backend_already_configured(
+        self, mock_cwd: Mock, mock_retrieve_manifest: Mock, mock_tf_handler_cls: Mock
+    ) -> None:
+        path = Path("/mock/path")
+        mock_cwd.return_value = Path("/mock/cwd")
+        mock_retrieve_manifest.return_value = self.mock_manifest
+        mock_tf_handler = Mock()
+        apply_error = SupervisedExecutionError("up", 1, "terraform apply failed")
+        mock_tf_handler.apply.side_effect = apply_error
+        mock_tf_handler.engine_dir_path = Path("/mock/cwd/engine")
+        mock_tf_handler_cls.return_value = mock_tf_handler
+
+        handler = UpHandler(display_manager=NullDisplay())
+        handler._store_access_manager = Mock()
+        # State already lives on the remote backend — nothing to rescue.
+        handler._store_access_manager.is_configured.return_value = True
+
+        with self.assertRaises(SupervisedExecutionError) as context:
+            handler.apply(path)
+
+        # The original error propagates unchanged, NOT a LocalStateNotPersistedError.
+        self.assertIs(context.exception, apply_error)
+        self.assertNotIsInstance(context.exception, LocalStateNotPersistedError)
 
     @patch("jupyter_deploy.engine.terraform.tf_up.TerraformUpHandler")
     @patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")


### PR DESCRIPTION
This PR fixes the `jd up` logic to record the state to the remote store even if `jd up` fails. That way, if the deployment fails in an ephemeral sandbox (e.g. a GitHub job or a lambda function), the terraform state is not lost, no cloud resources are orphaned and the project can be restored later using the standard mechanism.

Closes: #284 

### Implementation
- raise a special `LocalStateNotPersistedError` in `UpHandler` if a/ `apply` fails and b/ the backend store is NOT configured
- catch that error in `<jd>/cli/app:up()`, persist local state to store in that case

### Testing
- forced fail `jd up` using an IAM role w/ missing permission, verified that `jd` saved the state to the remote store
- deleted the local dir
- restored the project from the store
- switched role and deployed