### PR TITLE
fix: eks-oidc template dependency graph

### DIFF
--- a/.github/AGENT.md
+++ b/.github/AGENT.md
@@ -55,6 +55,23 @@ deploys the published package). The ~30-min deploy is readable in its own job; t
 `test_deployment` verify then runs separately against the now-existing project. The job's
 `timeout-minutes` bounds the deploy.
 
+## Release ordering & gotchas
+
+Lessons from coordinated plugin/CLI/template releases — read before releasing:
+
+- **Release order for coupled changes: plugin → CLI → templates.** A template's
+  `manifest.yaml` can require CLI features (e.g. new component/health command schema);
+  the eks-oidc release gate installs the CLI *unpinned from prod PyPI*, so the CLI must
+  be published **first** or the gate's deploy fails at `jd config` with a manifest schema
+  error. There's no min-CLI-version check — the coupling is implicit.
+- **The CLI gate's `eks-functional-test` needs a live app #5 deployment.** Don't tear
+  app #5 down before a CLI release, or that job fails at restore. (App #5 is redeployed
+  by the eks-oidc gate, so there's a chicken-and-egg between the two gates — deploy app #5
+  before releasing the CLI.)
+- **Test PyPI re-publish is a safe no-op.** `uv publish --check-url` skips identical
+  files, so re-running a release gate from the same commit does NOT burn the version —
+  as long as the built artifact is byte-identical (don't change the package between runs).
+
 ## Testing Workflow Changes
 
 To iterate on E2E workflow changes, create a temporary push-triggered workflow:

--- a/AGENT.md
+++ b/AGENT.md
@@ -82,6 +82,7 @@ Code: `./libs/jupyter-deploy-tf-aws-eks-oidc`
 
 All `local-exec` provisioners MUST set `interpreter = ["/bin/bash", "-c"]` — Terraform defaults to `/bin/sh`.
 With `bootstrap_cluster_creator_admin_permissions = false`, the caller's IAM role MUST be listed in `admin_role_names` to retain cluster access. A `check` block validates this at plan time.
+Destroy order is load-bearing and enforced via `depends_on` (see `eks_addons.tf`/`iam_role`/`vpc` comments): VPC+roles → DaemonSet addons (CNI/kube-proxy) → node groups → Deployment addons (coredns/ebs-csi/…) → Helm releases → workspaces, so the operator stays alive through Helm uninstalls.
 
 ## CI infrastructure template package
 Code: `./libs/jupyter-infra-tf-aws-iam-ci`
@@ -259,5 +260,9 @@ Refer to `docs/AGENT.md`
 Refer to `diagrams/AGENT.md`
 
 ## Making changes in the GitHub CI
+
+Refer to `.github/AGENT.md`.
+
+## Handling releases to PyPI
 
 Refer to `.github/AGENT.md`

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/__init__.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/__init__.py
@@ -1,3 +1,3 @@
 """AWS EKS OIDC Terraform template for deploying JupyterLab workspaces on Kubernetes."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/github-rbac/Chart.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/github-rbac/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: github-rbac
 description: GitHub team RBAC for jupyter-k8s workspaces
-version: 0.1.1
+version: 0.1.2
 type: application

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/Chart.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: workspace-defaults
-version: 0.1.1
+version: 0.1.2
 description: Default workspace resources (access strategy, workspace template)
 type: application

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/eks_addons.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/eks_addons.tf
@@ -3,6 +3,46 @@ resource "time_sleep" "wait_for_nodes" {
   depends_on      = [module.eks_cluster]
 }
 
+# --- Addon ordering aggregators ---
+#
+# These two null_resources are single-source-of-truth barriers that let node
+# groups and Helm releases order themselves against the addons WITHOUT each one
+# re-deriving (and eventually getting wrong) the per-resource addon matrix.
+# No addon depends on a node group or a Helm release, so these introduce no cycle.
+
+# DaemonSet addons a node needs to be functional: vpc-cni (pod IPs) and kube-proxy
+# (Service/ClusterIP routing). The node group depends_on this, so on create the
+# CNI is in place before nodes join, and on destroy the nodes drain BEFORE these
+# are removed. Only DaemonSets belong here: they report healthy with zero nodes,
+# so requiring them before the node group never deadlocks. Deployment addons
+# (coredns, ebs-csi, ...) must NOT be here — they need a schedulable node, so
+# gating the node group on them would be a create-time cycle.
+resource "null_resource" "core_node_addons" {
+  depends_on = [
+    aws_eks_addon.vpc_cni,
+    aws_eks_addon.kube_proxy,
+  ]
+}
+
+# Every cluster addon. The Helm releases (helm.tf) depend_on this, so on create
+# all addons are up before any chart installs, and on destroy every chart
+# uninstalls BEFORE any addon is removed — i.e. the addons a chart relies on
+# (ebs-csi for PVC/PV teardown, coredns for in-cluster DNS, cert-manager,
+# external-dns, ...) stay alive for the entire uninstall. Add a new addon here
+# once and all charts inherit the ordering. external_dns is count-gated; the
+# splat reference resolves to an empty list when disabled.
+resource "null_resource" "cluster_addons" {
+  depends_on = [
+    aws_eks_addon.vpc_cni,
+    aws_eks_addon.kube_proxy,
+    aws_eks_addon.coredns,
+    aws_eks_addon.pod_identity_agent,
+    aws_eks_addon.ebs_csi_driver,
+    aws_eks_addon.cert_manager,
+    aws_eks_addon.external_dns,
+  ]
+}
+
 resource "aws_eks_addon" "vpc_cni" {
   cluster_name = module.eks_cluster.cluster_name
   addon_name   = "vpc-cni"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/helm.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/helm.tf
@@ -56,7 +56,7 @@ resource "helm_release" "traefik_crds" {
   # alive until every release has finished uninstalling. Without it the node groups
   # and helm uninstalls tear down concurrently; the operator dies mid-uninstall and
   # CR finalizers never clear → "context deadline exceeded" (run 28182357633).
-  depends_on = [aws_eks_addon.cert_manager, aws_eks_access_policy_association.admin_role, aws_eks_access_policy_association.admin_user, module.node_group]
+  depends_on = [null_resource.cluster_addons, aws_eks_access_policy_association.admin_role, aws_eks_access_policy_association.admin_user, module.node_group]
 }
 
 resource "helm_release" "jupyter_k8s" {
@@ -85,7 +85,7 @@ resource "helm_release" "jupyter_k8s" {
     },
   ]
 
-  depends_on = [aws_eks_addon.cert_manager, helm_release.traefik_crds, kubernetes_namespace_v1.shared, module.node_group]
+  depends_on = [null_resource.cluster_addons, helm_release.traefik_crds, kubernetes_namespace_v1.shared, module.node_group]
 }
 
 resource "helm_release" "workspace_router" {
@@ -204,5 +204,5 @@ resource "helm_release" "workspace_router" {
     },
   ]
 
-  depends_on = [module.node_group, helm_release.jupyter_k8s, aws_eks_addon.cert_manager, helm_release.traefik_crds, null_resource.wait_for_lb_cleanup, kubernetes_namespace_v1.shared]
+  depends_on = [module.node_group, helm_release.jupyter_k8s, null_resource.cluster_addons, helm_release.traefik_crds, null_resource.wait_for_lb_cleanup, kubernetes_namespace_v1.shared]
 }

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/main.tf
@@ -63,7 +63,7 @@ resource "random_id" "postfix" {
 
 locals {
   template_name    = "tf-aws-eks-oidc"
-  template_version = "0.1.1"
+  template_version = "0.1.2"
 
   default_tags = {
     Source       = "jupyter-deploy"
@@ -221,6 +221,15 @@ module "node_group" {
   max_size        = tonumber(each.value.max_size)
   desired_size    = tonumber(each.value.desired_size)
   combined_tags   = local.combined_tags
+
+  # The node-role policy attachments and VPC routing are already ordered via the
+  # references above (node_role.role_arn and vpc.private_subnet_ids, whose outputs
+  # depend_on their attachments/route tables). The DaemonSet addons are NOT in
+  # that closure — vpc-cni and kube-proxy only reference the cluster, so they are
+  # siblings of the node group and otherwise drain in the first destroy wave,
+  # killing pod networking on still-running nodes. Gate on core_node_addons so the
+  # nodes come up after, and tear down before, those addons (see eks_addons.tf).
+  depends_on = [null_resource.core_node_addons]
 }
 
 module "oauth_secret" {

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/main.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/main.tf
@@ -4,6 +4,17 @@ resource "aws_iam_role" "this" {
   tags               = var.combined_tags
 }
 
+# Each attachment references aws_iam_role.this.name, so Terraform always destroys
+# the attachments BEFORE the role itself — which AWS requires (a role cannot be
+# deleted while policies are still attached).
+#
+# Note what this edge does NOT do: it does not order the attachments relative to
+# whatever CONSUMES this role (e.g. an EKS node group built on node_role). A
+# consumer that only references the `role_arn` output depends on the role, not on
+# these attachments — they are siblings, unordered against each other. On destroy
+# Terraform is then free to remove an attachment while the consumer is still live,
+# stripping (for the node role) the worker/CNI permissions out from under running
+# nodes. The `role_arn` output below closes that gap.
 resource "aws_iam_role_policy_attachment" "policies" {
   for_each   = { for idx, arn in var.policy_arns : tostring(idx) => arn }
   role       = aws_iam_role.this.name

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/iam_role/outputs.tf
@@ -1,5 +1,14 @@
+# `depends_on` on the output makes every CONSUMER of role_arn transitively depend
+# on the policy attachments, not just on the bare role. This is what guarantees:
+#   - on create: the policies are attached before the consumer (e.g. node group)
+#     comes up, so nodes never boot with missing worker/CNI permissions;
+#   - on destroy: the consumer is torn down before the attachments are removed, so
+#     a node group's CNI/worker policies stay attached until the nodes are gone.
+# Without it, role_arn references only aws_iam_role.this.arn (the role), leaving
+# the attachments unordered against the consumer — see the note in main.tf.
 output "role_arn" {
-  value = aws_iam_role.this.arn
+  value      = aws_iam_role.this.arn
+  depends_on = [aws_iam_role_policy_attachment.policies]
 }
 
 output "role_name" {

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/vpc/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/modules/vpc/outputs.tf
@@ -6,10 +6,40 @@ output "igw_id" {
   value = aws_internet_gateway.this.id
 }
 
+# The subnet IDs are the only networking outputs a consumer (EKS cluster, node
+# group) references — so by default a consumer depends on the subnets but NOT on
+# the route tables, associations, NAT gateways or IGW that make those subnets
+# actually route traffic. Those are siblings with no external reference, so on
+# destroy Terraform is free to remove them in the first wave — tearing down
+# routing out from under still-running nodes, ELBs and pods (e.g. route table
+# associations destroyed while the NLB and node groups are still live).
+#
+# depends_on on the subnet outputs pulls the whole networking set into every
+# consumer's dependency closure:
+#   - on create: routing exists before nodes/ELBs come up;
+#   - on destroy: nodes/cluster/ELBs are torn down before routing is removed.
+# (The IGW also has its own NLB-cleanup ordering via the igw_id output; this is
+# the complementary guarantee for subnet-consuming resources.)
 output "public_subnet_ids" {
   value = aws_subnet.public[*].id
+  depends_on = [
+    aws_route_table_association.public,
+    aws_route_table_association.private,
+    aws_route_table.public,
+    aws_route_table.private,
+    aws_nat_gateway.this,
+    aws_internet_gateway.this,
+  ]
 }
 
 output "private_subnet_ids" {
   value = aws_subnet.private[*].id
+  depends_on = [
+    aws_route_table_association.public,
+    aws_route_table_association.private,
+    aws_route_table.public,
+    aws_route_table.private,
+    aws_nat_gateway.this,
+    aws_internet_gateway.this,
+  ]
 }

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -52,8 +52,9 @@ resource "helm_release" "github_rbac" {
   chart            = "${path.module}/../charts/github-rbac"
   namespace        = var.workspace_shared_namespace
   create_namespace = false
-  # Uninstall can wait on RoleBinding teardown during a slow destroy; give it the
-  # same 600s headroom as the other CR-bearing releases (default is 5 min).
+  # Headroom over the 5-min provider default. No longer strictly necessary now
+  # that destroy_workspaces clears the CRs and the addon/node ordering keeps the
+  # operator alive through uninstall
   timeout = 600
 
   set = concat(
@@ -87,9 +88,10 @@ resource "helm_release" "workspace_defaults" {
   chart            = "${path.module}/../charts/workspace-defaults"
   namespace        = var.workspace_shared_namespace
   create_namespace = false
-  # Ships the jupyterlab WorkspaceTemplate (operator-finalized). Install AND
-  # uninstall wait on the operator reconciling/clearing it; the 5-min provider
-  # default can lag on a slow/contended cluster during a mass destroy.
+  # Ships the jupyterlab WorkspaceTemplate (operator-finalized). Install waits on
+  # the operator reconciling it. Uninstall is ~seconds now that destroy_workspaces
+  # clears the CRs first and the addon/node ordering keeps the operator alive, so
+  # this 600s (vs 5-min default) is no longer strictly necessary.
   timeout = 600
 
   set = concat([

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 template:
   name: tf-aws-eks-oidc
   engine: terraform
-  version: 0.1.1
+  version: 0.1.2
 health:
   active: true
   expected-status-code: 302

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/pyproject.toml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-tf-aws-eks-oidc"
-version = "0.1.1"
+version = "0.1.2"
 description = "OIDC terraform template to deploy JupyterLab workspaces on AWS EKS with GitHub authentication."
 readme = "README.md"
 authors = [

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_home_volume.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_home_volume.py
@@ -17,8 +17,10 @@ def test_home_volume_persists_across_restart(e2e_deployment: EndToEndDeployment,
     """Write a file, stop workspace, restart, verify file still exists."""
     name = e2e_workspace
 
-    # Write a sentinel file to the home volume
-    e2e_deployment.cli.run_command(
+    # Write a sentinel file to the home volume. The seeded workspace is only polled
+    # to "Running" (not exec-readiness), so this first exec can still race with a
+    # container that isn't accepting connections yet — retry on transient errors.
+    e2e_deployment.cli.run_exec_with_retry(
         [
             "jupyter-deploy",
             "server",
@@ -40,11 +42,10 @@ def test_home_volume_persists_across_restart(e2e_deployment: EndToEndDeployment,
     e2e_deployment.cli.poll_scoped_server_status(name, "Running", timeout_s=300)
     e2e_deployment.cli.wait_for_workspace_pod_exec_ready(name)
 
-    # Verify the sentinel file persisted
-    verify_file_exists_on_server(e2e_deployment, f"/home/jovyan/{SENTINEL_FILE}", name=name)
-
-    # Verify content
-    result = e2e_deployment.cli.run_command(
+    # Verify content persisted. Every exec below runs against a container that
+    # just restarted and can still flap ("container not found") even after the
+    # readiness gate above, so route them through run_exec_with_retry.
+    result = e2e_deployment.cli.run_exec_with_retry(
         [
             "jupyter-deploy",
             "server",
@@ -59,7 +60,7 @@ def test_home_volume_persists_across_restart(e2e_deployment: EndToEndDeployment,
     assert "persistence-ok" in result.stdout
 
     # Cleanup
-    e2e_deployment.cli.run_command(
+    e2e_deployment.cli.run_exec_with_retry(
         [
             "jupyter-deploy",
             "server",

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -59,6 +59,58 @@ def test_chart_versions_match_template_version() -> None:
         )
 
 
+def _extract_depends_on_names(block: str, resource_type: str) -> set[str]:
+    """Return the set of `<resource_type>` names referenced in a depends_on list."""
+    match = re.search(r"depends_on\s*=\s*\[(.*?)\]", block, re.DOTALL)
+    assert match is not None, "no depends_on block found"
+    refs = re.findall(rf"{re.escape(resource_type)}\.(\w+)", match.group(1))
+    return set(refs)
+
+
+def _extract_resource_block(content: str, resource_type: str, resource_name: str) -> str:
+    """Return the body of a `resource "<type>" "<name>" {{ ... }}` block."""
+    start = re.search(
+        rf'resource\s+"{re.escape(resource_type)}"\s+"{re.escape(resource_name)}"\s*\{{',
+        content,
+    )
+    assert start is not None, f"resource {resource_type}.{resource_name} not found"
+
+    depth = 1
+    idx = start.end()
+    while idx < len(content) and depth > 0:
+        if content[idx] == "{":
+            depth += 1
+        elif content[idx] == "}":
+            depth -= 1
+        idx += 1
+    return content[start.end() : idx - 1]
+
+
+def test_all_eks_addons_gated_by_cluster_addons() -> None:
+    """Every aws_eks_addon MUST appear in null_resource.cluster_addons.depends_on.
+
+    This is the barrier that keeps all cluster addons alive until every Helm chart
+    has uninstalled (see eks_addons.tf comments). If a new addon is added but not
+    wired into this aggregator, the Helm destroy ordering silently regresses and
+    `jd down` can leave undeletable resources in etcd. Guard against that drift.
+    """
+    addons_tf = TEMPLATE_PATH / "engine" / "eks_addons.tf"
+    content = addons_tf.read_text()
+
+    declared_addons = set(re.findall(r'resource\s+"aws_eks_addon"\s+"(\w+)"', content))
+    assert declared_addons, "no aws_eks_addon resources found in eks_addons.tf"
+
+    cluster_addons_block = _extract_resource_block(content, "null_resource", "cluster_addons")
+    gated_addons = _extract_depends_on_names(cluster_addons_block, "aws_eks_addon")
+
+    missing = declared_addons - gated_addons
+    assert not missing, (
+        f"aws_eks_addon(s) {sorted(missing)} are not listed in "
+        "null_resource.cluster_addons.depends_on — Helm chart destroy ordering will "
+        "silently regress. Add them to the aggregator in eks_addons.tf."
+    )
+
+
 def test_main_tf_version_matches_template_version() -> None:
     manifest_path = TEMPLATE_PATH / "manifest.yaml"
     manifest = yaml.safe_load(manifest_path.read_text())

--- a/libs/pytest-jupyter-deploy/pyproject.toml
+++ b/libs/pytest-jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-jupyter-deploy"
-version = "0.2.6"
+version = "0.2.7"
 description = "Pytest plugin for E2E testing of jupyter-deploy templates"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/cli.py
@@ -1,5 +1,6 @@
 """CLI wrapper for jupyter-deploy commands."""
 
+import logging
 import re
 import subprocess
 import time
@@ -11,6 +12,8 @@ import pexpect
 from jupyter_deploy import cmd_utils as jd_cmd_utils
 from jupyter_deploy import constants as jd_constants
 from jupyter_deploy.handlers.base_project_handler import retrieve_project_manifest
+
+logger = logging.getLogger(__name__)
 
 
 class JDCliError(RuntimeError):
@@ -239,6 +242,58 @@ class JDCli:
                 last_error = e
                 time.sleep(interval_s)
         raise TimeoutError(f"Exec not ready on '{name}' within {timeout_s}s (last error: {last_error})")
+
+    def run_exec_with_retry(
+        self,
+        cmd: list[str],
+        timeout_seconds: int | None = None,
+        capture_output: bool = True,
+        retries: int = 2,
+        interval_s: int = 10,
+    ) -> subprocess.CompletedProcess[str]:
+        """Run a `server exec` command, retrying on transient container-readiness errors.
+
+        `wait_for_workspace_pod_exec_ready` only proves the pod accepted ONE exec;
+        a container can still flap immediately after (e.g. right after a stop/start
+        restart), so a subsequent raw exec races and fails with "container not
+        found" / "unable to upgrade connection". Any exec issued against a
+        workspace that may have just (re)started should go through this wrapper so
+        those transient errors are retried instead of failing the test. Non-transient
+        failures (real command errors) propagate immediately.
+
+        Args:
+            cmd: Command to run (a `jupyter-deploy server exec ...` invocation)
+            timeout_seconds: Per-attempt command timeout
+            capture_output: Whether to capture stdout/stderr
+            retries: Number of retries after the first attempt (so retries+1 attempts total)
+            interval_s: Seconds to wait between attempts
+
+        Returns:
+            CompletedProcess instance from the first successful attempt
+
+        Raises:
+            JDCliError: If the command fails with a non-transient error, or if only
+                transient errors occur across all attempts (the last one is re-raised)
+        """
+        last_error: JDCliError | None = None
+        for attempt in range(retries + 1):
+            try:
+                return self.run_command(cmd, timeout_seconds=timeout_seconds, capture_output=capture_output)
+            except JDCliError as e:
+                if not self._is_transient_exec_error(e):
+                    raise
+                last_error = e
+                if attempt < retries:
+                    logger.warning(
+                        "Transient exec error (attempt %d/%d), retrying in %ds: %s",
+                        attempt + 1,
+                        retries + 1,
+                        interval_s,
+                        e,
+                    )
+                    time.sleep(interval_s)
+        assert last_error is not None
+        raise last_error
 
     @classmethod
     def _is_transient_exec_error(cls, error: JDCliError) -> bool:

--- a/uv.lock
+++ b/uv.lock
@@ -907,7 +907,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-tf-aws-eks-oidc"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "libs/jupyter-deploy-tf-aws-eks-oidc" }
 dependencies = [
     { name = "boto3" },
@@ -1769,7 +1769,7 @@ wheels = [
 
 [[package]]
 name = "pytest-jupyter-deploy"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "libs/pytest-jupyter-deploy" }
 dependencies = [
     { name = "jupyter-deploy" },


### PR DESCRIPTION
This PR fixes the resource dependency graph for the `eks-oidc` template such that `jd down` reliably succeeds.

Also in this PR:
- harden home volume E2E test to retry flaky pod-exec (when container is not fully stable)
- bump eks-oidc template version `0.1.1` > `0.1.2`; needed for stuck [release](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/28474410753)
- bump plugin version `0.2.6` > `0.2.7`

### Implementation
- order resource logically 1) {VPC + IAM roles/policies} > 2) Cluster > 3) daemonset AddOns > 4) Managed Nodes Groups > 5) pod-based AddOns > 6) external helm charts (traefik, operator, router) > 7) template charts (workspace defaults, GH RBAC)
- S3, ECR, CodeBuild and EKS-OIDC kept as leaf resources (created / deleted in parallel)
- add `null_resource` to group 3) and 5)
- make node groups (4) depend on 3)
- make external helm charts (6) depend on 3) & 5) (in addition to 4))
- keep template charts (7) to depend on 7)
- this ensures that workspace defaults get destroyed first, then operator/router, then nodes, then cluster, and finally VPC/IAM resources; previously, some resources in 1) and 7) were sibblings, leading to race condition and un-deletable resources in etcd due to webhook.  
- add retry util in plugin, use in flaky e2e test

### Testing
- redeploy `eks-oidc` template, ran full E2E test suite
- ran home volume E2E test suite 5x in a row
- ran `jd down`, verify that the resources delete in the right order
