### PR TITLE
feat: helm chart components

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -233,6 +233,37 @@ Examples (for project-dir == sandbox-e2e, ci-dir == sandbox-ci):
 **Gotcha:** `JD_E2E_RBAC_TEAM` in `.env` MUST match the team in `oauth_allowed_teams` that the sandbox was deployed with.
 The RBAC RoleBinding on the cluster grants workspace access to that group — if they don't match, all impersonation-based workspace tests will fail with `Forbidden`.
 
+## Deploying and Tearing Down Projects
+
+These operations mutate live cloud infrastructure. Follow them exactly.
+
+**IMPORTANT: You MUST ALWAYS let a `jd up` or `jd down` run to completion.**
+Never interrupt, kill, cancel, or time out an in-progress `jd up`/`jd down` (or the
+underlying `terraform` process). A full EKS deploy/destroy can take 20-30 minutes;
+run it in the background and wait for it to finish rather than aborting. Interrupting
+an apply mid-run is how partial/duplicate deployments and orphaned resources happen.
+
+**IMPORTANT:** `jd up` automatically backs up the project (files + terraform state) to
+the remote store (an S3 bucket) after a full run — **even if the run ends in failure.**
+
+**IMPORTANT:** A NEW variable added to the template won't apply to an existing deployment
+until you also add it to that deployment's `<project-dir>/variables.yaml` `overrides:`
+block (a fresh `jd init` picks it up automatically; an existing project does not).
+
+To teardown a deployment:
+- confirm with the user that it's okay
+- run `jd down -y` (let it complete — see above)
+- once fully succeeded:
+  - remove the store entry with `jd projects delete <PROJECT-ID> --store-type s3-only`
+  - delete the local `<project-dir>`
+- if you hit issues:
+  - see logs with `jd history show down`; possibly retry
+  - `cd <project-dir>/engine` and try the `terraform` command directly
+  - if all else fails, look up AWS resources by tag (`DeploymentId`) via the Resource
+    Groups Tagging API and clean them up manually. **Note:** tags may not capture every
+    resource — watch for resources created by Kubernetes operators (LBs, ENIs, security
+    groups, VPC endpoints).
+
 ## Debugging and Investigating Deployments
 
 **Important:** Most `jd` commands (`init` excepted) assume the `cwd` is a particular project; change dir, or use the `--path` attribute (most commands support it).

--- a/docs/source/reference/resource/component.md
+++ b/docs/source/reference/resource/component.md
@@ -19,6 +19,7 @@ $ jd component [OPTIONS] COMMAND [ARGS]...
 * `show`: Display detailed information about a...
 * `logs`: Print the logs of a component.
 * `restart`: Restart a persisting component.
+* `reconcile`: Bring the actual resources in line with...
 * `trigger`: Trigger an ephemeral job from a...
 
 ## `component list`
@@ -122,6 +123,31 @@ $ jd component restart [OPTIONS]
 **Options**:
 
 * `--name TEXT`: Name of the component to restart.  [required]
+* `-p, --path PATH`: Directory of the project.
+* `--help`: Show this message and exit.
+
+## `component reconcile`
+
+Bring the actual resources in line with the component declaration.
+
+Update managed resources that drifted and re-create resources deleted
+out-of-band.
+
+However, resources that were removed from the declaration since the last
+<jd component reconcile> or <jd up> may become orphaned.
+
+Run either from a project directory that you created with <jd init>;
+or pass --path <project-dir>.
+
+**Usage**:
+
+```console
+$ jd component reconcile [OPTIONS]
+```
+
+**Options**:
+
+* `--name TEXT`: Name of the release component to reconcile.  [required]
 * `-p, --path PATH`: Directory of the project.
 * `--help`: Show this message and exit.
 

--- a/docs/source/reference/resource/component.md
+++ b/docs/source/reference/resource/component.md
@@ -131,10 +131,8 @@ $ jd component restart [OPTIONS]
 Bring the actual resources in line with the component declaration.
 
 Update managed resources that drifted and re-create resources deleted
-out-of-band.
-
-However, resources that were removed from the declaration since the last
-<jd component reconcile> or <jd up> may become orphaned.
+out-of-band. However, resources that were removed from the declaration
+since the last <jd component reconcile> or <jd up> will become orphaned.
 
 Run either from a project directory that you created with <jd init>;
 or pass --path <project-dir>.

--- a/docs/source/templates/aws-eks-oidc-template/details.md
+++ b/docs/source/templates/aws-eks-oidc-template/details.md
@@ -145,6 +145,7 @@ The template provides two variable presets:
 |---|---|
 | `cluster_name` | Name of the EKS cluster |
 | `cluster_endpoint` | API server endpoint URL for the EKS cluster |
+| `cluster_arn` | ARN of the EKS cluster |
 | `cluster_ca_certificate` | Base64-encoded CA certificate for the EKS cluster |
 | `region` | AWS region where the cluster is deployed |
 | `deployment_id` | Unique deployment identifier |

