### PR TITLE
fix: network probe flakiness

### DIFF
--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/network_probe.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/workspaces/network_probe.py
@@ -15,18 +15,32 @@ CNI addon must set enableNetworkPolicy=true) — otherwise every probe is allowe
 import json
 import subprocess
 import time
+import uuid
 
 # Operator-generated Service name for a workspace: "workspace-<name>-service".
 _WORKSPACE_SERVICE_FMT = "workspace-{name}-service"
 _CURL_IMAGE = "curlimages/curl:latest"
 # curl exit 28 == operation timeout → the connection was blocked (denied).
 _CURL_TIMEOUT_EXIT = 28
+# Default prefix for probe-pod names; a unique suffix is always appended.
+_DEFAULT_POD_PREFIX = "netpol-probe"
 
 
 def workspace_service_host(workspace_name: str, namespace: str = "default") -> str:
     """Return the in-cluster DNS host for a workspace's Service."""
     service = _WORKSPACE_SERVICE_FMT.format(name=workspace_name)
     return f"{service}.{namespace}.svc.cluster.local"
+
+
+def _unique_pod_name(prefix: str) -> str:
+    """Build a collision-free probe-pod name from prefix plus a random suffix.
+
+    Probe pods are deleted with --wait=false, so a pod from an earlier test can
+    still be terminating when a later test runs. Reusing a fixed name then fails
+    the create with 'AlreadyExists: object is being deleted'. A random suffix per
+    probe guarantees a fresh name every time, so creates never collide.
+    """
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
 
 
 def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
@@ -53,7 +67,7 @@ def probe_service(
     from_namespace: str,
     pod_labels: dict[str, str] | None = None,
     connect_timeout_s: int = 8,
-    pod_name: str = "netpol-probe",
+    pod_name_prefix: str = _DEFAULT_POD_PREFIX,
 ) -> bool:
     """Attempt to reach an in-cluster host:port from a pod in from_namespace.
 
@@ -61,6 +75,10 @@ def probe_service(
     probe a policy's podSelector), connects to http://host:port/, then reads the
     container's terminated exit code (not kubectl's, which is unreliable for
     run --rm). The pod is always deleted on the way out.
+
+    Each probe runs under a freshly-generated unique pod name (pod_name_prefix
+    plus a random suffix), so a still-terminating pod from a prior probe never
+    collides with this create.
 
     Returns:
         True if the connection was allowed (curl reached the endpoint),
@@ -72,6 +90,7 @@ def probe_service(
             not be silently read as "denied".
     """
     url = f"http://{host}:{port}/"
+    pod_name = _unique_pod_name(pod_name_prefix)
 
     overrides: dict = {"spec": {"restartPolicy": "Never"}}
     if pod_labels:
@@ -129,7 +148,7 @@ def probe_service_allowed(
     pod_labels: dict[str, str] | None = None,
     attempts: int = 5,
     connect_timeout_s: int = 8,
-    pod_name: str = "netpol-probe",
+    pod_name_prefix: str = _DEFAULT_POD_PREFIX,
 ) -> bool:
     """Probe repeatedly, returning True as soon as one probe is allowed.
 
@@ -142,14 +161,14 @@ def probe_service_allowed(
     # spuriously time out before the allow rule is in place (it fails closed). This
     # retry converges on the steady-state answer for ALLOW assertions; default-deny
     # is immediate and stable, so deny assertions should use probe_service directly.
-    for attempt in range(attempts):
+    for _ in range(attempts):
         if probe_service(
             host,
             port,
             from_namespace=from_namespace,
             pod_labels=pod_labels,
             connect_timeout_s=connect_timeout_s,
-            pod_name=f"{pod_name}-{attempt}",
+            pod_name_prefix=pod_name_prefix,
         ):
             return True
     return False
@@ -163,7 +182,7 @@ def probe_workspace(
     port: int = 8888,
     pod_labels: dict[str, str] | None = None,
     connect_timeout_s: int = 8,
-    pod_name: str = "netpol-probe",
+    pod_name_prefix: str = _DEFAULT_POD_PREFIX,
 ) -> bool:
     """Attempt to reach a workspace Service from a pod in from_namespace.
 
@@ -176,7 +195,7 @@ def probe_workspace(
         from_namespace=from_namespace,
         pod_labels=pod_labels,
         connect_timeout_s=connect_timeout_s,
-        pod_name=pod_name,
+        pod_name_prefix=pod_name_prefix,
     )
 
 

