### PR TITLE
feat: automated roborev code review

### DIFF
--- a/.github/workflows/roborev-review.yml
+++ b/.github/workflows/roborev-review.yml
@@ -1,0 +1,222 @@
+# Automated roborev PR review.
+#
+# Triggered on pull_request_target so it runs with base-repo credentials even
+# for fork PRs (a plain pull_request workflow gets no OIDC token from a fork).
+# The review fires per PR revision, in parallel with CI, regardless of CI result.
+#
+# SECURITY: pull_request_target runs with repository credentials. This job must
+# never execute code from the PR. It checks out the trusted base branch, fetches
+# the PR head as git objects only, and hands roborev a ref range. The review
+# container holds only the Bedrock creds (mounted, not env), never the GITHUB_TOKEN:
+# roborev prints the review and the runner posts it. The IAM role can only pull the
+# image and invoke Bedrock, and the token can only comment and set statuses, so a
+# prompt-injected review of a malicious diff can at worst spend model tokens and
+# produce a misleading comment.
+#
+# Inert until these repo variables are set (after tf-aws-iam-ci is deployed with
+# create_review_resources = true and the review image is published):
+#   REVIEW_RUN_ROLE_ARN   IAM role ARN (review_run_iam_role_arn output)
+#   REVIEW_IMAGE          ECR image ref, e.g. <repo-url>:latest
+#   REVIEW_BEDROCK_MODEL  Bedrock model / inference-profile ID (e.g. us.anthropic.claude-opus-4-8)
+#   REVIEW_AWS_REGION     optional, defaults to us-west-2
+
+name: roborev review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "PR number to review"
+        required: true
+        type: string
+      smoke:
+        description: "Smoke test only: verify the OIDC to Bedrock chain, skip review"
+        type: boolean
+        default: false
+
+# One review per PR; a new push cancels the in-flight review for that PR.
+concurrency:
+  group: roborev-review-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+  id-token: write
+
+jobs:
+  review:
+    name: roborev review
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: >-
+      github.event.pull_request.draft != true
+      && vars.REVIEW_RUN_ROLE_ARN != ''
+      && vars.REVIEW_IMAGE != ''
+      && vars.REVIEW_BEDROCK_MODEL != ''
+    environment: review
+    steps:
+      # Trusted base branch only. The PR head is fetched as data later, never run.
+      - name: Checkout base
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Resolve PR and head SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_FROM_EVENT: ${{ github.event.pull_request.number }}
+          HEAD_FROM_EVENT: ${{ github.event.pull_request.head.sha }}
+          PR_FROM_INPUT: ${{ inputs.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pr="$PR_FROM_INPUT"
+          else
+            pr="$PR_FROM_EVENT"
+          fi
+
+          # Current head of the PR. The stale-head guard below compares this to the
+          # revision that triggered the run, so superseded revisions are skipped
+          # before any model tokens are spent.
+          current_head=$(gh api "repos/$REPO/pulls/$pr" --jq .head.sha)
+
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$HEAD_FROM_EVENT" != "$current_head" ]; then
+            echo "PR #$pr head moved ($HEAD_FROM_EVENT -> $current_head); skipping superseded revision."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base=$(gh api "repos/$REPO/pulls/$pr" --jq .base.sha)
+          {
+            echo "pr=$pr"
+            echo "head=$current_head"
+            echo "base=$base"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.pr.outputs.skip != 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.REVIEW_RUN_ROLE_ARN }}
+          aws-region: ${{ vars.REVIEW_AWS_REGION || 'us-west-2' }}
+          # Pin the session to 1h: long enough for the 30-min job with margin, short
+          # enough to keep the leaked-credential window small. Keep this above the job
+          # timeout; a longer job means raising both.
+          role-duration-seconds: 3600
+
+      # Keep the AWS creds out of the container env: write the OIDC session creds to
+      # a file the smoke/review containers read via a read-only mount, so the keys
+      # are not passed with -e. The gh token is never given to the container; the
+      # runner posts the review comment itself (see "Run review and post comment").
+      - name: Stage AWS credentials for mounting
+        if: steps.pr.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/aws"
+          {
+            echo "[default]"
+            echo "aws_access_key_id=$AWS_ACCESS_KEY_ID"
+            echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY"
+            echo "aws_session_token=$AWS_SESSION_TOKEN"
+          } > "$RUNNER_TEMP/aws/credentials"
+          # The container runs as uid 1000 (node), a different uid than the runner,
+          # so the mounted file must be readable by others for the container to read.
+          chmod 644 "$RUNNER_TEMP/aws/credentials"
+
+      - name: Pull review image
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          REVIEW_IMAGE: ${{ vars.REVIEW_IMAGE }}
+        run: |
+          set -euo pipefail
+          registry="${REVIEW_IMAGE%%/*}"
+          aws ecr get-login-password --region "${{ vars.REVIEW_AWS_REGION || 'us-west-2' }}" \
+            | docker login --username AWS --password-stdin "$registry"
+          docker pull "$REVIEW_IMAGE"
+
+      - name: Mark review in progress
+        if: steps.pr.outputs.skip != 'true' && !inputs.smoke
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X POST "repos/$REPO/statuses/${{ steps.pr.outputs.head }}" \
+            -f context=roborev/review -f state=pending \
+            -f description="review running" > /dev/null
+
+      - name: Smoke test (Bedrock reachability)
+        if: steps.pr.outputs.skip != 'true' && inputs.smoke
+        env:
+          REVIEW_IMAGE: ${{ vars.REVIEW_IMAGE }}
+        run: |
+          set -euo pipefail
+          out=$(docker run --rm \
+            -v "$RUNNER_TEMP/aws:/home/node/.aws:ro" \
+            -e AWS_REGION -e AWS_DEFAULT_REGION \
+            -e CLAUDE_CODE_USE_BEDROCK=1 \
+            -e ANTHROPIC_MODEL="${{ vars.REVIEW_BEDROCK_MODEL }}" \
+            "$REVIEW_IMAGE" claude -p "Reply with exactly: BEDROCK_OK")
+          echo "model replied: $out"
+          [[ "$out" == *BEDROCK_OK* ]]
+
+      - name: Run review and post comment
+        id: run
+        if: steps.pr.outputs.skip != 'true' && !inputs.smoke
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          REVIEW_IMAGE: ${{ vars.REVIEW_IMAGE }}
+          PR: ${{ steps.pr.outputs.pr }}
+          HEAD_SHA: ${{ steps.pr.outputs.head }}
+          BASE_SHA: ${{ steps.pr.outputs.base }}
+        run: |
+          set -euo pipefail
+          # Fetch the PR head as git objects only. Never checked out, never executed.
+          git fetch --no-tags origin "+${HEAD_SHA}:refs/roborev/head" 2>/dev/null \
+            || git fetch --no-tags origin "pull/${PR}/head:refs/roborev/head"
+          base_sha=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+
+          # The review runs in the container with only the mounted Bedrock creds and
+          # prints the comment to stdout (logs go to stderr). The gh token is never
+          # passed to the container; the runner posts the captured output below, so
+          # the diff-processing context never holds the token.
+          docker run --rm \
+            -v "$RUNNER_TEMP/aws:/home/node/.aws:ro" \
+            -e AWS_REGION -e AWS_DEFAULT_REGION \
+            -e CLAUDE_CODE_USE_BEDROCK=1 \
+            -e ANTHROPIC_MODEL="${{ vars.REVIEW_BEDROCK_MODEL }}" \
+            -v "$PWD:/workspace" -w /workspace \
+            "$REVIEW_IMAGE" \
+            sh -c "git config --global --add safe.directory /workspace \
+              && roborev ci review --ref ${base_sha}..${HEAD_SHA} \
+                   --pr ${PR} --gh-repo ${REPO} \
+                   --min-severity medium --reasoning standard" \
+            > "$RUNNER_TEMP/review.md"
+
+          [ -s "$RUNNER_TEMP/review.md" ] || { echo "review produced no output"; exit 1; }
+          gh pr comment "$PR" --repo "$REPO" --body-file "$RUNNER_TEMP/review.md"
+
+      # Always close out the pending status, even if fetch/review failed or the
+      # run was cancelled, so no PR is left with a dangling "review running".
+      - name: Report status
+        if: always() && steps.pr.outputs.skip != 'true' && !inputs.smoke
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.pr.outputs.head }}
+          OUTCOME: ${{ steps.run.outcome }}
+        run: |
+          set -euo pipefail
+          state=error
+          [ "$OUTCOME" = "success" ] && state=success
+          gh api -X POST "repos/${REPO}/statuses/${HEAD_SHA}" \
+            -f context=roborev/review -f state="$state" \
+            -f description="review $state" > /dev/null