--- a/docs/source/templates/aws-eks-oidc-template/prerequisites.md
+++ b/docs/source/templates/aws-eks-oidc-template/prerequisites.md
@@ -91,5 +91,6 @@ The template requires the following tools installed locally:
 - [Terraform](https://developer.hashicorp.com/terraform/install) (>= 1.6)
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/) (for `jd cluster login` and direct cluster access)
+- [Helm](https://helm.sh/docs/intro/install/) (for `jd component reconcile`)
 
 `jupyter-deploy` will prompt you to install any missing tool during `jd config`.

--- a/docs/source/templates/aws-eks-oidc-template/user-guide.md
+++ b/docs/source/templates/aws-eks-oidc-template/user-guide.md
@@ -109,6 +109,9 @@ jd component restart --name oauth2-proxy
 
 # trigger a CronJob manually
 jd component trigger --name jwt-rotator
+
+# reconcile a HelmRelease (re-assert desired state, recreating deleted objects)
+jd component reconcile --name workspace-router-chart
 ```
 
 ## Take down

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -147,6 +147,9 @@ jd component logs --name dex
 
 # restart a component (deployment only)
 jd component restart --name oauth2-proxy
+
+# reconcile a component (HelmRelease only; re-asserts desired state)
+jd component reconcile --name workspace-router-chart
 ```
 
 ### Take down
@@ -291,6 +294,7 @@ The template provides two variable presets:
 |---|---|
 | `cluster_name` | Name of the EKS cluster |
 | `cluster_endpoint` | API server endpoint URL for the EKS cluster |
+| `cluster_arn` | ARN of the EKS cluster |
 | `cluster_ca_certificate` | Base64-encoded CA certificate for the EKS cluster |
 | `region` | AWS region where the cluster is deployed |
 | `deployment_id` | Unique deployment identifier |

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
@@ -112,6 +112,20 @@ handles ordering, but if a destroy stalls for 15+ minutes on subnet deletion, lo
 leftover NLB tagged with the cluster name and delete it with
 `aws elbv2 delete-load-balancer`.
 
+## Orphaned AWS resources after an incomplete destroy
+
+Some AWS resources are created by in-cluster controllers (AWS Load Balancer Controller,
+external-dns), not by Terraform, so they are **not** in the Terraform state.
+They also may not carry the `DeploymentId` tag, so a tag search alone can miss them.
+Check for and remove the following resources:
+- Network Load Balancers still referencing the (now-deleted) cluster VPC
+- Target groups outlive the NLB. They are tagged kubernetes.io/cluster/<cluster-name>=owned
+
+**Important:** verify each resource's owning cluster/VPC before deleting. Target groups
+and external-dns Route53 records are tagged with the *owning cluster name* — a same-account
+cluster in another region (or a different template's deployment) will have its own, and
+those must be left alone.
+
 ## `kubectl` / `jd cluster login` returns Forbidden
 
 The cluster is created with `bootstrap_cluster_creator_admin_permissions = false`, so

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/outputs.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/outputs.tf
@@ -8,6 +8,11 @@ output "cluster_endpoint" {
   value       = module.eks_cluster.cluster_endpoint
 }
 
+output "cluster_arn" {
+  description = "ARN of the EKS cluster."
+  value       = module.eks_cluster.cluster_arn
+}
+
 output "cluster_ca_certificate" {
   description = "Base64-encoded CA certificate for the EKS cluster."
   value       = module.eks_cluster.cluster_ca_certificate

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -12,6 +12,7 @@ requirements:
 - name: awscli
 - name: kubectl
 - name: yq
+- name: helm
 values:
 - name: deployment_id
   source: output
@@ -25,9 +26,6 @@ values:
 - name: kubeconfig_path
   source: output
   source-key: kubeconfig_path
-- name: workspace_shared_namespace
-  source: output
-  source-key: workspace_shared_namespace
 - name: cluster_name
   source: output
   source-key: cluster_name
@@ -37,24 +35,9 @@ values:
 - name: cluster_ca_certificate
   source: output
   source-key: cluster_ca_certificate
-- name: workspace_base_url
-  source: output
-  source-key: workspace_base_url
-- name: workspace_patch_start
-  source: output
-  source-key: workspace_patch_start
-- name: workspace_patch_stop
-  source: output
-  source-key: workspace_patch_stop
 - name: server_default_scope
   source: output
   source-key: server_default_scope
-- name: workspace_router_namespace
-  source: output
-  source-key: workspace_router_namespace
-- name: workspace_operator_namespace
-  source: output
-  source-key: workspace_operator_namespace
 project-store:
   store-type: s3-only
 multi-host: true
@@ -381,6 +364,9 @@ commands:
     - api-attribute: extra
       source: cli
       source-key: extra
+    - api-attribute: expected_cluster_config
+      source: output
+      source-key: cluster_arn
   results:
   - result-name: server.logs
     source: result
@@ -487,6 +473,9 @@ commands:
     - api-attribute: container
       source: cli
       source-key: service
+    - api-attribute: expected_cluster_config
+      source: output
+      source-key: cluster_arn
 - cmd: component.customresourcewithoutstatus.status
   sequence:
   - api-name: k8s.custom.get
@@ -632,6 +621,9 @@ commands:
     - api-attribute: extra
       source: cli
       source-key: extra
+    - api-attribute: expected_cluster_config
+      source: output
+      source-key: cluster_arn
   results:
   - result-name: component.deployment.logs.logs
     source: result
@@ -705,6 +697,9 @@ commands:
     - api-attribute: extra
       source: cli
       source-key: extra
+    - api-attribute: expected_cluster_config
+      source: output
+      source-key: cluster_arn
   results:
   - result-name: component.cronjob.logs.logs
     source: result
@@ -723,6 +718,69 @@ commands:
   - result-name: component.cronjob.trigger.job_name
     source: result
     source-key: '[0].JobName'
+- cmd: component.helmrelease.status
+  sequence:
+  - api-name: helm.status
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: expected_cluster_config
+      source: output
+      source-key: cluster_arn
+  results:
+  - result-name: component.helmrelease.status.status
+    source: result
+    source-key: '[0].Status'
+  - result-name: component.helmrelease.status.status_category
+    source: result
+    source-key: '[0].StatusCategory'
+  - result-name: component.helmrelease.status.details
+    source: result
+    source-key: '[0].Details'
+  - result-name: component.helmrelease.status.sub_component
+    source: result
+    source-key: '[0].SubComponent'
+- cmd: component.helmrelease.show
+  sequence:
+  - api-name: helm.show
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: expected_cluster_config
+      source: output
+      source-key: cluster_arn
+  results:
+  - result-name: component.helmrelease.show.name
+    source: result
+    source-key: '[0].Name'
+  - result-name: component.helmrelease.show.resource
+    source: result
+    source-key: '[0].Resource'
+- cmd: component.helmrelease.reconcile
+  sequence:
+  - api-name: helm.reconcile
+    arguments:
+    - api-attribute: name
+      source: cli
+      source-key: name
+    - api-attribute: scope
+      source: cli
+      source-key: scope
+    - api-attribute: expected_cluster_config
+      source: output
+      source-key: cluster_arn
+  results:
+  - result-name: component.helmrelease.reconcile.output
+    source: result
+    source-key: '[0].Output'
 - cmd: image.status
   sequence:
   - api-name: aws.ecr.describe-image
@@ -984,6 +1042,66 @@ components:
         method: k8s.batch.get-job-logs
       trigger:
         method: k8s.batch.create-job-from-cronjob
+  traefik-crds:
+    type: HelmRelease
+    description: Traefik CRDs chart
+    resource-name: traefik-crds
+    scope: workspace_router_namespace
+    verbs:
+      status:
+        method: helm.status
+      show:
+        method: helm.show
+      reconcile:
+        method: helm.reconcile
+  workspace-operator-chart:
+    type: HelmRelease
+    description: Workspace operator chart (jupyter-k8s)
+    resource-name: jupyter-k8s
+    scope: workspace_operator_namespace
+    verbs:
+      status:
+        method: helm.status
+      show:
+        method: helm.show
+      reconcile:
+        method: helm.reconcile
+  workspace-router-chart:
+    type: HelmRelease
+    description: Workspace router chart (routing, auth, web UI)
+    resource-name: jupyter-k8s-aws-oidc
+    scope: workspace_router_namespace
+    verbs:
+      status:
+        method: helm.status
+      show:
+        method: helm.show
+      reconcile:
+        method: helm.reconcile
+  github-rbac-chart:
+    type: HelmRelease
+    description: GitHub team RBAC RoleBindings chart
+    resource-name: github-rbac
+    scope: workspace_shared_namespace
+    verbs:
+      status:
+        method: helm.status
+      show:
+        method: helm.show
+      reconcile:
+        method: helm.reconcile
+  workspace-defaults-chart:
+    type: HelmRelease
+    description: Default WorkspaceTemplate and access strategy chart
+    resource-name: workspace-defaults
+    scope: workspace_shared_namespace
+    verbs:
+      status:
+        method: helm.status
+      show:
+        method: helm.show
+      reconcile:
+        method: helm.reconcile
 supervised-execution:
   config:
     config.terraform-plan:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/patches/remove-default-template-label.json
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/patches/remove-default-template-label.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "labels": {
+      "workspace.jupyter.org/default-template": null
+    }
+  }
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
@@ -1,8 +1,10 @@
 """E2E tests for component commands on the EKS OIDC template."""
 
 import json
+import subprocess
 import time
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 from pytest_jupyter_deploy.cli import JDCliError
@@ -41,6 +43,10 @@ def _get_crd_names(e2e_deployment: EndToEndDeployment) -> list[str]:
         for name, comp in _get_manifest_components(e2e_deployment).items()
         if comp.type == "CustomResourceDefinition"
     ]
+
+
+def _get_helmrelease_names(e2e_deployment: EndToEndDeployment) -> list[str]:
+    return [name for name, comp in _get_manifest_components(e2e_deployment).items() if comp.type == "HelmRelease"]
 
 
 def _poll_component_status(
@@ -204,6 +210,21 @@ def test_cluster_custom_resource_crd_show(e2e_deployment: EndToEndDeployment) ->
 
 
 @pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_helmrelease_component_status_deployed(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify each HelmRelease component reports its deployed status."""
+    e2e_deployment.ensure_deployed()
+
+    helm_names = _get_helmrelease_names(e2e_deployment)
+    assert helm_names, "Expected HelmRelease components for the platform charts"
+
+    for name in helm_names:
+        result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "status", "--name", name])
+        # helm reports `deployed` for a healthy release; a superseded revision would also be acceptable.
+        assert f"{name} status:" in result.stdout, f"Expected status line for '{name}':\n{result.stdout}"
+        assert "deployed" in result.stdout, f"Expected '{name}' to be deployed:\n{result.stdout}"
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
 def test_component_status_not_found(e2e_deployment: EndToEndDeployment) -> None:
     """Verify status for a non-existent component fails gracefully."""
     e2e_deployment.ensure_deployed()
@@ -264,6 +285,42 @@ def test_component_show_custom_resource(e2e_deployment: EndToEndDeployment) -> N
     data = json.loads(result.stdout)
     assert "name" in data, f"Expected 'name' in JSON response, got: {list(data.keys())}"
     assert "resource" in data, f"Expected 'resource' in JSON response, got: {list(data.keys())}"
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_helmrelease_component_show(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify show --json returns the helm release info for a HelmRelease component.
+
+    Targets the router release specifically because it carries the GitHub OAuth client
+    secret in its chart config — the case that must be redacted.
+    """
+    e2e_deployment.ensure_deployed()
+
+    name = "workspace-router-chart"
+    assert name in _get_helmrelease_names(e2e_deployment), f"Expected a HelmRelease component named '{name}'"
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", name, "--json"])
+    data = json.loads(result.stdout)
+    # `name` is the helm release name (the component's resource-name), not the component name.
+    assert data["name"] == "jupyter-k8s-aws-oidc", f"Unexpected release name for '{name}': {data['name']}"
+    # The resource is the `helm status --output json` payload (with the manifest redacted).
+    resource = json.loads(data["resource"]) if isinstance(data["resource"], str) else data["resource"]
+    assert resource.get("info", {}).get("status") == "deployed", f"Unexpected release info for '{name}': {resource}"
+    assert "version" in resource, f"Expected a revision 'version' in release info for '{name}'"
+
+    # The rendered manifest is replaced with a placeholder, not the full YAML blob.
+    assert resource.get("manifest") == "<redacted>", (
+        f"Expected manifest to be redacted, got: {resource.get('manifest')}"
+    )
+
+    # `resources` is a per-kind breakdown of the managed objects.
+    resources = resource.get("resources")
+    assert isinstance(resources, dict), f"Expected 'resources' to be a dict, got: {resources!r}"
+    assert resources, f"Expected a non-empty per-kind resource breakdown for '{name}'"
+
+    # The GitHub OAuth client secret must be redacted, never exposed in plaintext.
+    client_secret = resource.get("config", {}).get("github", {}).get("clientSecret")
+    assert client_secret == "****", f"Expected github.clientSecret to be redacted, got: {client_secret!r}"
 
 
 def test_component_show_description(e2e_deployment: EndToEndDeployment) -> None:
@@ -415,3 +472,135 @@ def test_component_trigger_not_found(e2e_deployment: EndToEndDeployment) -> None
 
     with pytest.raises(JDCliError):
         e2e_deployment.cli.run_command(["jupyter-deploy", "component", "trigger", "--name", "i-do-not-exist"])
+
+
+# ── component reconcile ──────────────────────────────────────────────────────
+
+# The workspace-defaults chart ships the `jupyterlab` WorkspaceTemplate carrying the
+# `workspace.jupyter.org/default-template` label. Removing that label out-of-band and
+# reconciling the release must restore it — a safe, revertible drift on a managed object.
+_RECONCILE_RELEASE_COMPONENT = "workspace-defaults-chart"
+_DEFAULT_TEMPLATE_KIND = "workspacetemplate"
+_DEFAULT_TEMPLATE_NAME = "jupyterlab"
+_DEFAULT_TEMPLATE_LABEL = "workspace.jupyter.org/default-template"
+_PATCHES_DIR = Path(__file__).parent / "patches"
+
+
+def _resolve_component_namespace(e2e_deployment: EndToEndDeployment, name: str) -> str:
+    """Resolve a component's namespace from its manifest scope output."""
+    comp = _get_manifest_components(e2e_deployment)[name]
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "show", "--output", comp.scope, "--text"])
+    return result.stdout.strip()
+
+
+def _kubectl_get_label(kind: str, name: str, namespace: str, label: str) -> str | None:
+    """Return the value of a label on a resource, or None if the label is absent."""
+    jsonpath = "{.metadata.labels." + label.replace(".", "\\.") + "}"
+    result = subprocess.run(
+        ["kubectl", "get", kind, name, "-n", namespace, "-o", f"jsonpath={jsonpath}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout if result.stdout != "" else None
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_component_reconcile_noop_on_no_drift(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify reconcile is idempotent: re-running with no drift changes nothing.
+
+    The first apply over helm-created objects reports `configured` (it writes the
+    last-applied-configuration annotation), so idempotency is asserted on a second
+    back-to-back reconcile: with nothing drifted, every object must report `unchanged`
+    (never `configured`/`created`) and the release stays healthy.
+    """
+    e2e_deployment.ensure_deployed()
+
+    # First reconcile settles the last-applied-configuration annotations.
+    first = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "component", "reconcile", "--name", _RECONCILE_RELEASE_COMPONENT]
+    )
+    assert "Reconciled" in first.stdout, f"Expected 'Reconciled' in output:\n{first.stdout}"
+
+    # Second reconcile with no intervening drift must be a genuine no-op.
+    second = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "component", "reconcile", "--name", _RECONCILE_RELEASE_COMPONENT]
+    )
+    assert "Reconciled" in second.stdout, f"Expected 'Reconciled' in output:\n{second.stdout}"
+    assert "configured" not in second.stdout and "created" not in second.stdout, (
+        f"Expected an idempotent no-op reconcile (all 'unchanged'), got:\n{second.stdout}"
+    )
+
+    status = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "component", "status", "--name", _RECONCILE_RELEASE_COMPONENT]
+    )
+    assert "deployed" in status.stdout, f"Release not healthy after no-op reconcile:\n{status.stdout}"
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_component_reconcile_add_back_missing_label(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify reconcile re-asserts a chart-managed field removed out-of-band.
+
+    Removes the `default-template` label from the jupyterlab WorkspaceTemplate (a
+    kubectl patch helm's template-diff would never notice), reconciles the release,
+    and asserts the label is restored — the core drift-recovery scenario of issue #294.
+    """
+    e2e_deployment.ensure_deployed()
+
+    namespace = _resolve_component_namespace(e2e_deployment, _RECONCILE_RELEASE_COMPONENT)
+
+    original = _kubectl_get_label(_DEFAULT_TEMPLATE_KIND, _DEFAULT_TEMPLATE_NAME, namespace, _DEFAULT_TEMPLATE_LABEL)
+    assert original is not None, (
+        f"Expected {_DEFAULT_TEMPLATE_NAME} to carry the {_DEFAULT_TEMPLATE_LABEL} label before the test"
+    )
+
+    # Remove the label out-of-band via a merge patch (value: null drops the key).
+    patch = (_PATCHES_DIR / "remove-default-template-label.json").read_text()
+    subprocess.run(
+        [
+            "kubectl",
+            "patch",
+            _DEFAULT_TEMPLATE_KIND,
+            _DEFAULT_TEMPLATE_NAME,
+            "-n",
+            namespace,
+            "--type=merge",
+            "-p",
+            patch,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert (
+        _kubectl_get_label(_DEFAULT_TEMPLATE_KIND, _DEFAULT_TEMPLATE_NAME, namespace, _DEFAULT_TEMPLATE_LABEL) is None
+    ), "Label should be removed before reconcile"
+
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "component", "reconcile", "--name", _RECONCILE_RELEASE_COMPONENT]
+    )
+    assert "Reconciled" in result.stdout, f"Expected 'Reconciled' in output:\n{result.stdout}"
+
+    restored = _kubectl_get_label(_DEFAULT_TEMPLATE_KIND, _DEFAULT_TEMPLATE_NAME, namespace, _DEFAULT_TEMPLATE_LABEL)
+    assert restored == original, (
+        f"Expected reconcile to restore label {_DEFAULT_TEMPLATE_LABEL}={original}, got {restored!r}"
+    )
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_component_reconcile_wrong_type(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify reconcile fails for a Deployment component (wrong type)."""
+    e2e_deployment.ensure_deployed()
+
+    name = _get_deployment_names(e2e_deployment)[0]
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "reconcile", "--name", name])
+
+
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_component_reconcile_not_found(e2e_deployment: EndToEndDeployment) -> None:
+    """Verify reconcile for a non-existent component fails gracefully."""
+    e2e_deployment.ensure_deployed()
+
+    with pytest.raises(JDCliError):
+        e2e_deployment.cli.run_command(["jupyter-deploy", "component", "reconcile", "--name", "i-do-not-exist"])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
@@ -92,9 +92,12 @@ def test_health_components_layer(e2e_deployment: EndToEndDeployment) -> None:
     # Components whose health is existence-based, keyed by manifest type.
     crd_names = {n for n, c in manifest_components.items() if c.type == "CustomResourceDefinition"}
     cr_names = {n for n, c in manifest_components.items() if c.type == "CustomResourceWithoutStatus"}
+    helm_names = {n for n, c in manifest_components.items() if c.type == "HelmRelease"}
     # The eks-oidc template declares the 3 Workspace CRDs + the access-strategy and template CRs.
     assert len(crd_names) >= 3, f"Expected >= 3 CustomResourceDefinition components, got {sorted(crd_names)}"
     assert len(cr_names) >= 2, f"Expected >= 2 CustomResourceWithoutStatus components, got {sorted(cr_names)}"
+    # The 5 platform charts are surfaced as HelmRelease components.
+    assert len(helm_names) == 5, f"Expected 5 HelmRelease components, got {sorted(helm_names)}"
 
     for entry in layers:
         assert entry["layer"] == "components"
@@ -122,6 +125,16 @@ def test_health_components_layer(e2e_deployment: EndToEndDeployment) -> None:
             assert _LABELED_VALUE_RE.match(entry["sub_component"]), (
                 f"CR '{name}' sub-component should be a 'label: value' pair, got: {entry['sub_component']!r}"
             )
+
+        if name in helm_names:
+            # HelmRelease rows report the release status, the target namespace in details,
+            # and a "resources: <count>" sub-component with a positive object count. In JSON
+            # output sub_component is the raw payload; the table renders it as "resources: N".
+            assert entry["status"] == "deployed", f"HelmRelease '{name}' status: {entry['status']}"
+            assert entry["detail"] != "", f"HelmRelease '{name}' should surface its namespace in detail"
+            sub = json.loads(entry["sub_component"])
+            assert sub["name"] == "resources", f"HelmRelease '{name}' sub-component label: {sub['name']!r}"
+            assert int(sub["status"]) > 0, f"HelmRelease '{name}' should track at least one resource: {sub!r}"
 
 
 def test_health_load_balancer_layer(e2e_deployment: EndToEndDeployment) -> None:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
@@ -13,8 +13,20 @@ class TestManifest(unittest.TestCase):
     MANIFEST_PATH: Path = TEMPLATE_PATH / "manifest.yaml"
     MANIFEST: dict[str, Any] | None = None
     VARIABLES_CONFIG: dict[str, Any] | None = None
-    EXPECTED_REQUIREMENTS = ["terraform", "awscli", "kubectl"]
-    EXPECTED_VALUES = ["deployment_id", "open_url", "aws_region"]
+    EXPECTED_REQUIREMENTS = ["terraform", "awscli", "kubectl", "helm"]
+    # Values that core handlers resolve by name via get_declared_output_def; removing any
+    # of these from the manifest would break the CLI (unlike command args, which source
+    # their output directly and do not need a values entry).
+    EXPECTED_VALUES = [
+        "deployment_id",
+        "open_url",
+        "aws_region",
+        "kubeconfig_path",
+        "cluster_name",
+        "cluster_endpoint",
+        "cluster_ca_certificate",
+        "server_default_scope",
+    ]
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -195,6 +207,43 @@ class TestManifest(unittest.TestCase):
             cr_kinds,
             f"Expected a CustomResourceWithoutStatus of kind WorkspaceTemplate, got kinds: {cr_kinds}",
         )
+
+    def test_helm_release_components_declared_with_reconcile(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        components = self.MANIFEST.get("components", {})
+        helm_components = {name: c for name, c in components.items() if c["type"] == "HelmRelease"}
+
+        # All five chart releases are surfaced as components.
+        self.assertEqual(
+            len(helm_components),
+            5,
+            f"Expected 5 HelmRelease components, got {len(helm_components)}: {list(helm_components)}",
+        )
+        for name, comp in helm_components.items():
+            self.assertIn("reconcile", comp["verbs"], f"HelmRelease component '{name}' must declare a reconcile verb")
+            self.assertIn("resource-name", comp, f"HelmRelease component '{name}' must declare its release name")
+
+    def test_helm_requirement_declared(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        requirement_names = {req["name"] for req in self.MANIFEST.get("requirements", [])}
+        self.assertIn("helm", requirement_names, "Template must require the helm CLI for reconcile")
+
+    def test_helmrelease_status_emits_sub_component(self) -> None:
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        cmd = next(
+            (c for c in self.MANIFEST.get("commands", []) if c["cmd"] == "component.helmrelease.status"),
+            None,
+        )
+        self.assertIsNotNone(cmd, "component.helmrelease.status command must exist")
+        result_names = {r["result-name"] for r in cmd.get("results", [])}
+        # The health dashboard renders this as "Sub-component: <namespace>, <N> resources".
+        self.assertIn("component.helmrelease.status.sub_component", result_names)
 
     def test_component_verbs_have_matching_commands(self) -> None:
         if self.MANIFEST is None:

--- a/libs/jupyter-deploy/jupyter_deploy/cli/component_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/component_app.py
@@ -188,6 +188,36 @@ def restart(
 
 
 @component_app.command()
+def reconcile(
+    name: Annotated[str, typer.Option("--name", help="Name of the release component to reconcile.")],
+    project_dir: Annotated[
+        Path | None,
+        typer.Option("--path", "-p", help="Directory of the project."),
+    ] = None,
+) -> None:
+    """Bring the actual resources in line with the component declaration.
+
+    Update managed resources that drifted and re-create resources deleted
+    out-of-band. However, resources that were removed from the declaration
+    since the last <jd component reconcile> or <jd up> will become orphaned.
+
+    Run either from a project directory that you created with <jd init>;
+    or pass --path <project-dir>.
+    """
+    console = Console()
+    with handle_cli_errors(console), cmd_utils.project_dir(project_dir):
+        simple_display_manager = SimpleDisplayManager(console=console)
+        handler = component_handler.ComponentHandler(display_manager=simple_display_manager)
+
+        with simple_display_manager.spinner(f"Reconciling {name}..."):
+            output = handler.reconcile_component(name=name)
+
+        simple_display_manager.success(f"Reconciled '{name}'.")
+        if output:
+            console.print(output)
+
+
+@component_app.command()
 def trigger(
     name: Annotated[str, typer.Option("--name", help="Name of the CronJob component to trigger.")],
     project_dir: Annotated[

--- a/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
@@ -21,6 +21,7 @@ from jupyter_deploy.exceptions import (
     InvalidComponentVerbError,
     InvalidInstructionArgumentError,
     InvalidInstructionResultError,
+    InvalidKubernetesClusterTargetError,
     InvalidManifestError,
     InvalidPresetError,
     InvalidProjectPathError,
@@ -215,9 +216,15 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except InvalidComponentVerbError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(f"Available actions for '{e.component_name}': {', '.join(e.valid_verbs)}")
+        raise typer.Exit(code=1) from None
+
+    except InvalidKubernetesClusterTargetError as e:
+        console.print(f":x: {e}", style="bold red", highlight=False)
+        console.line()
+        console.print(":bulb: Run [bold cyan]jd cluster login[/].")
         raise typer.Exit(code=1) from None
 
     except ResourceNotFoundError as e:

--- a/libs/jupyter-deploy/jupyter_deploy/cmd_utils.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cmd_utils.py
@@ -73,7 +73,7 @@ def switch_dir(dir_path: Path | None) -> Generator:
         os.chdir(original_dir)
 
 
-def run_cmd_and_capture_output(cmds: list[str], exec_dir: Path | None = None) -> str:
+def run_cmd_and_capture_output(cmds: list[str], exec_dir: Path | None = None, stdin_input: str | None = None) -> str:
     """Run command, returns output.
 
     Raises:
@@ -82,6 +82,7 @@ def run_cmd_and_capture_output(cmds: list[str], exec_dir: Path | None = None) ->
     with switch_dir(exec_dir):
         result = subprocess.run(
             cmds,
+            input=stdin_input,
             capture_output=True,
             text=True,
             check=True,

--- a/libs/jupyter-deploy/jupyter_deploy/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/enum.py
@@ -160,6 +160,7 @@ class JupyterDeployTool(str, Enum):
 
     AWS_CLI = "aws-cli"
     AWS_SSM_PLUGIN = "aws-ssm-plugin"
+    HELM = "helm"
     JQ = "jq"
     KUBECTL = "kubectl"
     TERRAFORM = "terraform"

--- a/libs/jupyter-deploy/jupyter_deploy/exceptions.py
+++ b/libs/jupyter-deploy/jupyter_deploy/exceptions.py
@@ -442,6 +442,26 @@ class ResourceNotFoundError(InstructionError, RuntimeError):
         super().__init__(msg)
 
 
+class InvalidKubernetesClusterTargetError(InstructionError, RuntimeError):
+    """Raised when a kubectl/helm subprocess would act on the wrong cluster.
+
+    The active kubeconfig context does not match the deployment's expected cluster
+    config, so the operation is refused to avoid mutating an unintended cluster.
+
+    Attributes:
+        current_context: The active kubectl context name (empty if unreadable)
+        expected_cluster_config: The value the active context must match (e.g. cluster ARN)
+    """
+
+    def __init__(self, current_context: str, expected_cluster_config: str) -> None:
+        self.current_context = current_context
+        self.expected_cluster_config = expected_cluster_config
+        super().__init__(
+            f"Invalid kubectl context: '{current_context}' does not match the project's "
+            f"cluster '{expected_cluster_config}'."
+        )
+
+
 class InstructionNotFoundError(InstructionError, RuntimeError):
     """Raised when an instruction cannot be found or is not implemented."""
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/kubernetes-component-management-instructions.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/kubernetes-component-management-instructions.md
@@ -1,7 +1,8 @@
-Components are the platform-level Kubernetes resources supporting your apps (e.g. router,
+Components are the platform-level resources supporting your apps (e.g. router,
 identity provider, controllers). Each one is backed by a Kubernetes **Deployment** (a
-long-running workload) or a **CronJob** (a scheduled job). You address a component by
-`--name`; `jd component list` reports each one's name and type.
+long-running workload), a **CronJob** (a scheduled job), or a **HelmRelease** (a chart
+managing a set of objects). You address a component by `--name`; `jd component list`
+reports each one's name and type.
 
 ```bash
 # list the components declared by this template (with their Deployment/CronJob type)
@@ -40,4 +41,13 @@ jd component restart --name COMPONENT-NAME
 
 # trigger a one-off Job from a CronJob-backed component (not valid for a Deployment)
 jd component trigger --name COMPONENT-NAME
+
+# reconcile a HelmRelease-backed component (re-assert desired state; not valid for a Deployment or CronJob)
+jd component reconcile --name COMPONENT-NAME
 ```
+
+Helm only acts on the diff between chart releases, so an object deleted out-of-band (a
+manual `kubectl delete`, an evicted CRD) is never recreated by a plain `helm upgrade`.
+`jd component reconcile` re-applies the release's stored manifest to the live cluster,
+recreating drifted or missing managed objects on demand. It requires a `helm` client on
+the host.

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/component_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/component_handler.py
@@ -246,6 +246,23 @@ class ComponentHandler(BaseProjectHandler):
         cli_paramdefs = self._build_cli_paramdefs(resource_name, component, namespace)
         runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
 
+    def reconcile_component(self, name: str) -> str:
+        """Re-assert a component's desired state, returns the reconcile output."""
+        component = self.project_manifest.get_component(name)
+        self._validate_verb(name, component, "reconcile")
+        namespace = self._resolve_namespace(component)
+        resource_name = self._get_resource_name(name, component)
+        cmd_name = self._get_command_name(component, "reconcile")
+        command = self.project_manifest.get_command(cmd_name)
+        runner = cmd_runner.ManifestCommandRunner(
+            display_manager=self.display_manager,
+            output_handler=self._output_handler,
+            variable_handler=self._variable_handler,
+        )
+        cli_paramdefs = self._build_cli_paramdefs(resource_name, component, namespace)
+        runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
+        return runner.get_result_value_with_fallback(command, f"{cmd_name}.output", str, "")
+
     def trigger_component(self, name: str) -> str:
         """Trigger a Job from a CronJob component. Returns the Job name."""
         component = self.project_manifest.get_component(name)

--- a/libs/jupyter-deploy/jupyter_deploy/provider/enum.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/enum.py
@@ -17,6 +17,7 @@ class ApiGroup(str, Enum):
 
     AWS = "aws"
     K8S = "k8s"
+    HELM = "helm"
 
     @classmethod
     def from_api_name(cls, api_name: str) -> "ApiGroup":

--- a/libs/jupyter-deploy/jupyter_deploy/provider/helm/helm_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/helm/helm_runner.py
@@ -1,0 +1,267 @@
+import json
+import subprocess
+from enum import Enum
+from typing import Any
+
+import yaml
+
+from jupyter_deploy import cmd_utils
+from jupyter_deploy.engine.supervised_execution import DisplayManager
+from jupyter_deploy.enum import StatusCategory
+from jupyter_deploy.exceptions import InstructionError, InstructionNotFoundError, ResourceNotFoundError
+from jupyter_deploy.provider.instruction_runner import InstructionRunner
+from jupyter_deploy.provider.k8s.kubeconfig_verify import verify_kubeconfig_context
+from jupyter_deploy.provider.resolved_argdefs import (
+    ResolvedInstructionArgument,
+    StrResolvedInstructionArgument,
+    require_arg,
+    retrieve_optional_arg,
+)
+from jupyter_deploy.provider.resolved_resultdefs import (
+    ResolvedInstructionResult,
+    StrResolvedInstructionResult,
+)
+
+# Helm release status strings (`.info.status`) mapped to jupyter-deploy health categories.
+# See https://helm.sh/docs/helm/helm_status/.
+_HEALTHY_STATUSES = frozenset({"deployed", "superseded"})
+_IN_PROGRESS_STATUSES = frozenset({"pending-install", "pending-upgrade", "pending-rollback", "uninstalling"})
+
+# The chart's `config` (user-supplied values) can contain plaintext credentials — e.g.
+# github.clientSecret, oauth2Proxy.cookieSecret, dex.oauth2ProxyClientSecret. Redact any
+# leaf whose key ends in these (case-insensitive) before showing the config.
+_REDACTED = "****"
+_SECRET_KEY_SUFFIXES = ("secret", "key", "password", "token")
+
+
+class HelmInstruction(str, Enum):
+    """Instructions supported by the Helm runner."""
+
+    STATUS = "status"
+    SHOW = "show"
+    RECONCILE = "reconcile"
+
+
+class HelmApiRunner(InstructionRunner):
+    """Routes helm.<instruction> to the `helm` (and `kubectl`) CLIs.
+
+    Helm is not a reconciler: `helm upgrade` only acts on the diff between the previous
+    and new rendered manifests, so an object deleted out-of-band is never recreated.
+    `reconcile` re-applies the release's stored manifest with `kubectl apply` to re-assert
+    desired state — recreating drifted or deleted managed objects on demand.
+    """
+
+    def __init__(self, display_manager: DisplayManager, kubeconfig_path: str | None = None) -> None:
+        super().__init__(display_manager)
+        self._kubeconfig_path = kubeconfig_path
+
+    def _run(
+        self, base_cmd: str, args: list[str], expected_cluster_config: str = "", stdin_input: str | None = None
+    ) -> str:
+        """Run a `helm`/`kubectl` subprocess, return stdout.
+
+        Follows the same auth pattern as the k8s runner's kubectl subprocesses: pass
+        `--kubeconfig` when a path is configured, otherwise rely on the ambient kubeconfig
+        (set up by `jd cluster login` / `aws eks update-kubeconfig`). When the command
+        declares an `expected_cluster_config`, the active context is verified against it
+        first to avoid acting on the wrong cluster.
+
+        Raises:
+            InvalidKubernetesClusterTargetError: If the active kubeconfig context targets the wrong cluster.
+            ResourceNotFoundError: If helm reports the release does not exist.
+            InstructionError: For any other non-zero exit.
+        """
+        verify_kubeconfig_context(expected_cluster_config or None, self._kubeconfig_path)
+
+        cmds = [base_cmd]
+        if self._kubeconfig_path:
+            cmds += ["--kubeconfig", self._kubeconfig_path]
+        cmds += args
+        try:
+            return cmd_utils.run_cmd_and_capture_output(cmds, stdin_input=stdin_input)
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr.strip() if e.stderr else ""
+            stderr_lower = stderr.lower()
+            if "release: not found" in stderr_lower or ("not found" in stderr_lower and "release" in stderr_lower):
+                raise ResourceNotFoundError(
+                    resource_kind="helm release",
+                    resource_name=args[1] if len(args) > 1 else "",
+                    original_message=stderr,
+                ) from None
+            raise InstructionError(stderr or f"command failed: {' '.join(cmds)}") from None
+
+    def _get_release_info(self, name: str, namespace: str, expected_cluster_config: str) -> dict[str, Any]:
+        raw = self._run(
+            "helm",
+            ["status", name, "--namespace", namespace, "--output", "json"],
+            expected_cluster_config=expected_cluster_config,
+        )
+        try:
+            info: dict[str, Any] = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise InstructionError(f"Could not parse helm status for release '{name}': {e}") from None
+        return info
+
+    @staticmethod
+    def _count_manifest_resources_by_kind(manifest: str) -> dict[str, int]:
+        """Count the Kubernetes objects a release tracks, grouped by `kind`.
+
+        Parses the YAML stream and tallies documents that declare a `kind`; this ignores
+        the empty/comment-only documents that `helm status` leaves between objects, so it
+        is more accurate than splitting on `---`. Returns e.g. {"Service": 6, "Deployment": 5}.
+        """
+        counts: dict[str, int] = {}
+        try:
+            for doc in yaml.safe_load_all(manifest):
+                if isinstance(doc, dict) and doc.get("kind"):
+                    kind = str(doc["kind"])
+                    counts[kind] = counts.get(kind, 0) + 1
+        except yaml.YAMLError:
+            return {}
+        return counts
+
+    @classmethod
+    def _count_manifest_resources(cls, manifest: str) -> int:
+        """Total number of Kubernetes objects a release tracks (sum over kinds)."""
+        return sum(cls._count_manifest_resources_by_kind(manifest).values())
+
+    @classmethod
+    def _redact_secrets(cls, value: Any) -> Any:
+        """Recursively redact secret-like values in a config tree.
+
+        A leaf is redacted when its key ends in a secret-like suffix (case-insensitive),
+        e.g. `clientSecret`, `cookieSecret`, `oauth2ProxyClientSecret`. Dicts and lists are
+        walked; other values are returned unchanged.
+        """
+        if isinstance(value, dict):
+            redacted: dict[str, Any] = {}
+            for k, v in value.items():
+                key_lower = str(k).lower()
+                if isinstance(v, str) and any(key_lower.endswith(s) for s in _SECRET_KEY_SUFFIXES):
+                    redacted[k] = _REDACTED
+                else:
+                    redacted[k] = cls._redact_secrets(v)
+            return redacted
+        if isinstance(value, list):
+            return [cls._redact_secrets(item) for item in value]
+        return value
+
+    @staticmethod
+    def _expected_cluster_config(resolved_arguments: dict[str, ResolvedInstructionArgument]) -> str:
+        # Optional per-command arg: when set, the active kubeconfig context must match it.
+        arg = retrieve_optional_arg(resolved_arguments, "expected_cluster_config", StrResolvedInstructionArgument, "")
+        return arg.value
+
+    def _status(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Getting helm release status: {name_arg.value}")
+        info = self._get_release_info(
+            name_arg.value, scope_arg.value, self._expected_cluster_config(resolved_arguments)
+        )
+
+        status = str(info.get("info", {}).get("status", "unknown"))
+        if status in _HEALTHY_STATUSES:
+            status_category = StatusCategory.HEALTHY
+        elif status in _IN_PROGRESS_STATUSES:
+            status_category = StatusCategory.IN_PROGRESS
+        else:
+            status_category = StatusCategory.DEGRADED
+
+        # Details surfaces the chart's target namespace; the sub-component reports how many
+        # Kubernetes objects the release tracks, rendered as "resources: <count>".
+        details = str(info.get("namespace", "") or scope_arg.value)
+        resource_count = self._count_manifest_resources(str(info.get("manifest", "")))
+        sub_component = json.dumps({"name": "resources", "status": str(resource_count)})
+
+        return {
+            "Status": StrResolvedInstructionResult(result_name="Status", value=status),
+            "StatusCategory": StrResolvedInstructionResult(result_name="StatusCategory", value=status_category),
+            "Details": StrResolvedInstructionResult(result_name="Details", value=details),
+            "SubComponent": StrResolvedInstructionResult(result_name="SubComponent", value=sub_component),
+        }
+
+    def _show(self, resolved_arguments: dict[str, ResolvedInstructionArgument]) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Getting helm release details: {name_arg.value}")
+        info = self._get_release_info(
+            name_arg.value, scope_arg.value, self._expected_cluster_config(resolved_arguments)
+        )
+
+        # Replace the rendered `manifest` — a huge YAML blob that dominates the output — with
+        # a placeholder (`helm get manifest` / `jd component reconcile` show it in full), and
+        # surface a per-kind breakdown of the managed objects instead, e.g.
+        # `resources: {"Service": 6, "Deployment": 5, ...}`.
+        resource = dict(info)
+        resource["resources"] = self._count_manifest_resources_by_kind(str(info.get("manifest", "")))
+        resource["manifest"] = "<redacted>"
+        # `config` holds user-supplied chart values, which can include plaintext secrets.
+        if "config" in resource:
+            resource["config"] = self._redact_secrets(resource["config"])
+
+        return {
+            "Name": StrResolvedInstructionResult(result_name="Name", value=name_arg.value),
+            "Resource": StrResolvedInstructionResult(result_name="Resource", value=json.dumps(resource)),
+        }
+
+    def _reconcile(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+        scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
+        expected_cluster_config = self._expected_cluster_config(resolved_arguments)
+
+        self.display_manager.info(f"Reconciling helm release: {name_arg.value}")
+        manifest = self._run(
+            "helm",
+            ["get", "manifest", name_arg.value, "--namespace", scope_arg.value],
+            expected_cluster_config=expected_cluster_config,
+        )
+        if not manifest.strip():
+            raise InstructionError(f"helm returned an empty manifest for release '{name_arg.value}'.")
+
+        # Re-apply the stored rendered manifest to re-assert desired state. Unlike
+        # `helm upgrade` (template-diff), `kubectl apply` acts against the live cluster,
+        # so objects deleted out-of-band are recreated.
+        #
+        # Do NOT pass `--namespace`: a release can ship objects into several namespaces
+        # (e.g. workspace-defaults renders into the shared namespace AND per-workspace
+        # namespaces), and each object in the stored manifest already carries its own
+        # namespace. Forcing one namespace makes kubectl reject objects that declare a
+        # different one.
+        applied = self._run(
+            "kubectl",
+            ["apply", "-f", "-"],
+            expected_cluster_config=expected_cluster_config,
+            stdin_input=manifest,
+        )
+
+        return {
+            "Output": StrResolvedInstructionResult(result_name="Output", value=applied.strip()),
+        }
+
+    def execute_instruction(
+        self,
+        instruction_name: str,
+        resolved_arguments: dict[str, ResolvedInstructionArgument],
+    ) -> dict[str, ResolvedInstructionResult]:
+        # Instruction names arrive fully qualified (e.g. "helm.reconcile"); strip the group prefix.
+        sub_instruction = instruction_name.split(".", 1)[1] if "." in instruction_name else instruction_name
+        try:
+            instruction = HelmInstruction(sub_instruction)
+        except ValueError:
+            raise InstructionNotFoundError(f"Unknown helm instruction: '{instruction_name}'") from None
+
+        if instruction == HelmInstruction.STATUS:
+            return self._status(resolved_arguments)
+        elif instruction == HelmInstruction.SHOW:
+            return self._show(resolved_arguments)
+        elif instruction == HelmInstruction.RECONCILE:
+            return self._reconcile(resolved_arguments)
+
+        raise InstructionNotFoundError(f"Unknown helm instruction: '{instruction_name}'")

--- a/libs/jupyter-deploy/jupyter_deploy/provider/instruction_runner_factory.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/instruction_runner_factory.py
@@ -38,27 +38,9 @@ class InstructionRunnerFactory:
             return runner
 
         if api_group == ApiGroup.K8S:
-            cluster_endpoint: str | None = None
-            cluster_ca_data: str | None = None
-            cluster_name: str | None = None
-            region: str | None = None
-            kubeconfig_path: str | None = None
-
-            try:
-                endpoint_def = outputs_handler.get_declared_output_def("cluster_endpoint", StrTemplateOutputDefinition)
-                ca_def = outputs_handler.get_declared_output_def("cluster_ca_certificate", StrTemplateOutputDefinition)
-                name_def = outputs_handler.get_declared_output_def("cluster_name", StrTemplateOutputDefinition)
-                region_def = outputs_handler.get_declared_output_def("aws_region", StrTemplateOutputDefinition)
-                cluster_endpoint = endpoint_def.value
-                cluster_ca_data = ca_def.value
-                cluster_name = name_def.value
-                region = region_def.value
-            except (NotImplementedError, KeyError, ValueError):
-                pass
-
-            if not all([cluster_endpoint, cluster_ca_data, cluster_name, region]):
-                kubeconfig_def = outputs_handler.get_declared_output_def("kubeconfig_path", StrTemplateOutputDefinition)
-                kubeconfig_path = kubeconfig_def.value
+            cluster_endpoint, cluster_ca_data, cluster_name, region, kubeconfig_path = (
+                InstructionRunnerFactory._resolve_cluster_credentials(outputs_handler)
+            )
 
             # do NOT move import to top level
             from jupyter_deploy.provider.k8s import k8s_runner
@@ -74,4 +56,54 @@ class InstructionRunnerFactory:
             InstructionRunnerFactory._api_group_runner_map[api_group] = runner
             return runner
 
+        if api_group == ApiGroup.HELM:
+            # helm/kubectl subprocesses authenticate via a kubeconfig (the path when set,
+            # else the ambient config set up by `jd cluster login`). The expected-cluster
+            # check, when a command declares it, is driven by an instruction argument.
+            _, _, _, _, kubeconfig_path = InstructionRunnerFactory._resolve_cluster_credentials(outputs_handler)
+
+            # do NOT move import to top level
+            from jupyter_deploy.provider.helm import helm_runner
+
+            runner = helm_runner.HelmApiRunner(
+                display_manager=display_manager,
+                kubeconfig_path=kubeconfig_path,
+            )
+            InstructionRunnerFactory._api_group_runner_map[api_group] = runner
+            return runner
+
         raise NotImplementedError(f"No runner implementation for API group: {api_group}")
+
+    @staticmethod
+    def _resolve_cluster_credentials(
+        outputs_handler: EngineOutputsHandler,
+    ) -> tuple[str | None, str | None, str | None, str | None, str | None]:
+        """Resolve EKS cluster credentials from template outputs.
+
+        Returns a tuple of (cluster_endpoint, cluster_ca_data, cluster_name, region,
+        kubeconfig_path). When the in-memory cluster credentials are incomplete, falls
+        back to the declared kubeconfig_path output.
+        """
+        cluster_endpoint: str | None = None
+        cluster_ca_data: str | None = None
+        cluster_name: str | None = None
+        region: str | None = None
+        kubeconfig_path: str | None = None
+
+        try:
+            endpoint_def = outputs_handler.get_declared_output_def("cluster_endpoint", StrTemplateOutputDefinition)
+            ca_def = outputs_handler.get_declared_output_def("cluster_ca_certificate", StrTemplateOutputDefinition)
+            name_def = outputs_handler.get_declared_output_def("cluster_name", StrTemplateOutputDefinition)
+            region_def = outputs_handler.get_declared_output_def("aws_region", StrTemplateOutputDefinition)
+            cluster_endpoint = endpoint_def.value
+            cluster_ca_data = ca_def.value
+            cluster_name = name_def.value
+            region = region_def.value
+        except (NotImplementedError, KeyError, ValueError):
+            pass
+
+        if not all([cluster_endpoint, cluster_ca_data, cluster_name, region]):
+            kubeconfig_def = outputs_handler.get_declared_output_def("kubeconfig_path", StrTemplateOutputDefinition)
+            kubeconfig_path = kubeconfig_def.value
+
+        return cluster_endpoint, cluster_ca_data, cluster_name, region, kubeconfig_path

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_batch_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_batch_runner.py
@@ -12,6 +12,7 @@ from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.enum import StatusCategory
 from jupyter_deploy.exceptions import InstructionError, InstructionNotFoundError
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
+from jupyter_deploy.provider.k8s.kubeconfig_verify import verify_kubeconfig_context
 from jupyter_deploy.provider.resolved_argdefs import (
     ResolvedInstructionArgument,
     StrResolvedInstructionArgument,
@@ -36,10 +37,13 @@ class K8sBatchInstruction(str, Enum):
 class K8sBatchRunner(InstructionRunner):
     """Runner class for Kubernetes Batch API instructions."""
 
-    def __init__(self, display_manager: DisplayManager, api_client: client.ApiClient) -> None:
+    def __init__(
+        self, display_manager: DisplayManager, api_client: client.ApiClient, kubeconfig_path: str | None = None
+    ) -> None:
         super().__init__(display_manager)
         self.batch_api = client.BatchV1Api(api_client)
         self.core_api = client.CoreV1Api(api_client)
+        self._kubeconfig_path = kubeconfig_path
 
     def _get_cronjob_status(
         self, resolved_arguments: dict[str, ResolvedInstructionArgument]
@@ -147,12 +151,18 @@ class K8sBatchRunner(InstructionRunner):
         scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
         query_arg = require_arg(resolved_arguments, "query", StrResolvedInstructionArgument)
         extra_arg = retrieve_optional_arg(resolved_arguments, "extra", StrResolvedInstructionArgument, "")
+        expected_cluster_config = retrieve_optional_arg(
+            resolved_arguments, "expected_cluster_config", StrResolvedInstructionArgument, ""
+        ).value
 
         self.display_manager.info(f"Getting logs for cronjob: {name_arg.value}")
 
         pod_name = self._resolve_cronjob_pod_name(name_arg.value, scope_arg.value, query_arg.value)
 
+        verify_kubeconfig_context(expected_cluster_config or None, self._kubeconfig_path)
         kubectl_cmd = ["kubectl", "logs", pod_name, "--namespace", scope_arg.value]
+        if self._kubeconfig_path:
+            kubectl_cmd.extend(["--kubeconfig", self._kubeconfig_path])
         if extra_arg.value:
             kubectl_cmd.extend(extra_arg.value.split())
 

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_core_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_core_runner.py
@@ -15,6 +15,7 @@ from jupyter_deploy.exceptions import (
     InteractiveSessionTimeoutError,
 )
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
+from jupyter_deploy.provider.k8s.kubeconfig_verify import verify_kubeconfig_context
 from jupyter_deploy.provider.resolved_argdefs import (
     ResolvedInstructionArgument,
     StrResolvedInstructionArgument,
@@ -134,12 +135,16 @@ class K8sCoreRunner(InstructionRunner):
         scope_arg = require_arg(resolved_arguments, "scope", StrResolvedInstructionArgument)
         container_arg = retrieve_optional_arg(resolved_arguments, "container", StrResolvedInstructionArgument, "")
         extra_arg = retrieve_optional_arg(resolved_arguments, "extra", StrResolvedInstructionArgument, "")
+        expected_cluster_config = retrieve_optional_arg(
+            resolved_arguments, "expected_cluster_config", StrResolvedInstructionArgument, ""
+        ).value
 
         self.display_manager.info(f"Getting logs for deployment {name_arg.value} in namespace: {scope_arg.value}")
 
         pod_name = self._resolve_pod_name(name_arg.value, scope_arg.value)
         container = container_arg.value if container_arg.value and container_arg.value != "default" else None
 
+        verify_kubeconfig_context(expected_cluster_config or None, self._kubeconfig_path)
         kubectl_cmd = ["kubectl", "logs", pod_name, "--namespace", scope_arg.value]
         if self._kubeconfig_path:
             kubectl_cmd.extend(["--kubeconfig", self._kubeconfig_path])
@@ -215,6 +220,9 @@ class K8sCoreRunner(InstructionRunner):
             resolved_arguments, "deployment_name", StrResolvedInstructionArgument, ""
         )
         name_arg = retrieve_optional_arg(resolved_arguments, "name", StrResolvedInstructionArgument, "")
+        expected_cluster_config = retrieve_optional_arg(
+            resolved_arguments, "expected_cluster_config", StrResolvedInstructionArgument, ""
+        ).value
 
         if deployment_name_arg.value:
             pod_name = self._resolve_pod_name(deployment_name_arg.value, scope_arg.value)
@@ -225,6 +233,7 @@ class K8sCoreRunner(InstructionRunner):
 
         container = container_arg.value if container_arg.value and container_arg.value != "default" else None
 
+        verify_kubeconfig_context(expected_cluster_config or None, self._kubeconfig_path)
         kubectl_cmd = ["kubectl", "exec", "-it", pod_name, "-n", scope_arg.value]
         if self._kubeconfig_path:
             kubectl_cmd.extend(["--kubeconfig", self._kubeconfig_path])

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_runner.py
@@ -90,7 +90,9 @@ class K8sApiRunner(InstructionRunner):
             self._service_runners[service_name] = service_runner
             return service_runner
         elif service_name == K8sService.BATCH:
-            service_runner = K8sBatchRunner(self.display_manager, api_client=api_client)
+            service_runner = K8sBatchRunner(
+                self.display_manager, api_client=api_client, kubeconfig_path=self.kubeconfig_path
+            )
             self._service_runners[service_name] = service_runner
             return service_runner
 

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/kubeconfig_verify.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/kubeconfig_verify.py
@@ -1,0 +1,41 @@
+import subprocess
+
+from jupyter_deploy import cmd_utils
+from jupyter_deploy.exceptions import InstructionError, InvalidKubernetesClusterTargetError
+
+
+def verify_kubeconfig_context(expected_cluster_config: str | None, kubeconfig_path: str | None = None) -> None:
+    """Guard against acting on the wrong cluster before shelling out to kubectl/helm.
+
+    The in-memory Kubernetes client is auth-pinned to a specific cluster, but `kubectl`
+    and `helm` subprocesses trust whatever the kubeconfig's current-context points at.
+    When a command declares an `expected_cluster_config` argument (e.g. the cluster ARN,
+    which `aws eks update-kubeconfig` uses as the context name), this asserts the active
+    context matches it exactly before the subprocess runs.
+
+    When `expected_cluster_config` is empty/None the check is skipped — commands that do
+    not declare it keep their previous behavior (backward compatible).
+
+    Raises:
+        InvalidKubernetesClusterTargetError: If the active context does not match the expected cluster.
+        InstructionError: If the current context cannot be read.
+    """
+    if not expected_cluster_config:
+        return
+
+    cmds = ["kubectl", "config", "current-context"]
+    if kubeconfig_path:
+        cmds += ["--kubeconfig", kubeconfig_path]
+
+    try:
+        current_context = cmd_utils.run_cmd_and_capture_output(cmds).strip()
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip() if e.stderr else ""
+        raise InstructionError(
+            f"Could not read the current kubectl context to verify the target cluster: {stderr}"
+        ) from None
+
+    if current_context != expected_cluster_config:
+        raise InvalidKubernetesClusterTargetError(
+            current_context=current_context, expected_cluster_config=expected_cluster_config
+        )

--- a/libs/jupyter-deploy/jupyter_deploy/verify_utils.py
+++ b/libs/jupyter-deploy/jupyter_deploy/verify_utils.py
@@ -55,6 +55,15 @@ def _check_jq_installation() -> None:
     )
 
 
+def _check_helm_installation() -> None:
+    """Shell out to verify `helm` install, raise ToolRequiredError if not found."""
+    return _check_installation(
+        tool_name="helm",
+        installation_url="https://helm.sh/docs/intro/install/",
+        version_cmds=["version", "--short"],
+    )
+
+
 def _check_kubectl_installation() -> None:
     """Shell out to verify `kubectl` install, raise ToolRequiredError if not found."""
     return _check_installation(
@@ -75,6 +84,7 @@ def _check_yq_installation() -> None:
 _TOOL_VERIFICATION_FN_MAP: dict[JupyterDeployTool, Callable[[], None]] = {
     JupyterDeployTool.AWS_CLI: _check_aws_cli_installation,
     JupyterDeployTool.AWS_SSM_PLUGIN: _check_ssm_plugin_installation,
+    JupyterDeployTool.HELM: _check_helm_installation,
     JupyterDeployTool.JQ: _check_jq_installation,
     JupyterDeployTool.KUBECTL: _check_kubectl_installation,
     JupyterDeployTool.TERRAFORM: _check_terraform_installation,

--- a/libs/jupyter-deploy/tests/unit/cli/test_component_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_component_app.py
@@ -15,7 +15,7 @@ class TestComponentApp(unittest.TestCase):
         result = runner.invoke(component_app, ["--help"])
 
         self.assertEqual(result.exit_code, 0)
-        for cmd in ["list", "status", "show", "logs", "restart", "trigger"]:
+        for cmd in ["list", "status", "show", "logs", "restart", "trigger", "reconcile"]:
             self.assertTrue(result.stdout.index(cmd) > 0, f"missing command: {cmd}")
 
     def test_no_arg_defaults_to_help(self) -> None:
@@ -305,8 +305,6 @@ class TestComponentRestartCommand(unittest.TestCase):
         mock_handler.restart_component.assert_called_once_with(name="traefik")
         self.assertIn("Restarted", result.stdout)
 
-
-class TestComponentRestartPathCommand(unittest.TestCase):
     @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
     @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_restart_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
@@ -317,6 +315,41 @@ class TestComponentRestartPathCommand(unittest.TestCase):
 
         runner = CliRunner()
         result = runner.invoke(component_app, ["restart", "--name", "traefik", "--path", "/my/project"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_project_dir.assert_called_once_with(Path("/my/project"))
+
+
+class TestComponentReconcileCommand(unittest.TestCase):
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_reconcile_calls_reconcile_component(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.reconcile_component.return_value = "service/foo configured"
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(component_app, ["reconcile", "--name", "workspace-router-chart"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_handler.reconcile_component.assert_called_once_with(name="workspace-router-chart")
+        self.assertIn("Reconciled", result.stdout)
+
+    @patch("jupyter_deploy.handlers.resource.component_handler.ComponentHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_reconcile_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
+        mock_project_dir.return_value.__enter__ = Mock(return_value=None)
+        mock_project_dir.return_value.__exit__ = Mock(return_value=None)
+        mock_handler: Mock = Mock()
+        mock_handler.reconcile_component.return_value = ""
+        mock_handler_class.return_value = mock_handler
+
+        runner = CliRunner()
+        result = runner.invoke(
+            component_app, ["reconcile", "--name", "workspace-router-chart", "--path", "/my/project"]
+        )
 
         self.assertEqual(result.exit_code, 0)
         mock_project_dir.assert_called_once_with(Path("/my/project"))

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_component_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_component_handler.py
@@ -34,6 +34,21 @@ def _mock_component_cronjob() -> JupyterDeployComponentDefinitionV1:
     )
 
 
+def _mock_component_helmrelease() -> JupyterDeployComponentDefinitionV1:
+    return JupyterDeployComponentDefinitionV1(
+        **{  # type: ignore[arg-type]
+            "type": "HelmRelease",
+            "scope": "workspace_router_namespace",
+            "resource-name": "jupyter-k8s-aws-oidc",
+            "verbs": {
+                "status": {"method": "helm.status"},
+                "show": {"method": "helm.show"},
+                "reconcile": {"method": "helm.reconcile"},
+            },
+        }
+    )
+
+
 def _mock_component_custom_resource() -> JupyterDeployComponentDefinitionV1:
     return JupyterDeployComponentDefinitionV1(
         **{  # type: ignore[arg-type]
@@ -723,3 +738,73 @@ class TestComponentHandlerTriggerComponent(unittest.TestCase):
             handler = ComponentHandler(display_manager=Mock())
             with self.assertRaises(RuntimeError):
                 handler.trigger_component("jwt-rotator")
+
+
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
+@patch("jupyter_deploy.handlers.resource.component_handler.tf_outputs.TerraformOutputsHandler")
+@patch("jupyter_deploy.handlers.base_project_handler.retrieve_project_manifest")
+class TestComponentHandlerReconcileComponent(unittest.TestCase):
+    def test_calls_reconcile_command_and_returns_output(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_helmrelease()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        mock_runner: Mock = Mock()
+        mock_runner.get_result_value_with_fallback.return_value = "service/foo configured"
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value = mock_runner
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            result = handler.reconcile_component("workspace-router-chart")
+
+        self.assertEqual(result, "service/foo configured")
+        manifest.get_command.assert_called_once_with("component.helmrelease.reconcile")
+        mock_runner.run_command_sequence.assert_called_once()
+        cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
+        # resource-name overrides the component key when building the release name
+        self.assertEqual(cli_paramdefs["name"].value, "jupyter-k8s-aws-oidc")
+        self.assertEqual(cli_paramdefs["scope"].value, "router-ns")
+
+    def test_raises_invalid_verb_for_reconcile_on_deployment(
+        self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
+    ) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_deployment()
+        mock_manifest_fn.return_value = manifest
+
+        handler = ComponentHandler(display_manager=Mock())
+
+        with self.assertRaises(InvalidComponentVerbError) as ctx:
+            handler.reconcile_component("traefik")
+
+        self.assertEqual(ctx.exception.verb, "reconcile")
+        self.assertEqual(ctx.exception.component_type, "Deployment")
+
+    def test_error_bubbles_up(self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock) -> None:
+        manifest: Mock = Mock()
+        manifest.get_engine.return_value = "terraform"
+        manifest.template.engine = "terraform"
+        manifest.get_component.return_value = _mock_component_helmrelease()
+        mock_manifest_fn.return_value = manifest
+
+        mock_output_handler: Mock = mock_outputs.return_value
+        mock_output_handler.get_full_project_outputs.return_value = _NS_OUTPUTS
+
+        with patch("jupyter_deploy.handlers.resource.component_handler.cmd_runner.ManifestCommandRunner") as mock_cmd:
+            mock_cmd.return_value.run_command_sequence.side_effect = RuntimeError("API failure")
+            manifest.get_command.return_value = Mock()
+
+            handler = ComponentHandler(display_manager=Mock())
+            with self.assertRaises(RuntimeError):
+                handler.reconcile_component("workspace-router-chart")

--- a/libs/jupyter-deploy/tests/unit/provider/helm/test_helm_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/helm/test_helm_runner.py
@@ -1,0 +1,319 @@
+import json
+import subprocess
+import unittest
+from unittest.mock import Mock, patch
+
+from jupyter_deploy.enum import StatusCategory
+from jupyter_deploy.exceptions import (
+    InstructionError,
+    InstructionNotFoundError,
+    InvalidKubernetesClusterTargetError,
+    ResourceNotFoundError,
+)
+from jupyter_deploy.provider.helm.helm_runner import HelmApiRunner
+from jupyter_deploy.provider.resolved_argdefs import StrResolvedInstructionArgument
+
+_RUN = "jupyter_deploy.provider.helm.helm_runner.cmd_utils.run_cmd_and_capture_output"
+
+
+def _build_args(
+    name: str = "workspace-router", scope: str = "jupyter-router", expected_cluster_config: str = ""
+) -> dict:
+    args = {
+        "name": StrResolvedInstructionArgument(argument_name="name", value=name),
+        "scope": StrResolvedInstructionArgument(argument_name="scope", value=scope),
+    }
+    if expected_cluster_config:
+        args["expected_cluster_config"] = StrResolvedInstructionArgument(
+            argument_name="expected_cluster_config", value=expected_cluster_config
+        )
+    return args
+
+
+def _make_runner() -> HelmApiRunner:
+    return HelmApiRunner(display_manager=Mock(), kubeconfig_path="/tmp/kubeconfig")
+
+
+class TestHelmApiRunnerStatus(unittest.TestCase):
+    @patch(_RUN)
+    def test_deployed_is_healthy(self, mock_run: Mock) -> None:
+        mock_run.return_value = json.dumps({"info": {"status": "deployed"}, "version": 3})
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.status", _build_args())
+
+        self.assertEqual(result["Status"].value, "deployed")
+        self.assertEqual(result["StatusCategory"].value, StatusCategory.HEALTHY)
+        # Details is the target namespace; with no `namespace` in the payload it falls back to scope.
+        self.assertEqual(result["Details"].value, "jupyter-router")
+
+    @patch(_RUN)
+    def test_pending_is_in_progress(self, mock_run: Mock) -> None:
+        mock_run.return_value = json.dumps({"info": {"status": "pending-upgrade"}, "version": 4})
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.status", _build_args())
+
+        self.assertEqual(result["StatusCategory"].value, StatusCategory.IN_PROGRESS)
+
+    @patch(_RUN)
+    def test_failed_is_degraded(self, mock_run: Mock) -> None:
+        mock_run.return_value = json.dumps({"info": {"status": "failed"}, "version": 1})
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.status", _build_args())
+
+        self.assertEqual(result["StatusCategory"].value, StatusCategory.DEGRADED)
+
+    @patch(_RUN)
+    def test_release_not_found_raises(self, mock_run: Mock) -> None:
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["helm"], stderr="Error: release: not found"
+        )
+        runner = _make_runner()
+
+        with self.assertRaises(ResourceNotFoundError):
+            runner.execute_instruction("helm.status", _build_args())
+
+
+class TestHelmApiRunnerStatusDetailsAndSubComponent(unittest.TestCase):
+    @patch(_RUN)
+    def test_details_is_namespace_and_sub_component_is_resource_count(self, mock_run: Mock) -> None:
+        manifest = "\n---\n".join(
+            [
+                "apiVersion: v1\nkind: Service\nmetadata:\n  name: traefik",
+                "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: traefik",
+                "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: cfg",
+            ]
+        )
+        mock_run.return_value = json.dumps(
+            {"info": {"status": "deployed"}, "version": 1, "namespace": "jupyter-k8s-router", "manifest": manifest}
+        )
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.status", _build_args())
+
+        # Details carries the target namespace (no longer the revision).
+        self.assertEqual(result["Details"].value, "jupyter-k8s-router")
+        # SubComponent renders as "resources: <count>".
+        sub = json.loads(result["SubComponent"].value)
+        self.assertEqual(sub["name"], "resources")
+        self.assertEqual(sub["status"], "3")
+
+    @patch(_RUN)
+    def test_ignores_empty_and_comment_manifest_docs(self, mock_run: Mock) -> None:
+        # helm status leaves blank / comment-only docs between objects; they must not count.
+        manifest = "\n---\n".join(
+            [
+                "# Source: chart/templates/svc.yaml\napiVersion: v1\nkind: Service\nmetadata:\n  name: a",
+                "",
+                "# just a comment, no object",
+            ]
+        )
+        mock_run.return_value = json.dumps(
+            {"info": {"status": "deployed"}, "version": 1, "namespace": "ns", "manifest": manifest}
+        )
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.status", _build_args())
+
+        sub = json.loads(result["SubComponent"].value)
+        self.assertEqual(sub["status"], "1")
+
+    @patch(_RUN)
+    def test_zero_resources_when_no_manifest(self, mock_run: Mock) -> None:
+        mock_run.return_value = json.dumps({"info": {"status": "deployed"}, "version": 1, "namespace": "ns"})
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.status", _build_args())
+
+        sub = json.loads(result["SubComponent"].value)
+        self.assertEqual(sub["status"], "0")
+
+    @patch(_RUN)
+    def test_details_falls_back_to_scope_when_namespace_absent(self, mock_run: Mock) -> None:
+        # If helm status omits `namespace`, Details uses the scope (target namespace) passed in.
+        mock_run.return_value = json.dumps({"info": {"status": "deployed"}, "version": 1, "manifest": ""})
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.status", _build_args(scope="my-namespace"))
+
+        self.assertEqual(result["Details"].value, "my-namespace")
+
+
+class TestHelmApiRunnerShow(unittest.TestCase):
+    @patch(_RUN)
+    def test_returns_resource_json(self, mock_run: Mock) -> None:
+        info = {"info": {"status": "deployed"}, "version": 2}
+        mock_run.return_value = json.dumps(info)
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.show", _build_args(name="jupyter-k8s"))
+
+        self.assertEqual(result["Name"].value, "jupyter-k8s")
+        resource = json.loads(result["Resource"].value)
+        # Original fields preserved; resources breakdown derived from the (absent) manifest.
+        self.assertEqual(resource["info"], {"status": "deployed"})
+        self.assertEqual(resource["version"], 2)
+        self.assertEqual(resource["resources"], {})
+
+    @patch(_RUN)
+    def test_redacts_manifest_but_keeps_resource_breakdown(self, mock_run: Mock) -> None:
+        # The rendered manifest is a huge YAML blob; show replaces it with a placeholder
+        # but surfaces a per-kind count.
+        manifest = "\n---\n".join(
+            [
+                "apiVersion: v1\nkind: Service\nmetadata:\n  name: traefik",
+                "apiVersion: v1\nkind: Service\nmetadata:\n  name: web",
+                "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: traefik",
+            ]
+        )
+        info = {
+            "info": {"status": "deployed"},
+            "version": 2,
+            "namespace": "jupyter-k8s-router",
+            "manifest": manifest,
+        }
+        mock_run.return_value = json.dumps(info)
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.show", _build_args(name="jupyter-k8s"))
+
+        resource = json.loads(result["Resource"].value)
+        self.assertEqual(resource["manifest"], "<redacted>")
+        self.assertEqual(resource["resources"], {"Service": 2, "Deployment": 1})
+        self.assertEqual(resource["namespace"], "jupyter-k8s-router")
+        self.assertEqual(resource["info"], {"status": "deployed"})
+
+    @patch(_RUN)
+    def test_redacts_secret_like_config_keys(self, mock_run: Mock) -> None:
+        info = {
+            "info": {"status": "deployed"},
+            "version": 1,
+            "manifest": "",
+            "config": {
+                "domain": "example.com",
+                "github": {"clientId": "Ov23li", "clientSecret": "supersecret"},
+                "oauth2Proxy": {"cookieSecret": "cookie-val"},
+                "dex": {"oauth2ProxyClientSecret": "dex-val"},
+                "webApp": {"clusterAccess": {"caCertBase64": "not-a-secret", "apiKey": "k-val"}},
+            },
+        }
+        mock_run.return_value = json.dumps(info)
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.show", _build_args(name="jupyter-k8s"))
+
+        cfg = json.loads(result["Resource"].value)["config"]
+        # secret-like keys redacted (nested, various suffixes)
+        self.assertEqual(cfg["github"]["clientSecret"], "****")
+        self.assertEqual(cfg["oauth2Proxy"]["cookieSecret"], "****")
+        self.assertEqual(cfg["dex"]["oauth2ProxyClientSecret"], "****")
+        self.assertEqual(cfg["webApp"]["clusterAccess"]["apiKey"], "****")
+        # non-secret keys preserved
+        self.assertEqual(cfg["domain"], "example.com")
+        self.assertEqual(cfg["github"]["clientId"], "Ov23li")
+        self.assertEqual(cfg["webApp"]["clusterAccess"]["caCertBase64"], "not-a-secret")
+
+
+class TestHelmApiRunnerReconcile(unittest.TestCase):
+    @patch(_RUN)
+    def test_pipes_manifest_to_kubectl_apply(self, mock_run: Mock) -> None:
+        manifest = "apiVersion: v1\nkind: Service\n"
+        mock_run.side_effect = [manifest, "service/foo configured"]
+        runner = _make_runner()
+
+        result = runner.execute_instruction("helm.reconcile", _build_args())
+
+        self.assertEqual(result["Output"].value, "service/foo configured")
+        # first call fetches the manifest via helm
+        helm_cmd = mock_run.call_args_list[0].args[0]
+        self.assertEqual(helm_cmd[:1], ["helm"])
+        self.assertIn("manifest", helm_cmd)
+        # second call applies it via kubectl with the manifest on stdin
+        apply_call = mock_run.call_args_list[1]
+        self.assertEqual(apply_call.args[0][:1], ["kubectl"])
+        self.assertIn("apply", apply_call.args[0])
+        self.assertEqual(apply_call.kwargs["stdin_input"], manifest)
+        # apply must NOT force a namespace: the manifest can span several namespaces and
+        # each object carries its own; forcing one makes kubectl reject the others.
+        self.assertNotIn("--namespace", apply_call.args[0])
+        self.assertNotIn("-n", apply_call.args[0])
+
+    @patch(_RUN)
+    def test_empty_manifest_raises(self, mock_run: Mock) -> None:
+        mock_run.return_value = "   \n"
+        runner = _make_runner()
+
+        with self.assertRaises(InstructionError):
+            runner.execute_instruction("helm.reconcile", _build_args())
+
+
+class TestHelmApiRunnerKubeconfig(unittest.TestCase):
+    @patch(_RUN)
+    def test_passes_kubeconfig_flag_when_path_set(self, mock_run: Mock) -> None:
+        mock_run.return_value = json.dumps({"info": {"status": "deployed"}, "version": 1})
+        runner = HelmApiRunner(display_manager=Mock(), kubeconfig_path="/tmp/kubeconfig")
+
+        runner.execute_instruction("helm.status", _build_args())
+
+        cmd = mock_run.call_args.args[0]
+        self.assertEqual(cmd[:3], ["helm", "--kubeconfig", "/tmp/kubeconfig"])
+
+    @patch(_RUN)
+    def test_uses_ambient_config_when_no_path(self, mock_run: Mock) -> None:
+        # Mirrors the k8s runner's kubectl subprocesses: no path -> rely on ambient kubeconfig.
+        mock_run.return_value = json.dumps({"info": {"status": "deployed"}, "version": 1})
+        runner = HelmApiRunner(display_manager=Mock())
+
+        runner.execute_instruction("helm.status", _build_args())
+
+        cmd = mock_run.call_args.args[0]
+        self.assertNotIn("--kubeconfig", cmd)
+        self.assertEqual(cmd[0], "helm")
+
+
+_ARN = "arn:aws:eks:us-west-2:1:cluster/jupyter-deploy-eks-abcd1234"
+
+
+class TestHelmApiRunnerContextVerification(unittest.TestCase):
+    @patch(_RUN)
+    def test_verifies_context_before_running_when_declared(self, mock_run: Mock) -> None:
+        # First call is the context check (kubectl config current-context); it matches,
+        # then the helm status call returns the release info.
+        mock_run.side_effect = [_ARN, json.dumps({"info": {"status": "deployed"}, "version": 1})]
+        runner = _make_runner()
+
+        runner.execute_instruction("helm.status", _build_args(expected_cluster_config=_ARN))
+
+        first_cmd = mock_run.call_args_list[0].args[0]
+        self.assertEqual(first_cmd[:3], ["kubectl", "config", "current-context"])
+
+    @patch(_RUN)
+    def test_aborts_on_wrong_cluster(self, mock_run: Mock) -> None:
+        mock_run.return_value = "arn:aws:eks:us-west-2:1:cluster/some-other-cluster"
+        runner = _make_runner()
+
+        with self.assertRaises(InvalidKubernetesClusterTargetError):
+            runner.execute_instruction("helm.reconcile", _build_args(expected_cluster_config=_ARN))
+        # only the context check ran; no helm/kubectl mutation was attempted
+        self.assertEqual(mock_run.call_count, 1)
+
+    @patch(_RUN)
+    def test_skips_verification_when_not_declared(self, mock_run: Mock) -> None:
+        # No expected_cluster_config arg -> no context check, straight to helm.
+        mock_run.return_value = json.dumps({"info": {"status": "deployed"}, "version": 1})
+        runner = _make_runner()
+
+        runner.execute_instruction("helm.status", _build_args())
+
+        first_cmd = mock_run.call_args_list[0].args[0]
+        self.assertEqual(first_cmd[0], "helm")
+
+
+class TestHelmApiRunnerDispatch(unittest.TestCase):
+    def test_unknown_instruction_raises(self) -> None:
+        runner = _make_runner()
+
+        with self.assertRaises(InstructionNotFoundError):
+            runner.execute_instruction("helm.rollback", _build_args())

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_runner.py
@@ -152,7 +152,9 @@ class TestK8sApiRunner(unittest.TestCase):
             instruction_name="k8s.batch.get-cronjob-status", resolved_arguments=resolved_args
         )
 
-        mock_batch_runner_class.assert_called_once_with(ANY, api_client=mock_api_client)
+        mock_batch_runner_class.assert_called_once_with(
+            ANY, api_client=mock_api_client, kubeconfig_path="/tmp/kubeconfig"
+        )
         mock_batch_runner.execute_instruction.assert_called_once_with(
             instruction_name="get-cronjob-status", resolved_arguments=resolved_args
         )

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_kubeconfig_verify.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_kubeconfig_verify.py
@@ -1,0 +1,58 @@
+import subprocess
+import unittest
+from unittest.mock import Mock, patch
+
+from jupyter_deploy.exceptions import InstructionError, InvalidKubernetesClusterTargetError
+from jupyter_deploy.provider.k8s.kubeconfig_verify import verify_kubeconfig_context
+
+_RUN = "jupyter_deploy.provider.k8s.kubeconfig_verify.cmd_utils.run_cmd_and_capture_output"
+_ARN = "arn:aws:eks:us-west-2:123:cluster/jupyter-deploy-eks-abcd1234"
+
+
+class TestVerifyKubeconfigContext(unittest.TestCase):
+    @patch(_RUN)
+    def test_passes_when_context_matches(self, mock_run: Mock) -> None:
+        mock_run.return_value = f"{_ARN}\n"
+
+        # should not raise
+        verify_kubeconfig_context(_ARN)
+
+        cmd = mock_run.call_args.args[0]
+        self.assertEqual(cmd, ["kubectl", "config", "current-context"])
+
+    @patch(_RUN)
+    def test_passes_kubeconfig_flag_when_path_set(self, mock_run: Mock) -> None:
+        mock_run.return_value = _ARN
+
+        verify_kubeconfig_context(_ARN, kubeconfig_path="/tmp/kc")
+
+        cmd = mock_run.call_args.args[0]
+        self.assertEqual(cmd, ["kubectl", "config", "current-context", "--kubeconfig", "/tmp/kc"])
+
+    @patch(_RUN)
+    def test_raises_invalid_target_on_mismatch(self, mock_run: Mock) -> None:
+        mock_run.return_value = "arn:aws:eks:us-west-2:123:cluster/some-other-cluster"
+
+        with self.assertRaises(InvalidKubernetesClusterTargetError) as ctx:
+            verify_kubeconfig_context(_ARN)
+
+        self.assertEqual(ctx.exception.expected_cluster_config, _ARN)
+        self.assertEqual(ctx.exception.current_context, "arn:aws:eks:us-west-2:123:cluster/some-other-cluster")
+
+    @patch(_RUN)
+    def test_raises_instruction_error_when_context_unreadable(self, mock_run: Mock) -> None:
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=1, cmd=["kubectl"], stderr="error: current-context is not set"
+        )
+
+        with self.assertRaises(InstructionError) as ctx:
+            verify_kubeconfig_context(_ARN)
+        self.assertNotIsInstance(ctx.exception, InvalidKubernetesClusterTargetError)
+
+    @patch(_RUN)
+    def test_skips_when_expected_config_empty(self, mock_run: Mock) -> None:
+        # No expected config declared -> skip (backward compatible).
+        verify_kubeconfig_context(None)
+        verify_kubeconfig_context("")
+
+        mock_run.assert_not_called()

--- a/libs/jupyter-deploy/tests/unit/provider/test_instruction_runner_factory.py
+++ b/libs/jupyter-deploy/tests/unit/provider/test_instruction_runner_factory.py
@@ -31,6 +31,14 @@ class TestInstructionRunnerFactory(unittest.TestCase):
         self.mock_k8s_runner_module = Mock()
         self.mock_k8s_runner_module.K8sApiRunner = self.mock_k8s_api_runner_cls
 
+        # helm provider module mocks
+        self.mock_helm_api_runner = Mock(spec=InstructionRunner)
+        self.mock_helm_api_runner_cls = Mock()
+        self.mock_helm_api_runner_cls.return_value = self.mock_helm_api_runner
+
+        self.mock_helm_runner_module = Mock()
+        self.mock_helm_runner_module.HelmApiRunner = self.mock_helm_api_runner_cls
+
         # outputs handler mock
         self.mock_outputs_handler = Mock(spec=EngineOutputsHandler)
         self.mock_str_template_output_def = Mock(spec=StrTemplateOutputDefinition)
@@ -55,6 +63,7 @@ class TestInstructionRunnerFactory(unittest.TestCase):
 
         aws_mod = "jupyter_deploy.provider.aws.aws_runner"
         k8s_mod = "jupyter_deploy.provider.k8s.k8s_runner"
+        helm_mod = "jupyter_deploy.provider.helm.helm_runner"
 
         if aws_mod not in sys.modules:
             modules_to_patch[aws_mod] = self.mock_aws_runner_module
@@ -65,6 +74,11 @@ class TestInstructionRunnerFactory(unittest.TestCase):
             modules_to_patch[k8s_mod] = self.mock_k8s_runner_module
         else:
             attrs_to_patch[k8s_mod] = self.mock_k8s_runner_module
+
+        if helm_mod not in sys.modules:
+            modules_to_patch[helm_mod] = self.mock_helm_runner_module
+        else:
+            attrs_to_patch[helm_mod] = self.mock_helm_runner_module
 
         with patch.dict(sys.modules, modules_to_patch):
             patches = [patch(key, val) for key, val in attrs_to_patch.items()]
@@ -237,6 +251,91 @@ class TestInstructionRunnerFactory(unittest.TestCase):
                 cluster_name=None,
                 region=None,
             )
+
+    def test_imports_helm_provider_with_eks_outputs_and_return_it(self) -> None:
+        # With full in-memory EKS creds the kubeconfig fallback is not read, so the helm
+        # runner gets kubeconfig_path=None and relies on the ambient kubeconfig.
+        mock_outputs_handler = Mock(spec=EngineOutputsHandler)
+
+        def _mock_get_declared(name: str, value_type: type) -> Mock:
+            values = {
+                "cluster_endpoint": "https://example.eks.amazonaws.com",
+                "cluster_ca_certificate": "Y2VydA==",
+                "cluster_name": "my-cluster",
+                "aws_region": "us-west-2",
+            }
+            mock_def = Mock(spec=StrTemplateOutputDefinition)
+            mock_def.value = values[name]
+            return mock_def
+
+        mock_outputs_handler.get_declared_output_def.side_effect = _mock_get_declared
+
+        with self.patch_provider_runner_modules():
+            importlib.reload(instruction_runner_factory)
+            InstructionRunnerFactory = instruction_runner_factory.InstructionRunnerFactory
+            InstructionRunnerFactory._api_group_runner_map = {}
+
+            runner = InstructionRunnerFactory.get_provider_instruction_runner(
+                "helm", mock_outputs_handler, NullDisplay()
+            )
+
+            self.assertEqual(self.mock_helm_api_runner, runner)
+            self.assertEqual({ApiGroup.HELM: self.mock_helm_api_runner}, InstructionRunnerFactory._api_group_runner_map)
+            # helm runner only takes display_manager + kubeconfig_path (no in-memory creds).
+            self.mock_helm_api_runner_cls.assert_called_once_with(display_manager=ANY, kubeconfig_path=None)
+
+    def test_imports_helm_provider_falls_back_to_kubeconfig(self) -> None:
+        mock_outputs_handler = Mock(spec=EngineOutputsHandler)
+
+        def _mock_get_declared(name: str, value_type: type) -> Mock:
+            if name == "kubeconfig_path":
+                mock_def = Mock(spec=StrTemplateOutputDefinition)
+                mock_def.value = "/tmp/kubeconfig"
+                return mock_def
+            raise NotImplementedError(f"No value: {name}")
+
+        mock_outputs_handler.get_declared_output_def.side_effect = _mock_get_declared
+
+        with self.patch_provider_runner_modules():
+            importlib.reload(instruction_runner_factory)
+            InstructionRunnerFactory = instruction_runner_factory.InstructionRunnerFactory
+            InstructionRunnerFactory._api_group_runner_map = {}
+
+            runner = InstructionRunnerFactory.get_provider_instruction_runner(
+                "helm", mock_outputs_handler, NullDisplay()
+            )
+
+            self.assertEqual(self.mock_helm_api_runner, runner)
+            self.mock_helm_api_runner_cls.assert_called_once_with(
+                display_manager=ANY, kubeconfig_path="/tmp/kubeconfig"
+            )
+
+    def test_recycle_helm_runner_provider_for_same_output_handler(self) -> None:
+        mock_outputs_handler = Mock(spec=EngineOutputsHandler)
+
+        def _mock_get_declared(name: str, value_type: type) -> Mock:
+            if name == "kubeconfig_path":
+                mock_def = Mock(spec=StrTemplateOutputDefinition)
+                mock_def.value = "/tmp/kubeconfig"
+                return mock_def
+            raise NotImplementedError(f"No value: {name}")
+
+        mock_outputs_handler.get_declared_output_def.side_effect = _mock_get_declared
+
+        with self.patch_provider_runner_modules():
+            importlib.reload(instruction_runner_factory)
+            InstructionRunnerFactory = instruction_runner_factory.InstructionRunnerFactory
+            InstructionRunnerFactory._api_group_runner_map = {}
+
+            first = InstructionRunnerFactory.get_provider_instruction_runner(
+                "helm", mock_outputs_handler, NullDisplay()
+            )
+            second = InstructionRunnerFactory.get_provider_instruction_runner(
+                "helm", mock_outputs_handler, NullDisplay()
+            )
+
+            self.assertEqual(first, second)
+            self.mock_helm_api_runner_cls.assert_called_once()
 
     def test_raise_not_value_error_on_unmatched_provider(self) -> None:
         mock_outputs_handler = Mock(spec=EngineOutputsHandler)

--- a/libs/jupyter-deploy/tests/unit/test_cmd_utils.py
+++ b/libs/jupyter-deploy/tests/unit/test_cmd_utils.py
@@ -162,6 +162,18 @@ class TestRunCmdAndCaptureOutput(unittest.TestCase):
         run_cmd_and_capture_output(["sudo", "whoami"])
         mock_run.assert_called_once_with(
             ["sudo", "whoami"],
+            input=None,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_passes_stdin_input(self, mock_run: Mock) -> None:
+        run_cmd_and_capture_output(["kubectl", "apply", "-f", "-"], stdin_input="manifest-body")
+        mock_run.assert_called_once_with(
+            ["kubectl", "apply", "-f", "-"],
+            input="manifest-body",
             capture_output=True,
             text=True,
             check=True,
@@ -194,6 +206,7 @@ class TestRunCmdAndCaptureOutput(unittest.TestCase):
         # Verify subprocess.run was called with correct arguments
         mock_run.assert_called_once_with(
             ["ls", "-la"],
+            input=None,
             capture_output=True,
             text=True,
             check=True,

--- a/libs/jupyter-deploy/tests/unit/test_verify_utils.py
+++ b/libs/jupyter-deploy/tests/unit/test_verify_utils.py
@@ -90,6 +90,32 @@ class TestCheckYqInstallation(unittest.TestCase):
         )
 
 
+class TestCheckHelmInstallation(unittest.TestCase):
+    @patch("jupyter_deploy.verify_utils._check_installation")
+    def test_passes_tool_name_install_url_and_version_cmds(self, mock_check: Mock) -> None:
+        verify_utils._check_helm_installation()
+        mock_check.assert_called_once_with(
+            tool_name="helm",
+            installation_url="https://helm.sh/docs/intro/install/",
+            version_cmds=["version", "--short"],
+        )
+
+    @patch("jupyter_deploy.cmd_utils.check_executable_installation")
+    def test_raises_when_helm_not_installed(self, mock_check: Mock) -> None:
+        mock_check.return_value = (False, None, "Command 'helm' not found")
+
+        with self.assertRaises(ToolRequiredError) as context:
+            verify_utils._check_helm_installation()
+
+        self.assertEqual(context.exception.tool_name, "helm")
+
+    def test_helm_is_mapped(self) -> None:
+        self.assertIs(
+            verify_utils._TOOL_VERIFICATION_FN_MAP[JupyterDeployTool.HELM],
+            verify_utils._check_helm_installation,
+        )
+
+
 class TestVerifyToolsInstallation(unittest.TestCase):
     def test_succeeds_for_empty_list(self) -> None:
         # Should not raise

--- a/libs/pytest-jupyter-deploy/README.md
+++ b/libs/pytest-jupyter-deploy/README.md
@@ -82,7 +82,7 @@ def test_requires_env_vars(e2e_deployment: EndToEndDeployment) -> None:
 ## E2E Test Container Image
 
 This package bundles a Dockerfile and docker-compose.yml for a containerized E2E test environment
-with Python, Terraform, AWS CLI, and Playwright pre-installed. The image is template-independent
+with Python, Terraform, AWS CLI, kubectl, Helm, and Playwright pre-installed. The image is template-independent
 and used by the [jupyter-deploy justfile](https://github.com/jupyter-infra/jupyter-deploy/blob/main/justfile)
 to run E2E tests locally.
 

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/image/Dockerfile
@@ -40,6 +40,9 @@ RUN curl -sLO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/st
 RUN curl -sL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" -o /usr/local/bin/yq && \
     chmod 0755 /usr/local/bin/yq
 
+# Install Helm (used by the eks-oidc template's `jd component reconcile`)
+RUN curl -sL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
 # Create user with configurable UID/GID (defaults to 1000:1000)
 ARG USER_UID=1000
 ARG USER_GID=1000

--- a/scripts/sync_auth_state.py
+++ b/scripts/sync_auth_state.py
@@ -10,6 +10,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 from datetime import UTC, datetime
@@ -21,9 +22,46 @@ from pytest_jupyter_deploy.constants import GITHUB_OAUTH_STATE_FILE
 
 AUTH_DIR = Path(AUTH_DIR_NAME)
 AUTH_FILE = AUTH_DIR / GITHUB_OAUTH_STATE_FILE
+ENV_FILE = Path(".env")
 
 WARN_THRESHOLD_DAYS = 7
 WARN_THRESHOLD_SECS = WARN_THRESHOLD_DAYS * 24 * 3600
+
+
+def expected_bot_user() -> str | None:
+    """Return the expected browser identity (JD_E2E_USER), or None if unset.
+
+    Reads the .env file first — the E2E workflow and just recipes write JD_E2E_USER
+    there (docker-compose passes it into the test container), and it is NOT exported
+    into the host shell where this script runs. Falls back to the process env for
+    interactive use where a caller has sourced .env.
+    """
+    if ENV_FILE.exists():
+        for line in ENV_FILE.read_text().splitlines():
+            key, _, value = line.partition("=")
+            if key.strip() == "JD_E2E_USER":
+                return value.strip() or None
+    return os.environ.get("JD_E2E_USER") or None
+
+
+def auth_state_identity(auth_content: str) -> str | None:
+    """Return the GitHub username the auth state authenticates as, or None if unknown.
+
+    GitHub stores the logged-in username in the `dotcom_user` cookie. UI tests reuse
+    the cached state as-is, so a state exported for one bot silently authenticates the
+    browser as that bot — even when JD_E2E_USER (which sets the workspace owner via
+    kubectl impersonation) points at a different account. That mismatch fails only the
+    owner-must-match-browser tests, deep into a run, with an opaque Unauthorized.
+    """
+    try:
+        data = json.loads(auth_content)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    for cookie in data.get("cookies", []):
+        if cookie.get("name") == "dotcom_user" and "github.com" in cookie.get("domain", ""):
+            value = cookie.get("value")
+            return str(value) if value is not None else None
+    return None
 
 
 def print_cookie_summary() -> int:
@@ -32,12 +70,14 @@ def print_cookie_summary() -> int:
         print(f"Error: {AUTH_FILE} does not exist")
         return 1
 
-    data = json.loads(AUTH_FILE.read_text())
+    content = AUTH_FILE.read_text()
+    data = json.loads(content)
     cookies = data.get("cookies", [])
     github_cookies = [c for c in cookies if ".github.com" in c.get("domain", "")]
     now = time.time()
 
-    print(f"GitHub cookies: {len(github_cookies)} (total: {len(cookies)})")
+    state_user = auth_state_identity(content)
+    print(f"GitHub cookies: {len(github_cookies)} (total: {len(cookies)}), authenticated as: {state_user or 'unknown'}")
     print()
 
     has_warning = False
@@ -95,10 +135,24 @@ def cmd_export(ci_dir: str) -> None:
 def cmd_import(ci_dir: str) -> None:
     secret_arn = jd_output("auth_state_secret_arn", ci_dir)
     print("Downloading auth state from Secrets Manager...")
-    AUTH_DIR.mkdir(parents=True, exist_ok=True)
     value = fetch_secret_value(secret_arn)
+
+    # Guard against importing a browser context for the wrong bot. The imported state
+    # is reused as-is by UI tests, so an identity mismatch with JD_E2E_USER would only
+    # surface as an Unauthorized failure on owner-scoped workspace tests, far into a run.
+    expected_user = expected_bot_user()
+    state_user = auth_state_identity(value)
+    if expected_user and state_user and state_user != expected_user:
+        print(f"Error: imported auth state authenticates as '{state_user}', but JD_E2E_USER='{expected_user}'.")
+        print("The cached browser context is for a different GitHub bot; refusing to import it.")
+        print(f"Re-seed it by running a UI test as '{expected_user}', then 'just auth-export {ci_dir}'.")
+        sys.exit(1)
+
+    AUTH_DIR.mkdir(parents=True, exist_ok=True)
     AUTH_FILE.write_text(value)
     print(f"Auth state imported to {AUTH_FILE}")
+    if state_user:
+        print(f"Authenticated as: {state_user}")
     print()
     print_cookie_summary()
 


### PR DESCRIPTION
This PR adds handling for helm releases as components in the CLI, and declares helm releases for the `eks-oidc` template. It also installs `helm` in the plugin image, and adds `helm` for as a prerequisite `eks-oidc` template.

Also in this PR:
- auto-detect that the `kubeconfig` matches the project cluster when running any `jd` command that shells out to `kubectl` or `helm` directly to avoid accidentally targeting the wrong cluster.
- remove unnecessary `values` entry from `eks-oidc` manifest
- improve root and `eks-oidc` AGENT.md

Closes: #294 

### User experience
- `jd health` --> display helm charts, their namespace and the number of resources they track
- `jd component list` --> display helm charts managed by `jd`
- `jd component show --name <CHART-NAME>` --> display information about the chart, its config, masking secrets
- `jd component status --name <CHART-NAME>` --> display helm status
- `jd component reconcile --name <CHART-NAME>` --> regenerate k8s resources manifest, run `kubectl apply` to correct any drift

### Implementation
- add `helm` as a tool, require it for `eks-oidc` template
- add provider for helm in `<cli>/provider/helm`, register w/ the command runner
- add util to verify the `kubeconfig` matches expectations in `<cli>/provider/k8s`, raise specific error on mismatch, add to the decorator handler
- update `ComponentHandler` and `HealthHandler` for `helm` components
- add `jd component reconcile` command
- update `jd health` command to display namespace in `Details` and resource count in `SubComponent` for charts
- declare actions and values in manifest of `eks-oidc` template
- update docs, AGENT.md, TROUBLESHOOTING.md templates
- update root AGENT.md
- install `helm` in plugin image

### Testing
- added E2E testing for helm-based components (in `jd health`, `jd component` methods)
- ran full E2E tests against a local `eks-oidc` deployment

### Screenshots
**jd component reconcile --help**
<img width="814" height="251" alt="Screenshot 2026-07-08 at 9 10 37 AM" src="https://github.com/user-attachments/assets/5093bf62-81f4-4ae0-b450-bc71d208f1ba" />

**jd health**
<img width="872" height="403" alt="Screenshot 2026-07-08 at 9 13 21 AM" src="https://github.com/user-attachments/assets/0782d0a5-b100-49a7-8b5e-26024bd95224" />

**jd component list**
<img width="809" height="321" alt="Screenshot 2026-07-08 at 9 14 01 AM" src="https://github.com/user-attachments/assets/24feff1c-ec48-41b9-9613-344ba0369075" />

**jd component status --name workspace-operator-chart**
<img width="566" height="30" alt="Screenshot 2026-07-08 at 9 14 45 AM" src="https://github.com/user-attachments/assets/5bffa43c-4a0e-4e60-84ae-39048eea24ee" />

**jd component show --name workspace-router-chart**
<img width="984" height="673" alt="Screenshot 2026-07-08 at 9 15 30 AM" src="https://github.com/user-attachments/assets/db239542-4db4-4ab2-93bf-691425f3b79a" />

