### PR TITLE
feat: turn on inspector2 ecr scanning with ci template

### DIFF
--- a/libs/jupyter-infra-tf-aws-iam-ci/README.md
+++ b/libs/jupyter-infra-tf-aws-iam-ci/README.md
@@ -59,6 +59,11 @@ This operation removes all the resources associated with this project in your AW
 jd down
 ```
 
+> **Note:** This template enables Amazon Inspector enhanced ECR scanning, which is an
+> account-wide setting. Running `jd down` disables Inspector ECR scanning for the **entire
+> account**, not just this deployment's repositories. This is intended for the single-purpose
+> CI account — do not deploy this template into a shared account.
+
 ## Details
 This project:
 - creates an IAM OIDC provider for GitHub Actions (`token.actions.githubusercontent.com`)
@@ -78,6 +83,7 @@ This project:
 - applies resource-based deny policies on bot account secrets (deny all except maintainers)
 - creates 5 ECR repositories for pre-built E2E test container images (one per OAuth app, KMS-encrypted, lifecycle policy keeps last 5 images)
 - creates an S3 bucket for E2E test result uploads (KMS-encrypted, public access blocked, 90-day object expiration)
+- enables Amazon Inspector enhanced scanning for ECR account-wide (so `jd image vulnerabilities` reports OS + language-package CVEs and EPSS scores)
 - tags all resources with `Source`, `Template`, `Version`, and `DeploymentId`
 
 ## Requirements
@@ -113,6 +119,7 @@ This project:
 | [null_resource](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [aws_ecr_repository](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
 | [aws_ecr_lifecycle_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) | resource |
+| [aws_inspector2_enabler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_enabler) | resource |
 | [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
@@ -132,6 +139,7 @@ This project:
 | iam_managed_policies_e2e | `list(string)` | `["AdministratorAccess"]` | AWS managed policy names to attach to the E2E role |
 | iam_managed_policies_release | `list(string)` | `["AdministratorAccess"]` | AWS managed policy names to attach to the release role |
 | maintainer_roles | `list(string)` | `["Admin"]` | IAM role names that may manage all secrets |
+| create_oidc_provider | `bool` | `true` | Whether to create the GitHub Actions OIDC provider (account-wide singleton) |
 | github_bot_account_email | `string` | Required | Email address of the GitHub bot account (stored in SSM Parameter Store) |
 | github_bot_account_password | `string` | Required (sensitive) | Password for the GitHub bot account |
 | github_bot_account_recovery_codes | `string` | Required (sensitive) | Recovery codes for the GitHub bot account |

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/AGENT.md.template
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/AGENT.md.template
@@ -11,9 +11,14 @@ Only one can exist for `token.actions.githubusercontent.com`. If another deploym
 in this account already created it, set `create_oidc_provider` to `false` to
 reference the existing one via data source instead.
 
+**IMPORTANT:** This template enables Amazon Inspector enhanced scanning for ECR, which
+is an account-wide setting. The CI account is single-purpose, so this is always on; running
+`jd down` disables it for the whole account.
+
 ### Resources managed
 
 - **OIDC provider** — GitHub Actions federation (conditional)
+- **Inspector2 enabler** — account-wide enhanced ECR scanning (conditional)
 - **IAM roles** — E2E and release roles with OIDC trust policies
 - **Secrets Manager** — auth state, bot account credentials, OAuth client secrets
 - **SSM parameters** — OAuth app client IDs (non-sensitive)

--- a/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/inspector.tf
+++ b/libs/jupyter-infra-tf-aws-iam-ci/jupyter_infra_tf_aws_iam_ci/template/engine/inspector.tf
@@ -1,0 +1,9 @@
+# Amazon Inspector2 enhanced scanning for ECR — account-wide.
+# The CI account is single-purpose, so enabling Inspector here does not conflict
+# with other deployments. This lets `jd image vulnerabilities` exercise the
+# Inspector code path (OS + language-package CVEs, EPSS, continuous re-scan)
+# in E2E tests rather than falling back to ECR basic scanning.
+resource "aws_inspector2_enabler" "ecr" {
+  account_ids    = [data.aws_caller_identity.current.account_id]
+  resource_types = ["ECR"]
+}


### PR DESCRIPTION
This PR configures the CI template to activate inspector2 scanner account-wide for ECR images. Refer to [documentation](https://docs.aws.amazon.com/inspector/latest/user/activate-scans.html).

Closes: #268 

### Testing
- restored CI template in CI account, port the change, apply