--- a/.github/workflows/roborev-review.yml
+++ b/.github/workflows/roborev-review.yml
@@ -125,9 +125,10 @@ jobs:
         if: steps.pr.outputs.skip != 'true'
         run: |
           set -euo pipefail
-          # Scratch HOME for the container: it runs as the runner's uid (see the
-          # docker run steps), which has no home in the image, and claude-code,
-          # gh, and git all need a writable HOME for their runtime state.
+          # The containers run as the runner's uid (see the docker run steps),
+          # which has no home directory in the image. claude-code, gh, and git
+          # need a writable HOME for their runtime state, so create a directory
+          # to mount at /home/node.
           mkdir -p "$RUNNER_TEMP/aws" "$RUNNER_TEMP/home"
           {
             echo "[default]"

--- a/.github/workflows/roborev-review.yml
+++ b/.github/workflows/roborev-review.yml
@@ -65,6 +65,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
           fetch-depth: 0
+          # The checkout is bind-mounted into the review container, which must
+          # never hold the gh token, so do not persist it into .git/config.
+          # The PR-head fetch later works anonymously (public repo); the
+          # runner's gh calls use the env token.
+          persist-credentials: false
 
       - name: Resolve PR and head SHA
         id: pr
@@ -120,16 +125,18 @@ jobs:
         if: steps.pr.outputs.skip != 'true'
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/aws"
+          # Scratch HOME for the container: it runs as the runner's uid (see the
+          # docker run steps), which has no home in the image, and claude-code,
+          # gh, and git all need a writable HOME for their runtime state.
+          mkdir -p "$RUNNER_TEMP/aws" "$RUNNER_TEMP/home"
           {
             echo "[default]"
             echo "aws_access_key_id=$AWS_ACCESS_KEY_ID"
             echo "aws_secret_access_key=$AWS_SECRET_ACCESS_KEY"
             echo "aws_session_token=$AWS_SESSION_TOKEN"
           } > "$RUNNER_TEMP/aws/credentials"
-          # The container runs as uid 1000 (node), a different uid than the runner,
-          # so the mounted file must be readable by others for the container to read.
-          chmod 644 "$RUNNER_TEMP/aws/credentials"
+          # The containers run as the runner's uid, so owner-only is enough.
+          chmod 600 "$RUNNER_TEMP/aws/credentials"
 
       - name: Pull review image
         if: steps.pr.outputs.skip != 'true'
@@ -159,6 +166,9 @@ jobs:
         run: |
           set -euo pipefail
           out=$(docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/home/node \
+            -v "$RUNNER_TEMP/home:/home/node" \
             -v "$RUNNER_TEMP/aws:/home/node/.aws:ro" \
             -e AWS_REGION -e AWS_DEFAULT_REGION \
             -e CLAUDE_CODE_USE_BEDROCK=1 \
@@ -188,7 +198,16 @@ jobs:
           # prints the comment to stdout (logs go to stderr). The gh token is never
           # passed to the container; the runner posts the captured output below, so
           # the diff-processing context never holds the token.
+          # --user matches the runner's uid so the bind-mounted workspace stays
+          # writable: for diffs over roborev's inline prompt cap it writes a
+          # snapshot file under the repo (.roborev/) and an entry in
+          # .git/info/exclude, which fail with EACCES under the image's default
+          # uid. On failure roborev's stdout holds the failure summary, so print
+          # it instead of leaving it captured and unseen.
           docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e HOME=/home/node \
+            -v "$RUNNER_TEMP/home:/home/node" \
             -v "$RUNNER_TEMP/aws:/home/node/.aws:ro" \
             -e AWS_REGION -e AWS_DEFAULT_REGION \
             -e CLAUDE_CODE_USE_BEDROCK=1 \
@@ -199,7 +218,9 @@ jobs:
               && roborev ci review --ref ${base_sha}..${HEAD_SHA} \
                    --pr ${PR} --gh-repo ${REPO} \
                    --min-severity medium --reasoning standard" \
-            > "$RUNNER_TEMP/review.md"
+            > "$RUNNER_TEMP/review.md" \
+            || { rc=$?; echo "roborev failed (exit $rc); container stdout:"; \
+                 cat "$RUNNER_TEMP/review.md"; exit "$rc"; }
 
           [ -s "$RUNNER_TEMP/review.md" ] || { echo "review produced no output"; exit 1; }
           gh pr comment "$PR" --repo "$REPO" --body-file "$RUNNER_TEMP/review.md"

--- a/.roborev.toml
+++ b/.roborev.toml
@@ -1,0 +1,7 @@
+# roborev review policy for this repo, shared by CI and local reviews.
+# Read by `roborev ci review` in .github/workflows/roborev-review.yml and by
+# the local post-commit hook (`roborev init`). Reference: https://roborev.io/configuration/
+
+[ci]
+agents = ["claude-code"]
+review_types = ["default", "security"]

--- a/AGENT.md
+++ b/AGENT.md
@@ -114,33 +114,7 @@ Always run from the root of the repository:
 
 ## Automated code review
 
-Open PRs are reviewed automatically by [roborev](https://roborev.io)
-in CI (`.github/workflows/roborev-review.yml`): each revision gets one review comment,
-backed by Claude on Bedrock. The review is informational, maintainers still approve and merge.
-
-You can run the same review locally before pushing. Install roborev from
-[roborev.io](https://roborev.io), then:
-
-```bash
-just review        # review the current branch vs main, on demand
-```
-
-`just review` runs `roborev review --branch --local --wait`: no daemon, no background
-process, using whatever coding agent you have installed (claude-code, codex, gemini, ...).
-It shares the policy file [`.roborev.toml`](.roborev.toml) with CI. CI runs the full matrix
-defined there (the `default` and `security` review types); a local run does a single review,
-so push to get the complete CI review.
-
-For a continuous loop where every commit is reviewed automatically (opt-in):
-
-```bash
-just review-setup  # one-time: installs the roborev post-commit hook
-# then, after any commit:
-roborev show HEAD  # see the latest review
-roborev refine     # iterate: review, fix, repeat until clean
-```
-
-Local review is optional; CI reviews every PR regardless.
+Open PRs are reviewed automatically in CI by [roborev](https://roborev.io) (policy in [`.roborev.toml`](.roborev.toml)). Run the same review locally with `just review`; see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## General coding rules
 1. you MUST NOT silence linters without the user's permission

--- a/AGENT.md
+++ b/AGENT.md
@@ -112,6 +112,36 @@ Always run from the root of the repository:
 2. Run unit tests: `just unit-test`
    - Runs `uv run pytest`
 
+## Automated code review
+
+Open PRs are reviewed automatically by [roborev](https://roborev.io)
+in CI (`.github/workflows/roborev-review.yml`): each revision gets one review comment,
+backed by Claude on Bedrock. The review is informational, maintainers still approve and merge.
+
+You can run the same review locally before pushing. Install roborev from
+[roborev.io](https://roborev.io), then:
+
+```bash
+just review        # review the current branch vs main, on demand
+```
+
+`just review` runs `roborev review --branch --local --wait`: no daemon, no background
+process, using whatever coding agent you have installed (claude-code, codex, gemini, ...).
+It shares the policy file [`.roborev.toml`](.roborev.toml) with CI. CI runs the full matrix
+defined there (the `default` and `security` review types); a local run does a single review,
+so push to get the complete CI review.
+
+For a continuous loop where every commit is reviewed automatically (opt-in):
+
+```bash
+just review-setup  # one-time: installs the roborev post-commit hook
+# then, after any commit:
+roborev show HEAD  # see the latest review
+roborev refine     # iterate: review, fix, repeat until clean
+```
+
+Local review is optional; CI reviews every PR regardless.
+
 ## General coding rules
 1. you MUST NOT silence linters without the user's permission
 2. you MUST NOT write docstrings that merely repeat a method name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,34 @@ just lint
 just unit-test
 ```
 
+## Code review
+
+Pull requests are reviewed automatically by [roborev](https://roborev.io), which posts a
+review comment on each revision. You can run the same review locally before pushing to catch
+issues early.
+
+Install roborev from [roborev.io](https://roborev.io), then:
+
+```bash
+just review
+```
+
+This reviews your current branch against `main` using whatever AI coding agent you have
+installed (claude-code, codex, gemini, and others), with no daemon or background process. It
+shares the policy file (`.roborev.toml`) with CI. CI runs the full matrix defined there (the
+`default` and `security` review types); a local run does a single review, so push to get the
+complete CI review.
+
+To review every commit automatically instead of on demand (opt-in):
+
+```bash
+just review-setup   # one-time: installs the roborev post-commit hook
+roborev show HEAD   # view the latest review
+roborev refine      # iterate: review, fix, repeat
+```
+
+Local review is optional; CI reviews every PR regardless.
+
 ## Work on the base template
 
 ### Prerequisites

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ jd --help
 
 ## Contributing
 
-Refer to the [Contributing guide](./CONTRIBUTING.md).
+Refer to the [Contributing guide](./CONTRIBUTING.md). Pull requests get an automated AI code
+review, and you can run the same review locally before pushing with `just review`.
 
 ## License
 

--- a/justfile
+++ b/justfile
@@ -1040,3 +1040,19 @@ ci-review-pull ecr_url tag="latest":
     {{container-tool}} pull "{{ecr_url}}:{{tag}}"
     {{container-tool}} tag "{{ecr_url}}:{{tag}}" jupyter-deploy-review:latest
     echo "✓ Pulled and tagged as jupyter-deploy-review:latest"
+
+# --- roborev local review ---
+
+# AI review of the current branch vs main (roborev, runs locally, no daemon)
+review:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v roborev >/dev/null 2>&1 || { echo "roborev not found. Install it from https://roborev.io, then optionally run 'just review-setup'."; exit 1; }
+    roborev review --branch --local --wait
+
+# Opt-in: install the roborev post-commit hook for continuous local review
+review-setup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    command -v roborev >/dev/null 2>&1 || { echo "roborev not found. Install it from https://roborev.io first."; exit 1; }
+    roborev init --agent claude-code


### PR DESCRIPTION
Closes #295. Adopts the automated roborev review already running in jupyter-k8s (jupyter-infra/jupyter-k8s#410) on jupyter-deploy's own PRs. This repo already builds the review image and provisions the IAM role via tf-aws-iam-ci; this PR adds the consumer side so its PRs get reviewed too. See #295 for the full architecture.

The review runs from `pull_request_target` (fork PRs get no OIDC token under `pull_request`) and never executes the PR's code: it checks out the trusted base, fetches the PR head as git objects, and hands roborev a `merge-base..head` range. The workflow is a verbatim copy of the jupyter-k8s reference, so all consumers share one proven, auditable pattern.

### Changes
- `.github/workflows/roborev-review.yml`: the review workflow. Inert until the repo variables `REVIEW_RUN_ROLE_ARN`, `REVIEW_IMAGE`, and `REVIEW_BEDROCK_MODEL` are set (optional `REVIEW_AWS_REGION`), so it merges safely.
- `.roborev.toml`: the shared review policy (claude-code agent, `default` and `security` review types).
- `justfile`: `just review` runs a one-shot local review of the branch against main; `just review-setup` installs the opt-in post-commit hook.
- `AGENT.md`, `CONTRIBUTING.md`, `README.md`: document the automated and local review.

Deferred to the rollout (tracked in #295): add jupyter-deploy to `review_repos` in tf-aws-iam-ci and re-apply, set the four repo variables, and create the `review` environment. The existing `.github/AGENT.md` note says the `review` environment must have protection rules; that needs reconciling with the auto-review flow (the run role is already bounded to ECR pull plus Bedrock invoke) when the environment is created. Until then the workflow stays inert.
