### PR TITLE
chore: type cmd hardening

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -527,17 +527,8 @@ commands:
     source-key: '[0].Resource'
 - cmd: component.customresourcedefinition.status
   sequence:
-  - api-name: k8s.custom.get-cluster
+  - api-name: k8s.apiextensions.get-crd
     arguments:
-    - api-attribute: group
-      source: cli
-      source-key: group
-    - api-attribute: version
-      source: cli
-      source-key: version
-    - api-attribute: plural
-      source: cli
-      source-key: plural
     - api-attribute: name
       source: cli
       source-key: name
@@ -547,17 +538,8 @@ commands:
     source-key: '[0].Resource'
 - cmd: component.customresourcedefinition.show
   sequence:
-  - api-name: k8s.custom.get-cluster
+  - api-name: k8s.apiextensions.get-crd
     arguments:
-    - api-attribute: group
-      source: cli
-      source-key: group
-    - api-attribute: version
-      source: cli
-      source-key: version
-    - api-attribute: plural
-      source: cli
-      source-key: plural
     - api-attribute: name
       source: cli
       source-key: name
@@ -996,9 +978,9 @@ components:
       path: .spec.versions[0].name
     verbs:
       status:
-        method: k8s.custom.get-cluster
+        method: k8s.apiextensions.get-crd
       show:
-        method: k8s.custom.get-cluster
+        method: k8s.apiextensions.get-crd
   workspace-template-crd:
     type: CustomResourceDefinition
     description: WorkspaceTemplate CRD
@@ -1007,9 +989,9 @@ components:
       path: .spec.versions[0].name
     verbs:
       status:
-        method: k8s.custom.get-cluster
+        method: k8s.apiextensions.get-crd
       show:
-        method: k8s.custom.get-cluster
+        method: k8s.apiextensions.get-crd
   workspace-access-strategy-crd:
     type: CustomResourceDefinition
     description: WorkspaceAccessStrategy CRD
@@ -1018,9 +1000,9 @@ components:
       path: .spec.versions[0].name
     verbs:
       status:
-        method: k8s.custom.get-cluster
+        method: k8s.apiextensions.get-crd
       show:
-        method: k8s.custom.get-cluster
+        method: k8s.apiextensions.get-crd
   oauth-access-strategy:
     type: CustomResourceWithoutStatus
     type-display: WorkspaceAccessStrategy

--- a/libs/jupyter-deploy/jupyter_deploy/api/k8s/apiextensions.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/k8s/apiextensions.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+from kubernetes.client import ApiextensionsV1Api, V1CustomResourceDefinition
+
+
+@dataclass(frozen=True)
+class CrdInfo:
+    """Typed detail for a CustomResourceDefinition.
+
+    `resource` is the full serialized object, kept so manifest display fields
+    that reference arbitrary paths (e.g. .spec.versions[0].name) keep working.
+    The typed fields expose the introspection that the generic custom-object
+    path could only reach stringly (established condition, served versions).
+    """
+
+    name: str
+    group: str
+    established: bool
+    served_versions: list[str] = field(default_factory=list)
+    stored_version: str = ""
+    resource: dict[str, Any] = field(default_factory=dict)
+
+
+def _is_established(crd: V1CustomResourceDefinition) -> bool:
+    status = crd.status
+    conditions = status.conditions if status else None
+    if not conditions:
+        return False
+    for condition in conditions:
+        if getattr(condition, "type", "") == "Established":
+            return getattr(condition, "status", "") == "True"
+    return False
+
+
+def get_crd(api: ApiextensionsV1Api, name: str) -> CrdInfo:
+    """Read a CustomResourceDefinition by name, return typed detail plus the full resource."""
+    crd = api.read_custom_resource_definition(name=name)
+    crd_name = crd.metadata.name if crd.metadata else ""
+    spec = crd.spec
+    group = spec.group if spec else ""
+    versions = spec.versions if spec and spec.versions else []
+    served_versions = [v.name for v in versions if getattr(v, "served", False)]
+    stored_version = next((v.name for v in versions if getattr(v, "storage", False)), "")
+    resource: dict[str, Any] = api.api_client.sanitize_for_serialization(crd)
+    return CrdInfo(
+        name=crd_name,
+        group=group,
+        established=_is_established(crd),
+        served_versions=served_versions,
+        stored_version=stored_version,
+        resource=resource,
+    )

--- a/libs/jupyter-deploy/jupyter_deploy/cli/cluster_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/cluster_app.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated
 