--- a/libs/pytest-jupyter-deploy/tests/test_network_probe.py
+++ b/libs/pytest-jupyter-deploy/tests/test_network_probe.py
@@ -1,0 +1,97 @@
+"""Unit tests for the network_probe helper's pod-naming and probe flow."""
+
+import subprocess
+from unittest.mock import patch
+
+from pytest_jupyter_deploy.workspaces import network_probe
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_unique_pod_name_is_prefixed_and_distinct() -> None:
+    """Each generated name keeps the prefix but gets a distinct random suffix."""
+    names = {network_probe._unique_pod_name("netpol-probe") for _ in range(100)}
+    assert len(names) == 100
+    for name in names:
+        assert name.startswith("netpol-probe-")
+        assert name != "netpol-probe"
+
+
+def test_probe_service_runs_pod_under_unique_name() -> None:
+    """probe_service creates and deletes a pod whose name is prefix + random suffix."""
+    create = _completed(returncode=0)
+    with (
+        patch.object(network_probe, "_run", return_value=create) as run_mock,
+        patch.object(network_probe, "_wait_for_terminated_exit_code", return_value=0) as wait_mock,
+        patch.object(network_probe, "delete_probe_pod") as delete_mock,
+    ):
+        allowed = network_probe.probe_service("svc.host", 8888, from_namespace="ns")
+
+    assert allowed is True
+    run_cmd = run_mock.call_args.args[0]
+    pod_name = run_cmd[run_cmd.index("run") + 1]
+    assert pod_name.startswith("netpol-probe-")
+    assert pod_name != "netpol-probe"
+    # The same unique name is waited on and cleaned up.
+    wait_mock.assert_called_once()
+    assert wait_mock.call_args.args[0] == pod_name
+    delete_mock.assert_called_once_with(pod_name, "ns")
+
+
+def test_probe_service_uses_custom_prefix() -> None:
+    """A caller-supplied prefix is honored, with a unique suffix still appended."""
+    with (
+        patch.object(network_probe, "_run", return_value=_completed(returncode=0)) as run_mock,
+        patch.object(network_probe, "_wait_for_terminated_exit_code", return_value=0),
+        patch.object(network_probe, "delete_probe_pod"),
+    ):
+        network_probe.probe_service("svc.host", 8888, from_namespace="ns", pod_name_prefix="custom")
+
+    run_cmd = run_mock.call_args.args[0]
+    pod_name = run_cmd[run_cmd.index("run") + 1]
+    assert pod_name.startswith("custom-")
+
+
+def test_probe_service_generates_fresh_name_each_call() -> None:
+    """Two sequential probes never reuse a pod name, even with the same prefix."""
+    seen: list[str] = []
+
+    def capture(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if "run" in cmd:
+            seen.append(cmd[cmd.index("run") + 1])
+        return _completed(returncode=0)
+
+    with (
+        patch.object(network_probe, "_run", side_effect=capture),
+        patch.object(network_probe, "_wait_for_terminated_exit_code", return_value=0),
+        patch.object(network_probe, "delete_probe_pod"),
+    ):
+        network_probe.probe_service("svc.host", 8888, from_namespace="ns")
+        network_probe.probe_service("svc.host", 8888, from_namespace="ns")
+
+    assert len(seen) == 2
+    assert seen[0] != seen[1]
+
+
+def test_probe_service_allowed_retries_with_distinct_names() -> None:
+    """Each retry attempt probes under a fresh, distinct pod name."""
+    seen: list[str] = []
+
+    def capture(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+        if "run" in cmd:
+            seen.append(cmd[cmd.index("run") + 1])
+        return _completed(returncode=0)
+
+    # Force every probe to read as denied (curl timeout exit 28) so all attempts run.
+    with (
+        patch.object(network_probe, "_run", side_effect=capture),
+        patch.object(network_probe, "_wait_for_terminated_exit_code", return_value=network_probe._CURL_TIMEOUT_EXIT),
+        patch.object(network_probe, "delete_probe_pod"),
+    ):
+        allowed = network_probe.probe_service_allowed("svc.host", 8888, from_namespace="ns", attempts=3)
+
+    assert allowed is False
+    assert len(seen) == 3
+    assert len(set(seen)) == 3


### PR DESCRIPTION
This PR addresses flakiness in the network policy end-to-end tests by hardening the plugin utilities to use different pod names.

Closes: #290 

### Testing
- ran the routing network E2E tests 5 times in a row
- ran the workspace E2E tests