@@ -84,7 +85,7 @@ def show(
             details = handler.show_cluster()
 
         if json_output:
-            console.print(json.dumps(details), highlight=False, markup=False, soft_wrap=True)
+            console.print(json.dumps(asdict(details)), highlight=False, markup=False, soft_wrap=True)
             return
 
-        console.print_json(json.dumps(details))
+        console.print_json(json.dumps(asdict(details)))

--- a/libs/jupyter-deploy/jupyter_deploy/cli/component_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/component_app.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated
 
@@ -44,10 +45,10 @@ def list_components(
         components = handler.list_components()
 
         if json_output:
-            console.print(json.dumps(components), highlight=False, markup=False, soft_wrap=True)
+            console.print(json.dumps([asdict(c) for c in components]), highlight=False, markup=False, soft_wrap=True)
             return
         if text_output:
-            console.out(",".join(c["name"] for c in components))
+            console.out(",".join(c.name for c in components))
             return
 
         table = Table()
@@ -55,7 +56,7 @@ def list_components(
         table.add_column("Type")
         table.add_column("Description")
         for c in components:
-            table.add_row(c["name"], c["type"], c["description"])
+            table.add_row(c.name, c.type, c.description)
         console.print(table)
 
 
@@ -123,10 +124,10 @@ def show(
             details = handler.show_component(name=name)
 
         if json_output:
-            console.print(json.dumps(details), highlight=False, markup=False, soft_wrap=True)
+            console.print(json.dumps(asdict(details)), highlight=False, markup=False, soft_wrap=True)
             return
 
-        console.print_json(json.dumps(details))
+        console.print_json(json.dumps(asdict(details)))
 
 
 @component_app.command(context_settings={"allow_extra_args": True, "allow_interspersed_args": False})

--- a/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/host_app.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated
 
@@ -281,7 +282,7 @@ def show(
             details = handler.show_host(name=name)
 
         if json_output:
-            console.print(json.dumps(details), highlight=False, markup=False, soft_wrap=True)
+            console.print(json.dumps(asdict(details)), highlight=False, markup=False, soft_wrap=True)
             return
 
-        console.print_json(json.dumps(details))
+        console.print_json(json.dumps(asdict(details)))

--- a/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/servers_app.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import asdict
 from pathlib import Path
 from typing import Annotated
 
@@ -397,7 +398,7 @@ def show(
             details = handler.show_server(name=name, scope=scope or None)
 
         if json_output:
-            console.print(json.dumps(details), highlight=False, markup=False, soft_wrap=True)
+            console.print(json.dumps(asdict(details)), highlight=False, markup=False, soft_wrap=True)
             return
 
-        console.print_json(json.dumps(details))
+        console.print_json(json.dumps(asdict(details)))

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/health_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/health_handler.py
@@ -111,7 +111,7 @@ class HealthHandler(BaseProjectHandler):
         results: list[HealthLayerResult] = []
 
         for comp in statuses:
-            category = comp.get("status_category", "")
+            category = comp.status_category
             if category == StatusCategory.DEGRADED:
                 status_category = StatusCategory.DEGRADED
             elif category == StatusCategory.IN_PROGRESS:
@@ -122,11 +122,11 @@ class HealthHandler(BaseProjectHandler):
             results.append(
                 HealthLayerResult(
                     layer=HealthLayer.COMPONENTS,
-                    name=comp["name"],
+                    name=comp.name,
                     status_category=status_category,
-                    status_text=comp.get("status", ""),
-                    detail=comp.get("details", ""),
-                    sub_component=comp.get("sub_component", ""),
+                    status_text=comp.status,
+                    detail=comp.details,
+                    sub_component=comp.sub_component,
                 )
             )
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/payloads.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/payloads.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 from jupyter_deploy.enum import StatusCategory
 
@@ -99,3 +100,63 @@ class ImageVulnerabilitiesResult:
     critical_count: int
     high_count: int
     vulnerabilities: list[ImageVulnerability]
+
+
+@dataclass
+class ClusterDetail:
+    """Result of jd cluster show."""
+
+    name: str = ""
+    label: str = ""
+    status: str = ""
+    endpoint: str = ""
+    version: str = ""
+
+
+@dataclass
+class ComponentInfo:
+    """Entry in the component list.
+
+    `type` is the display type (type-display when set, else the internal type).
+    """
+
+    name: str
+    type: str
+    description: str
+
+
+@dataclass
+class ComponentStatus:
+    """Status of a single component for dashboard display."""
+
+    name: str
+    type: str
+    status: str
+    status_category: str
+    details: str
+    sub_component: str
+
+
+@dataclass
+class ComponentDetail:
+    """Result of jd component show."""
+
+    name: str = ""
+    resource: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HostDetail:
+    """Result of jd host show."""
+
+    name: str = ""
+    status: str = ""
+    resource: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ServerDetail:
+    """Result of jd server show."""
+
+    name: str = ""
+    resource: dict[str, Any] = field(default_factory=dict)

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/cluster_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/cluster_handler.py
@@ -1,12 +1,10 @@
-from typing import Any
-
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
 from jupyter_deploy.engine.enum import EngineType
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.enum import StatusCategory
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
-from jupyter_deploy.handlers.payloads import HealthLayer, HealthLayerResult
+from jupyter_deploy.handlers.payloads import ClusterDetail, HealthLayer, HealthLayerResult
 from jupyter_deploy.handlers.resource.resource_utils import collect_results
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
 
@@ -99,9 +97,9 @@ class ClusterHandler(BaseProjectHandler):
     def health(self) -> HealthLayerResult:
         """Returns a HealthLayerResult for the cluster layer."""
         info = self.show_cluster()
-        cluster_label = info.get("label", "")
-        status = info.get("status", "")
-        version = info.get("version", "")
+        cluster_label = info.label
+        status = info.status
+        version = info.version
 
         detail = f"v{version}" if version else ""
 
@@ -132,8 +130,8 @@ class ClusterHandler(BaseProjectHandler):
             sub_component="-",
         )
 
-    def show_cluster(self) -> dict[str, Any]:
-        """Returns cluster metadata dict."""
+    def show_cluster(self) -> ClusterDetail:
+        """Returns cluster metadata."""
         command = self.project_manifest.get_command("cluster.show")
         runner = cmd_runner.ManifestCommandRunner(
             display_manager=self.display_manager,
@@ -141,4 +139,11 @@ class ClusterHandler(BaseProjectHandler):
             variable_handler=self._variable_handler,
         )
         runner.run_command_sequence(command, cli_paramdefs={})
-        return collect_results(runner, command)
+        results = collect_results(runner, command)
+        return ClusterDetail(
+            name=results.get("name", ""),
+            label=results.get("label", ""),
+            status=results.get("status", ""),
+            endpoint=results.get("endpoint", ""),
+            version=results.get("version", ""),
+        )

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/component_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/component_handler.py
@@ -7,6 +7,7 @@ from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.exceptions import InvalidComponentVerbError, ResourceNotFoundError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
+from jupyter_deploy.handlers.payloads import ComponentDetail, ComponentInfo, ComponentStatus
 from jupyter_deploy.handlers.resource.resource_utils import collect_results, render_display_field
 from jupyter_deploy.manifest import JupyterDeployComponentDefinitionV1
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
@@ -14,13 +15,15 @@ from jupyter_deploy.provider.resolved_clidefs import ResolvedCliParameter, StrRe
 
 # Component types whose health is existence-based: the resource carries no controller-managed
 # status, so a successful get means "Present" and a 404 (ResourceNotFoundError) means "Not Found".
-# CustomResourceDefinition is cluster-scoped (no namespace), fetched via k8s.custom.get-cluster.
+# CustomResourceDefinition is cluster-scoped (no namespace).
 CUSTOM_RESOURCE_WITHOUT_STATUS = "CustomResourceWithoutStatus"
 CUSTOM_RESOURCE_DEFINITION = "CustomResourceDefinition"
 EXISTENCE_COMPONENT_TYPES = frozenset({CUSTOM_RESOURCE_WITHOUT_STATUS, CUSTOM_RESOURCE_DEFINITION})
 
 # CustomResourceDefinition is a well-known cluster-scoped kind: its CRD coordinates are fixed,
-# so components of this type don't declare them.
+# so components of this type don't declare them. These are still injected as CLI params so that
+# manifests routing the CRD through the generic k8s.custom.get-cluster instruction keep working;
+# the typed k8s.apiextensions.get-crd instruction simply ignores the extra coordinates.
 CRD_GROUP = "apiextensions.k8s.io"
 CRD_VERSION = "v1"
 CRD_PLURAL = "customresourcedefinitions"
@@ -105,14 +108,14 @@ class ComponentHandler(BaseProjectHandler):
                 cli_paramdefs[k] = StrResolvedCliParameter(parameter_name=k, value=v)
         return cli_paramdefs
 
-    def list_components(self) -> list[dict[str, str]]:
+    def list_components(self) -> list[ComponentInfo]:
         """Return the list of components with name, type, and description.
 
         `type` is the display type (type-display when set, else the internal type).
         """
         components = self.project_manifest.get_components()
         return [
-            {"name": name, "type": comp.type_display or comp.type, "description": comp.description}
+            ComponentInfo(name=name, type=comp.type_display or comp.type, description=comp.description)
             for name, comp in components.items()
         ]
 
@@ -121,10 +124,10 @@ class ComponentHandler(BaseProjectHandler):
         component = self.project_manifest.get_component(name)
         return component.description
 
-    def get_all_status(self) -> list[dict[str, str]]:
+    def get_all_status(self) -> list[ComponentStatus]:
         """Return status of all components for dashboard display."""
         components = self.project_manifest.get_components()
-        results: list[dict[str, str]] = []
+        results: list[ComponentStatus] = []
         for name, comp_def in components.items():
             namespace = self._resolve_namespace(comp_def)
             cmd_name = self._get_command_name(comp_def, "status")
@@ -159,14 +162,14 @@ class ComponentHandler(BaseProjectHandler):
                 details = f"{comp_def.type.lower()} '{name}' not found"
                 sub_component = ""
             results.append(
-                {
-                    "name": name,
-                    "type": comp_def.type,
-                    "status": status,
-                    "status_category": status_category,
-                    "details": details,
-                    "sub_component": sub_component,
-                }
+                ComponentStatus(
+                    name=name,
+                    type=comp_def.type,
+                    status=status,
+                    status_category=status_category,
+                    details=details,
+                    sub_component=sub_component,
+                )
             )
         return results
 
@@ -194,7 +197,7 @@ class ComponentHandler(BaseProjectHandler):
         runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
         return runner.get_result_value(command, f"{cmd_name}.status", str)
 
-    def show_component(self, name: str) -> dict[str, Any]:
+    def show_component(self, name: str) -> ComponentDetail:
         """Return detailed information about a component."""
         component = self.project_manifest.get_component(name)
         self._validate_verb(name, component, "show")
@@ -209,7 +212,8 @@ class ComponentHandler(BaseProjectHandler):
         )
         cli_paramdefs = self._build_cli_paramdefs(resource_name, component, namespace)
         runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
-        return collect_results(runner, command)
+        results = collect_results(runner, command)
+        return ComponentDetail(name=results.get("name", ""), resource=results.get("resource", {}))
 
     def get_component_logs(self, name: str, extra: list[str] | None = None) -> str:
         """Return logs for a component."""

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/host_handler.py
@@ -6,6 +6,7 @@ from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.exceptions import ResourceNameRequiredError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
+from jupyter_deploy.handlers.payloads import HostDetail
 from jupyter_deploy.handlers.resource.resource_utils import collect_results
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
 from jupyter_deploy.provider.resolved_clidefs import (
@@ -75,7 +76,7 @@ class HostHandler(BaseProjectHandler):
         runner.run_command_sequence(command, cli_paramdefs=cli_paramdefs)
         return runner.get_result_value(command, "host.status", str)
 
-    def show_host(self, name: str) -> dict[str, Any]:
+    def show_host(self, name: str) -> HostDetail:
         """Returns detailed information about a host."""
         command = self.project_manifest.get_command("host.show")
         runner = cmd_runner.ManifestCommandRunner(
@@ -89,7 +90,12 @@ class HostHandler(BaseProjectHandler):
                 "name": StrResolvedCliParameter(parameter_name="name", value=name),
             },
         )
-        return collect_results(runner, command)
+        results = collect_results(runner, command)
+        return HostDetail(
+            name=results.get("name", ""),
+            status=results.get("status", ""),
+            resource=results.get("resource", {}),
+        )
 
     def _build_cli_paramdefs(self, name: str | None = None) -> dict[str, ResolvedCliParameter[Any]]:
         cli_paramdefs: dict[str, ResolvedCliParameter[Any]] = {}

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/resource/server_handler.py
@@ -7,6 +7,7 @@ from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.engine.terraform import tf_outputs, tf_variables
 from jupyter_deploy.exceptions import ResourceNameRequiredError
 from jupyter_deploy.handlers.base_project_handler import BaseProjectHandler
+from jupyter_deploy.handlers.payloads import ServerDetail
 from jupyter_deploy.handlers.resource.resource_utils import collect_results, evaluate_status_rules
 from jupyter_deploy.provider import manifest_command_runner as cmd_runner
 from jupyter_deploy.provider.resolved_clidefs import ResolvedCliParameter, StrResolvedCliParameter
@@ -96,7 +97,7 @@ class ServerHandler(BaseProjectHandler):
         resource_json = runner.get_result_value(command, "server.status.resource", str)
         return evaluate_status_rules(resource_json, rules)
 
-    def show_server(self, name: str, scope: str | None = None) -> dict[str, Any]:
+    def show_server(self, name: str, scope: str | None = None) -> ServerDetail:
         """Returns detailed information about a server."""
         resolved_scope = self._resolve_scope(scope)
         command = self.project_manifest.get_command("server.show")
@@ -112,7 +113,8 @@ class ServerHandler(BaseProjectHandler):
                 "scope": StrResolvedCliParameter(parameter_name="scope", value=resolved_scope),
             },
         )
-        return collect_results(runner, command)
+        results = collect_results(runner, command)
+        return ServerDetail(name=results.get("name", ""), resource=results.get("resource", {}))
 
     def _build_cli_paramdefs(
         self,

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_apiextensions_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_apiextensions_runner.py
@@ -1,0 +1,73 @@
+import json
+from enum import Enum
+
+from kubernetes import client
+
+from jupyter_deploy.api.k8s import apiextensions as k8s_apiextensions
+from jupyter_deploy.engine.supervised_execution import DisplayManager
+from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.provider.instruction_runner import InstructionRunner
+from jupyter_deploy.provider.resolved_argdefs import (
+    ResolvedInstructionArgument,
+    StrResolvedInstructionArgument,
+    require_arg,
+)
+from jupyter_deploy.provider.resolved_resultdefs import (
+    ListStrResolvedInstructionResult,
+    ResolvedInstructionResult,
+    StrResolvedInstructionResult,
+)
+
+
+class K8sApiextensionsInstruction(str, Enum):
+    """K8s apiextensions API instructions accessible from manifest api-name."""
+
+    GET_CRD = "get-crd"
+
+
+class K8sApiextensionsRunner(InstructionRunner):
+    """Runner for the Kubernetes apiextensions API (CustomResourceDefinition).
+
+    Uses the typed ApiextensionsV1Api rather than the generic CustomObjectsApi,
+    so CRD introspection (established condition, served versions) is typed rather
+    than resolved through stringly-typed field paths.
+    """
+
+    def __init__(self, display_manager: DisplayManager, api_client: client.ApiClient) -> None:
+        super().__init__(display_manager)
+        self.apiextensions_api = client.ApiextensionsV1Api(api_client)
+
+    def _get_crd(
+        self, resolved_arguments: dict[str, ResolvedInstructionArgument]
+    ) -> dict[str, ResolvedInstructionResult]:
+        name_arg = require_arg(resolved_arguments, "name", StrResolvedInstructionArgument)
+
+        self.display_manager.info(f"Getting CustomResourceDefinition/{name_arg.value}")
+        info = k8s_apiextensions.get_crd(self.apiextensions_api, name=name_arg.value)
+
+        return {
+            "Name": StrResolvedInstructionResult(result_name="Name", value=info.name),
+            "Resource": StrResolvedInstructionResult(result_name="Resource", value=json.dumps(info.resource)),
+            "Established": StrResolvedInstructionResult(
+                result_name="Established", value="true" if info.established else "false"
+            ),
+            "ServedVersions": ListStrResolvedInstructionResult(
+                result_name="ServedVersions", value=info.served_versions
+            ),
+            "StoredVersion": StrResolvedInstructionResult(result_name="StoredVersion", value=info.stored_version),
+        }
+
+    def execute_instruction(
+        self,
+        instruction_name: str,
+        resolved_arguments: dict[str, ResolvedInstructionArgument],
+    ) -> dict[str, ResolvedInstructionResult]:
+        try:
+            instruction = K8sApiextensionsInstruction(instruction_name)
+        except ValueError:
+            raise InstructionNotFoundError(f"Unknown K8s apiextensions instruction: '{instruction_name}'") from None
+
+        if instruction == K8sApiextensionsInstruction.GET_CRD:
+            return self._get_crd(resolved_arguments)
+
+        raise InstructionNotFoundError(f"Unknown K8s apiextensions instruction: '{instruction_name}'")

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_runner.py
@@ -5,6 +5,7 @@ from kubernetes import client
 from jupyter_deploy.engine.supervised_execution import DisplayManager
 from jupyter_deploy.exceptions import InstructionNotFoundError
 from jupyter_deploy.provider.instruction_runner import InstructionRunner
+from jupyter_deploy.provider.k8s.k8s_apiextensions_runner import K8sApiextensionsRunner
 from jupyter_deploy.provider.k8s.k8s_apps_runner import K8sAppsRunner
 from jupyter_deploy.provider.k8s.k8s_batch_runner import K8sBatchRunner
 from jupyter_deploy.provider.k8s.k8s_client_factory import K8sClientFactory
@@ -22,6 +23,7 @@ class K8sService(str, Enum):
     CUSTOM = "custom"
     APPS = "apps"
     BATCH = "batch"
+    APIEXTENSIONS = "apiextensions"
 
 
 class K8sApiRunner(InstructionRunner):
@@ -93,6 +95,10 @@ class K8sApiRunner(InstructionRunner):
             service_runner = K8sBatchRunner(
                 self.display_manager, api_client=api_client, kubeconfig_path=self.kubeconfig_path
             )
+            self._service_runners[service_name] = service_runner
+            return service_runner
+        elif service_name == K8sService.APIEXTENSIONS:
+            service_runner = K8sApiextensionsRunner(self.display_manager, api_client=api_client)
             self._service_runners[service_name] = service_runner
             return service_runner
 

--- a/libs/jupyter-deploy/tests/unit/api/k8s/test_apiextensions.py
+++ b/libs/jupyter-deploy/tests/unit/api/k8s/test_apiextensions.py
@@ -1,0 +1,109 @@
+import unittest
+from unittest.mock import Mock
+
+from kubernetes.client import ApiextensionsV1Api
+from kubernetes.client.exceptions import ApiException
+
+from jupyter_deploy.api.k8s.apiextensions import get_crd
+
+_NOT_FOUND = ApiException(status=404, reason="Not Found")
+
+
+def _mock_version(name: str, served: bool, storage: bool) -> Mock:
+    version = Mock()
+    version.name = name
+    version.served = served
+    version.storage = storage
+    return version
+
+
+def _mock_condition(cond_type: str, status: str) -> Mock:
+    condition = Mock()
+    condition.type = cond_type
+    condition.status = status
+    return condition
+
+
+def _mock_crd(
+    name: str = "workspaces.workspace.jupyter.org",
+    group: str = "workspace.jupyter.org",
+    versions: list[Mock] | None = None,
+    conditions: list[Mock] | None = None,
+) -> Mock:
+    crd = Mock()
+    crd.metadata = Mock()
+    crd.metadata.name = name
+    crd.spec = Mock()
+    crd.spec.group = group
+    crd.spec.versions = versions if versions is not None else []
+    crd.status = Mock()
+    crd.status.conditions = conditions
+    return crd
+
+
+class TestGetCrd(unittest.TestCase):
+    def _make_api(self, crd: Mock) -> Mock:
+        mock_api: Mock = Mock(spec=ApiextensionsV1Api)
+        mock_api.read_custom_resource_definition.return_value = crd
+        mock_api.api_client = Mock()
+        mock_api.api_client.sanitize_for_serialization.return_value = {
+            "metadata": {"name": crd.metadata.name},
+            "spec": {"group": crd.spec.group},
+        }
+        return mock_api
+
+    def test_returns_typed_detail(self) -> None:
+        crd = _mock_crd(
+            versions=[_mock_version("v1alpha1", served=True, storage=True)],
+            conditions=[_mock_condition("Established", "True")],
+        )
+        mock_api = self._make_api(crd)
+
+        info = get_crd(mock_api, name="workspaces.workspace.jupyter.org")
+
+        self.assertEqual(info.name, "workspaces.workspace.jupyter.org")
+        self.assertEqual(info.group, "workspace.jupyter.org")
+        self.assertTrue(info.established)
+        self.assertEqual(info.served_versions, ["v1alpha1"])
+        self.assertEqual(info.stored_version, "v1alpha1")
+        self.assertEqual(info.resource["spec"]["group"], "workspace.jupyter.org")
+        mock_api.read_custom_resource_definition.assert_called_once_with(name="workspaces.workspace.jupyter.org")
+
+    def test_established_false_when_condition_absent(self) -> None:
+        crd = _mock_crd(conditions=None)
+        mock_api = self._make_api(crd)
+
+        info = get_crd(mock_api, name="workspaces.workspace.jupyter.org")
+
+        self.assertFalse(info.established)
+
+    def test_established_false_when_condition_not_true(self) -> None:
+        crd = _mock_crd(conditions=[_mock_condition("Established", "False")])
+        mock_api = self._make_api(crd)
+
+        info = get_crd(mock_api, name="workspaces.workspace.jupyter.org")
+
+        self.assertFalse(info.established)
+
+    def test_filters_served_versions_and_picks_stored(self) -> None:
+        crd = _mock_crd(
+            versions=[
+                _mock_version("v1alpha1", served=True, storage=False),
+                _mock_version("v1beta1", served=True, storage=True),
+                _mock_version("v1alpha0", served=False, storage=False),
+            ],
+            conditions=[_mock_condition("Established", "True")],
+        )
+        mock_api = self._make_api(crd)
+
+        info = get_crd(mock_api, name="workspaces.workspace.jupyter.org")
+
+        self.assertEqual(info.served_versions, ["v1alpha1", "v1beta1"])
+        self.assertEqual(info.stored_version, "v1beta1")
+
+    def test_raises_on_api_error(self) -> None:
+        mock_api: Mock = Mock(spec=ApiextensionsV1Api)
+        mock_api.read_custom_resource_definition.side_effect = _NOT_FOUND
+
+        with self.assertRaises(ApiException):
+            get_crd(mock_api, name="nonexistent")

--- a/libs/jupyter-deploy/tests/unit/cli/test_cluster_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_cluster_app.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from typer.testing import CliRunner
 
 from jupyter_deploy.cli.cluster_app import cluster_app
+from jupyter_deploy.handlers.payloads import ClusterDetail
 
 
 class TestClusterApp(unittest.TestCase):
@@ -151,7 +152,7 @@ class TestClusterShowCommand(unittest.TestCase):
     @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_calls_show_cluster(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
         mock_handler: Mock = Mock()
-        mock_handler.show_cluster.return_value = {"name": "my-cluster", "status": "ACTIVE", "version": "1.30"}
+        mock_handler.show_cluster.return_value = ClusterDetail(name="my-cluster", status="ACTIVE", version="1.30")
         mock_handler_class.return_value = mock_handler
         mock_project_dir.return_value.__enter__.return_value = None
 
@@ -166,7 +167,7 @@ class TestClusterShowCommand(unittest.TestCase):
     @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_default_output_contains_details(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
         mock_handler: Mock = Mock()
-        mock_handler.show_cluster.return_value = {"name": "my-cluster", "status": "ACTIVE", "version": "1.30"}
+        mock_handler.show_cluster.return_value = ClusterDetail(name="my-cluster", status="ACTIVE", version="1.30")
         mock_handler_class.return_value = mock_handler
         mock_project_dir.return_value.__enter__.return_value = None
 
@@ -182,7 +183,7 @@ class TestClusterShowCommand(unittest.TestCase):
     @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_json_output(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
         mock_handler: Mock = Mock()
-        mock_handler.show_cluster.return_value = {"name": "my-cluster", "status": "ACTIVE", "version": "1.30"}
+        mock_handler.show_cluster.return_value = ClusterDetail(name="my-cluster", status="ACTIVE", version="1.30")
         mock_handler_class.return_value = mock_handler
         mock_project_dir.return_value.__enter__.return_value = None
 
@@ -199,7 +200,7 @@ class TestClusterShowCommand(unittest.TestCase):
     @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_switches_dir_with_path(self, mock_project_dir: Mock, mock_handler_class: Mock) -> None:
         mock_handler: Mock = Mock()
-        mock_handler.show_cluster.return_value = {"name": "c", "status": "ACTIVE"}
+        mock_handler.show_cluster.return_value = ClusterDetail(name="c", status="ACTIVE")
         mock_handler_class.return_value = mock_handler
         mock_project_dir.return_value.__enter__.return_value = None
 

--- a/libs/jupyter-deploy/tests/unit/cli/test_component_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_component_app.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 from typer.testing import CliRunner
 
 from jupyter_deploy.cli.component_app import component_app
+from jupyter_deploy.handlers.payloads import ComponentDetail, ComponentInfo
 
 
 class TestComponentApp(unittest.TestCase):
@@ -34,9 +35,9 @@ class TestComponentListCommand(unittest.TestCase):
         mock_project_dir.return_value.__exit__ = Mock(return_value=None)
         mock_handler: Mock = Mock()
         mock_handler.list_components.return_value = [
-            {"name": "traefik", "type": "Deployment", "description": "Ingress controller"},
-            {"name": "dex", "type": "Deployment", "description": "Identity provider"},
-            {"name": "jwt-rotator", "type": "CronJob", "description": "Rotates JWT keys"},
+            ComponentInfo(name="traefik", type="Deployment", description="Ingress controller"),
+            ComponentInfo(name="dex", type="Deployment", description="Identity provider"),
+            ComponentInfo(name="jwt-rotator", type="CronJob", description="Rotates JWT keys"),
         ]
         mock_handler_class.return_value = mock_handler
 
@@ -58,8 +59,8 @@ class TestComponentListCommand(unittest.TestCase):
         mock_project_dir.return_value.__exit__ = Mock(return_value=None)
         mock_handler: Mock = Mock()
         mock_handler.list_components.return_value = [
-            {"name": "traefik", "type": "Deployment", "description": "Ingress controller"},
-            {"name": "dex", "type": "Deployment", "description": "Identity provider"},
+            ComponentInfo(name="traefik", type="Deployment", description="Ingress controller"),
+            ComponentInfo(name="dex", type="Deployment", description="Identity provider"),
         ]
         mock_handler_class.return_value = mock_handler
 
@@ -79,8 +80,8 @@ class TestComponentListCommand(unittest.TestCase):
         mock_project_dir.return_value.__exit__ = Mock(return_value=None)
         mock_handler: Mock = Mock()
         mock_handler.list_components.return_value = [
-            {"name": "traefik", "type": "Deployment", "description": "Ingress controller"},
-            {"name": "dex", "type": "Deployment", "description": "Identity provider"},
+            ComponentInfo(name="traefik", type="Deployment", description="Ingress controller"),
+            ComponentInfo(name="dex", type="Deployment", description="Identity provider"),
         ]
         mock_handler_class.return_value = mock_handler
 
@@ -158,7 +159,7 @@ class TestComponentShowCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__ = Mock(return_value=None)
         mock_project_dir.return_value.__exit__ = Mock(return_value=None)
         mock_handler: Mock = Mock()
-        mock_handler.show_component.return_value = {"name": "traefik", "image": "traefik:v2.10"}
+        mock_handler.show_component.return_value = ComponentDetail(name="traefik", resource={"image": "traefik:v2.10"})
         mock_handler_class.return_value = mock_handler
 
         runner = CliRunner()
@@ -190,7 +191,9 @@ class TestComponentShowCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__ = Mock(return_value=None)
         mock_project_dir.return_value.__exit__ = Mock(return_value=None)
         mock_handler: Mock = Mock()
-        mock_handler.show_component.return_value = {"name": "traefik", "image": "traefik:v2.10", "replicas": 1}
+        mock_handler.show_component.return_value = ComponentDetail(
+            name="traefik", resource={"image": "traefik:v2.10", "replicas": 1}
+        )
         mock_handler_class.return_value = mock_handler
 
         runner = CliRunner()
@@ -207,7 +210,7 @@ class TestComponentShowCommand(unittest.TestCase):
         mock_project_dir.return_value.__enter__ = Mock(return_value=None)
         mock_project_dir.return_value.__exit__ = Mock(return_value=None)
         mock_handler: Mock = Mock()
-        mock_handler.show_component.return_value = {"name": "traefik"}
+        mock_handler.show_component.return_value = ComponentDetail(name="traefik")
         mock_handler_class.return_value = mock_handler
 
         runner = CliRunner()

--- a/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_host_app.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from typer.testing import CliRunner
 
 from jupyter_deploy.cli.host_app import host_app
+from jupyter_deploy.handlers.payloads import HostDetail
 
 
 class TestHostApp(unittest.TestCase):
@@ -908,7 +909,7 @@ class TestHostShowCommand(unittest.TestCase):
         mock_host_handler = Mock()
 
         mock_host_handler.show_host = mock_show_host
-        mock_show_host.return_value = {"name": "node-1", "status": "Ready"}
+        mock_show_host.return_value = HostDetail(name="node-1", status="Ready")
 
         return mock_host_handler, {
             "show_host": mock_show_host,
@@ -959,7 +960,7 @@ class TestHostShowCommand(unittest.TestCase):
     @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_json_output(self, mock_project_dir: Mock, mock_host_handler_class: Mock) -> None:
         mock_host_handler = Mock()
-        mock_host_handler.show_host.return_value = {"name": "node-1", "status": "Ready", "resource": '{"spec": {}}'}
+        mock_host_handler.show_host.return_value = HostDetail(name="node-1", status="Ready", resource={"spec": {}})
         mock_host_handler_class.return_value = mock_host_handler
         mock_project_dir.return_value.__enter__.return_value = None
 

--- a/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_servers_app.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 from typer.testing import CliRunner
 
 from jupyter_deploy.cli.servers_app import servers_app
+from jupyter_deploy.handlers.payloads import ServerDetail
 from jupyter_deploy.manifest import InvalidServiceError
 
 
@@ -1364,7 +1365,7 @@ class TestServerShowCmd(unittest.TestCase):
         mock_server_handler = Mock()
 
         mock_server_handler.show_server = mock_show_server
-        mock_show_server.return_value = {"name": "my-ws", "resource": '{"spec": {}}'}
+        mock_show_server.return_value = ServerDetail(name="my-ws", resource={"spec": {}})
 
         return mock_server_handler, {
             "show_server": mock_show_server,
@@ -1415,7 +1416,7 @@ class TestServerShowCmd(unittest.TestCase):
     @patch("jupyter_deploy.cmd_utils.project_dir")
     def test_json_output(self, mock_project_dir: Mock, mock_server_handler_class: Mock) -> None:
         mock_server_handler = Mock()
-        mock_server_handler.show_server.return_value = {"name": "my-ws", "resource": '{"spec": {}}'}
+        mock_server_handler.show_server.return_value = ServerDetail(name="my-ws", resource={"spec": {}})
         mock_server_handler_class.return_value = mock_server_handler
         mock_project_dir.return_value.__enter__.return_value = None
 

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_cluster_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_cluster_handler.py
@@ -197,10 +197,11 @@ class TestClusterHandler(unittest.TestCase):
         handler = ClusterHandler(display_manager=NullDisplay())
         result = handler.show_cluster()
 
-        self.assertEqual(result["name"], "my-cluster")
-        self.assertEqual(result["status"], "ACTIVE")
-        self.assertEqual(result["endpoint"], "https://ABC.eks.amazonaws.com")
-        self.assertEqual(result["version"], "1.29.0")
+        self.assertEqual(result.name, "my-cluster")
+        self.assertEqual(result.label, "EKS")
+        self.assertEqual(result.status, "ACTIVE")
+        self.assertEqual(result.endpoint, "https://ABC.eks.amazonaws.com")
+        self.assertEqual(result.version, "1.29.0")
         mock_manifest_fns["get_command"].assert_called_once_with("cluster.show")
         mock_cmd_runner_fns["run_command_sequence"].assert_called_once_with(mock_cmd, cli_paramdefs={})
 

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_component_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_component_handler.py
@@ -204,9 +204,9 @@ class TestComponentHandlerListComponents(unittest.TestCase):
         handler = ComponentHandler(display_manager=Mock())
         components = handler.list_components()
 
-        by_name = {c["name"]: c for c in components}
-        self.assertEqual(by_name["jupyterlab-template"]["type"], "WorkspaceTemplate")
-        self.assertEqual(by_name["traefik"]["type"], "Deployment")  # falls back to type
+        by_name = {c.name: c for c in components}
+        self.assertEqual(by_name["jupyterlab-template"].type, "WorkspaceTemplate")
+        self.assertEqual(by_name["traefik"].type, "Deployment")  # falls back to type
 
 
 @patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")
@@ -281,9 +281,9 @@ class TestComponentHandlerGetAllStatus(unittest.TestCase):
             results = handler.get_all_status()
 
         self.assertEqual(len(results), 2)
-        self.assertEqual(results[0]["name"], "traefik")
-        self.assertEqual(results[0]["status"], "Ready")
-        self.assertEqual(results[1]["name"], "jwt-rotator")
+        self.assertEqual(results[0].name, "traefik")
+        self.assertEqual(results[0].status, "Ready")
+        self.assertEqual(results[1].name, "jwt-rotator")
         manifest.get_command.assert_any_call("component.deployment.status")
         manifest.get_command.assert_any_call("component.cronjob.status")
 
@@ -335,8 +335,8 @@ class TestComponentHandlerCustomResourceWithoutStatus(unittest.TestCase):
             handler = ComponentHandler(display_manager=Mock())
             results = handler.get_all_status()
 
-        self.assertEqual(results[0]["status"], "Present")
-        self.assertEqual(results[0]["status_category"], "healthy")
+        self.assertEqual(results[0].status, "Present")
+        self.assertEqual(results[0].status_category, "healthy")
         manifest.get_command.assert_called_with("component.customresourcewithoutstatus.status")
         cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
         self.assertEqual(cli_paramdefs["name"].value, "jupyterlab")
@@ -376,8 +376,8 @@ class TestComponentHandlerCustomResourceWithoutStatus(unittest.TestCase):
             handler = ComponentHandler(display_manager=Mock())
             results = handler.get_all_status()
 
-        self.assertEqual(results[0]["details"], "jupyter-k8s-shared")
-        self.assertEqual(results[0]["sub_component"], "access-strategy: oauth-access-strategy")
+        self.assertEqual(results[0].details, "jupyter-k8s-shared")
+        self.assertEqual(results[0].sub_component, "access-strategy: oauth-access-strategy")
 
     def test_missing_when_resource_not_found(
         self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
@@ -392,8 +392,8 @@ class TestComponentHandlerCustomResourceWithoutStatus(unittest.TestCase):
             handler = ComponentHandler(display_manager=Mock())
             results = handler.get_all_status()
 
-        self.assertEqual(results[0]["status"], "Not Found")
-        self.assertEqual(results[0]["status_category"], "degraded")
+        self.assertEqual(results[0].status, "Not Found")
+        self.assertEqual(results[0].status_category, "degraded")
 
     def test_get_component_status_present(
         self, mock_manifest_fn: Mock, mock_outputs: Mock, mock_variables: Mock
@@ -482,13 +482,15 @@ class TestComponentHandlerCustomResourceDefinition(unittest.TestCase):
             handler = ComponentHandler(display_manager=Mock())
             results = handler.get_all_status()
 
-        self.assertEqual(results[0]["status"], "Present")
-        self.assertEqual(results[0]["status_category"], "healthy")
-        self.assertEqual(results[0]["details"], "v1alpha1")
+        self.assertEqual(results[0].status, "Present")
+        self.assertEqual(results[0].status_category, "healthy")
+        self.assertEqual(results[0].details, "v1alpha1")
         manifest.get_command.assert_called_with("component.customresourcedefinition.status")
         cli_paramdefs = mock_runner.run_command_sequence.call_args.kwargs["cli_paramdefs"]
         self.assertNotIn("scope", cli_paramdefs)
         self.assertEqual(cli_paramdefs["name"].value, "workspaces.workspace.jupyter.org")
+        # CRD coordinates stay injected for backward compatibility with manifests routing
+        # the CRD through the generic k8s.custom.get-cluster instruction.
         self.assertEqual(cli_paramdefs["group"].value, "apiextensions.k8s.io")
         self.assertEqual(cli_paramdefs["plural"].value, "customresourcedefinitions")
 
@@ -505,8 +507,8 @@ class TestComponentHandlerCustomResourceDefinition(unittest.TestCase):
             handler = ComponentHandler(display_manager=Mock())
             results = handler.get_all_status()
 
-        self.assertEqual(results[0]["status"], "Not Found")
-        self.assertEqual(results[0]["status_category"], "degraded")
+        self.assertEqual(results[0].status, "Not Found")
+        self.assertEqual(results[0].status_category, "degraded")
 
 
 @patch("jupyter_deploy.handlers.resource.component_handler.tf_variables.TerraformVariablesHandler")

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_host_handler.py
@@ -404,9 +404,9 @@ class TestHostHandler(unittest.TestCase):
         result = handler.show_host(name="node-1")
 
         # Verify — keys come from manifest result-name with "host.show." prefix stripped
-        self.assertEqual(result["name"], "node-1")
-        self.assertEqual(result["status"], "Ready")
-        self.assertEqual(result["resource"], {"metadata": {"name": "node-1"}})
+        self.assertEqual(result.name, "node-1")
+        self.assertEqual(result.status, "Ready")
+        self.assertEqual(result.resource, {"metadata": {"name": "node-1"}})
 
         cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
         self.assertIn("name", cli_paramdefs)

--- a/libs/jupyter-deploy/tests/unit/handlers/resource/test_server_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/resource/test_server_handler.py
@@ -419,8 +419,8 @@ class TestServerHandler(unittest.TestCase):
         result = handler.show_server(name="my-ws", scope="default")
 
         # Verify — keys come from manifest result-name with "server.show." prefix stripped
-        self.assertEqual(result["name"], "my-ws")
-        self.assertEqual(result["resource"], {"spec": {}})
+        self.assertEqual(result.name, "my-ws")
+        self.assertEqual(result.resource, {"spec": {}})
 
         cli_paramdefs = mock_cmd_runner_fns["run_command_sequence"].call_args[1]["cli_paramdefs"]
         self.assertIn("name", cli_paramdefs)

--- a/libs/jupyter-deploy/tests/unit/handlers/test_health_handler.py
+++ b/libs/jupyter-deploy/tests/unit/handlers/test_health_handler.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 from jupyter_deploy.enum import StatusCategory
 from jupyter_deploy.handlers.health_handler import HealthHandler
 from jupyter_deploy.handlers.payloads import (
+    ComponentStatus,
     HealthLayer,
     HealthLayerResult,
     ImageStatusResult,
@@ -82,8 +83,22 @@ class TestHealthHandlerCheckComponents(unittest.TestCase):
     def test_components_returns_row_per_component(self) -> None:
         handler, _, _, mock_comp, _ = _make_handler()
         mock_comp.get_all_status.return_value = [
-            {"name": "traefik", "status_category": StatusCategory.HEALTHY, "details": "3/3 pods", "sub_component": ""},
-            {"name": "dex", "status_category": StatusCategory.DEGRADED, "details": "0/1 pods", "sub_component": ""},
+            ComponentStatus(
+                name="traefik",
+                type="Deployment",
+                status="Ready",
+                status_category=StatusCategory.HEALTHY,
+                details="3/3 pods",
+                sub_component="",
+            ),
+            ComponentStatus(
+                name="dex",
+                type="Deployment",
+                status="Degraded",
+                status_category=StatusCategory.DEGRADED,
+                details="0/1 pods",
+                sub_component="",
+            ),
         ]
 
         results = handler._check_components()

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_apiextensions_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_apiextensions_runner.py
@@ -1,0 +1,71 @@
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from jupyter_deploy.api.k8s.apiextensions import CrdInfo
+from jupyter_deploy.engine.supervised_execution import NullDisplay
+from jupyter_deploy.exceptions import InstructionNotFoundError
+from jupyter_deploy.provider.k8s.k8s_apiextensions_runner import K8sApiextensionsRunner
+from jupyter_deploy.provider.resolved_argdefs import ResolvedInstructionArgument, StrResolvedInstructionArgument
+
+
+class TestK8sApiextensionsRunner(unittest.TestCase):
+    def _make_runner(self) -> K8sApiextensionsRunner:
+        mock_api_client: Mock = Mock()
+        with patch("jupyter_deploy.provider.k8s.k8s_apiextensions_runner.client") as mock_client_mod:
+            mock_client_mod.ApiextensionsV1Api.return_value = Mock()
+            runner = K8sApiextensionsRunner(NullDisplay(), api_client=mock_api_client)
+        return runner
+
+    @patch("jupyter_deploy.provider.k8s.k8s_apiextensions_runner.k8s_apiextensions")
+    def test_get_crd_returns_typed_results(self, mock_k8s_apiextensions: Mock) -> None:
+        runner = self._make_runner()
+        resource = {
+            "metadata": {"name": "workspaces.workspace.jupyter.org"},
+            "spec": {"group": "workspace.jupyter.org"},
+        }
+        mock_k8s_apiextensions.get_crd.return_value = CrdInfo(
+            name="workspaces.workspace.jupyter.org",
+            group="workspace.jupyter.org",
+            established=True,
+            served_versions=["v1alpha1"],
+            stored_version="v1alpha1",
+            resource=resource,
+        )
+
+        args: dict[str, ResolvedInstructionArgument] = {
+            "name": StrResolvedInstructionArgument(argument_name="name", value="workspaces.workspace.jupyter.org")
+        }
+        result = runner.execute_instruction(instruction_name="get-crd", resolved_arguments=args)
+
+        self.assertEqual(result["Name"].value, "workspaces.workspace.jupyter.org")
+        self.assertEqual(json.loads(result["Resource"].value)["spec"]["group"], "workspace.jupyter.org")
+        self.assertEqual(result["Established"].value, "true")
+        self.assertEqual(result["ServedVersions"].value, ["v1alpha1"])
+        self.assertEqual(result["StoredVersion"].value, "v1alpha1")
+        mock_k8s_apiextensions.get_crd.assert_called_once_with(
+            runner.apiextensions_api, name="workspaces.workspace.jupyter.org"
+        )
+
+    @patch("jupyter_deploy.provider.k8s.k8s_apiextensions_runner.k8s_apiextensions")
+    def test_get_crd_established_false_serializes_false(self, mock_k8s_apiextensions: Mock) -> None:
+        runner = self._make_runner()
+        mock_k8s_apiextensions.get_crd.return_value = CrdInfo(
+            name="workspaces.workspace.jupyter.org",
+            group="workspace.jupyter.org",
+            established=False,
+        )
+
+        args: dict[str, ResolvedInstructionArgument] = {
+            "name": StrResolvedInstructionArgument(argument_name="name", value="workspaces.workspace.jupyter.org")
+        }
+        result = runner.execute_instruction(instruction_name="get-crd", resolved_arguments=args)
+
+        self.assertEqual(result["Established"].value, "false")
+        self.assertEqual(result["ServedVersions"].value, [])
+
+    def test_unknown_instruction_raises(self) -> None:
+        runner = self._make_runner()
+
+        with self.assertRaises(InstructionNotFoundError):
+            runner.execute_instruction(instruction_name="bogus", resolved_arguments={})

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_runner.py
@@ -160,6 +160,32 @@ class TestK8sApiRunner(unittest.TestCase):
         )
         self.assertEqual(result, expected_result)
 
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sApiextensionsRunner")
+    @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sClientFactory")
+    def test_execute_instantiates_apiextensions_runner_and_delegates(
+        self, mock_factory: Mock, mock_apiext_runner_class: Mock
+    ) -> None:
+        mock_api_client: Mock = Mock()
+        mock_factory.from_kubeconfig.return_value = mock_api_client
+
+        mock_apiext_runner: Mock = Mock()
+        mock_apiext_runner_class.return_value = mock_apiext_runner
+        expected_result = {"result_key": Mock(spec=ResolvedInstructionResult)}
+        mock_apiext_runner.execute_instruction.return_value = expected_result
+
+        runner = K8sApiRunner(NullDisplay(), kubeconfig_path="/tmp/kubeconfig")
+        resolved_args: dict[str, ResolvedInstructionArgument] = {"arg1": Mock(spec=ResolvedInstructionArgument)}
+
+        result = runner.execute_instruction(
+            instruction_name="k8s.apiextensions.get-crd", resolved_arguments=resolved_args
+        )
+
+        mock_apiext_runner_class.assert_called_once_with(ANY, api_client=mock_api_client)
+        mock_apiext_runner.execute_instruction.assert_called_once_with(
+            instruction_name="get-crd", resolved_arguments=resolved_args
+        )
+        self.assertEqual(result, expected_result)
+
     @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sCoreRunner")
     @patch("jupyter_deploy.provider.k8s.k8s_runner.K8sClientFactory")
     def test_uses_eks_cluster_when_all_params_provided(self, mock_factory: Mock, mock_core_runner_class: Mock) -> None:


### PR DESCRIPTION
This PR hardens the return types of resources and health handlers, and add dedicated API and command runner for Kubernetes CustomResourceDefinition.

Closes: #269 
Closes: #282 

### User experience
No change

### Implementation
- use `api.read_custom_resource_definition` in <jd>/api/k8s/apiextension
- register new runner in <jd>/provider/k8s/k8s_apiextensions_runner
- register w/ k8s_runner in <jd>/provider/k8s
- define cli <-> handler contract as typed payloads in <jd>/handlers/payload
- update Handler, CLI accordingly
- update `eks-oidc` manifest to use new CRD handling for CRD components

### Testing
- backward-compatibility: run resources & health E2E tests on existing `eks-oidc` template w/o updating manifest
- backward-compatibility: run server & host E2E tests on existing `base` template
- update manifest of `eks-oidc` template: run resources & health E2E tests