### PR TITLE
feat: ws readiness probes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -84,6 +84,8 @@ All `local-exec` provisioners MUST set `interpreter = ["/bin/bash", "-c"]` — T
 With `bootstrap_cluster_creator_admin_permissions = false`, the caller's IAM role MUST be listed in `admin_role_names` to retain cluster access. A `check` block validates this at plan time.
 Destroy order is load-bearing and enforced via `depends_on` (see `eks_addons.tf`/`iam_role`/`vpc` comments): VPC+roles → DaemonSet addons (CNI/kube-proxy) → node groups → Deployment addons (coredns/ebs-csi/…) → Helm releases → workspaces, so the operator stays alive through Helm uninstalls.
 
+Do NOT bump the `version` in the local charts' `Chart.yaml` (`charts/*/Chart.yaml`) when editing chart contents. Only bump versions with the versioning script.
+
 ## CI infrastructure template package
 Code: `./libs/jupyter-infra-tf-aws-iam-ci`
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/AGENT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/AGENT.md.template
@@ -10,9 +10,13 @@ jupyter-k8s operator for workspace lifecycle management, and controls access wit
 
 The template deploys:
 - A VPC with public and private subnets across 2 AZs
-- An EKS cluster with managed node groups
+- An EKS cluster in the VPC with Identity provider configured for GitHub
+- Two EKS managed node groups: `components` (operators/platform pods) and `workspaces` (workspace pods),
+  each labelled `jupyter-deploy/role=<components|workspaces>` and autoscaled by the cluster-autoscaler
 - EKS add-ons: vpc-cni, kube-proxy, coredns, pod-identity-agent, ebs-csi-driver, cert-manager, external-dns
-- Helm releases: traefik-crds, jupyter-k8s operator, aws-traefik-dex (OIDC routing)
+- Helm releases: traefik-crds, jupyter-k8s operator, jupyter-k8s-aws-oidc (OIDC routing + web UI),
+  workspace-defaults and github-rbac (local charts), cluster-autoscaler, and optionally aws-for-fluent-bit
+  for send pod logs to CloudWatch.
 - Dex as an OIDC identity provider on the cluster for kubectl authentication
 
 Unlike the single-host EC2 template, this is a multi-app deployment: each user gets their own
@@ -75,6 +79,11 @@ owners may need to approve the OAuth app for it to access team membership; see G
 ### Manage the platform components
 {{ kubernetes-component-management-instructions }}
 
+### Inspect the workspace images
+{{ image-management-instructions }}
+
+{{ aws-inspector-scanning }}
+
 ### View the full terraform logs
 
 {{ history-logs-instructions }}
@@ -119,9 +128,13 @@ Applications are gated by a `_use` boolean variable (e.g. `workspace_app_jupyter
 ### Charts directory
 
 `./charts/` contains local Helm charts:
-- `workspace-defaults/` — deploys the default access strategy and template into the shared namespace. It makes it easy for workspace users to create workspace later
-To modify chart values, edit the `yamlencode({...})` block in the corresponding `.tf` file (`workspaces.tf`).
-Charts are deployed via `helm_release` with a local path, so changes take effect on the next `jd up`.
+- `workspace-defaults/` — deploys the default WorkspaceTemplate (and its workspace-ingress
+  NetworkPolicies) into the shared namespace, so workspace users can create workspaces later
+- `github-rbac/` — Roles/RoleBindings granting the `oauth_allowed_teams` GitHub teams workspace
+  permissions in each `workspace_rbac_namespaces` namespace, as well as read permission into
+  the shared namespace (`jupyter-k8s-shared`).
+Both are deployed via `helm_release` with a local path (see `workspaces.tf`), where values are passed
+through `set = [...]` blocks. Editing a chart's templates/values takes effect on the next `jd up`.
 
 ### Web UI
 
@@ -141,6 +154,12 @@ It handles the DNS race condition on fresh deploys because:
 
 The script waits for all routing deployments (traefik, dex, oauth2-proxy, authmiddleware) to become ready,
 and triggers on domain, cluster name, or router chart version/revision changes.
+
+### Core platform daemonset and operators
+
+- core daemonset: `vpc-cni` and `kube-proxy` EKS add-ons (`eks_addons.tf`).
+- autoscaling: cluster-autoscaler scales both node groups on pending pods (`platform_cluster_autoscaler.tf`).
+- logging: optional Fluent Bit DaemonSet ships pod logs to CloudWatch (`platform_logging.tf`, `var.enable_component_logging`).
 
 ### Destroy-time workspace cleanup
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
@@ -36,6 +36,15 @@ spec:
     maxSize: "100Gi"
     defaultStorageClassName: {{ .Values.workspaceTemplate.storageClassName }}
     defaultMountPath: "/home/jovyan"
+  # Gate workspace readiness on the app actually accepting connections, so the
+  # operator does not flip status.condition[Available]=True before the server is
+  # up. Complements the access-strategy startupProbe.
+  defaultReadinessProbe:
+    tcpSocket:
+      port: {{ .Values.workspaceTemplate.readinessProbe.port }}
+    initialDelaySeconds: {{ .Values.workspaceTemplate.readinessProbe.initialDelaySeconds }}
+    periodSeconds: {{ .Values.workspaceTemplate.readinessProbe.periodSeconds }}
+    failureThreshold: {{ .Values.workspaceTemplate.readinessProbe.failureThreshold }}
   defaultPodSecurityContext:
     fsGroup: 1000
   defaultNodeSelector:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/values.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/values.yaml
@@ -27,6 +27,19 @@ workspaceTemplate:
   ownershipType: OwnerOnly
   # -- StorageClass for the workspace persistent volume.
   storageClassName: ebs-sc
+  # -- TCP readiness probe applied to workspace pods. The operator waits for this
+  # probe to pass before marking the workspace Available, so the app is reachable
+  # by the time users are redirected to it.
+  readinessProbe:
+    # -- Container port the probe connects to (the workspace app port).
+    port: 8888
+    # -- Seconds to wait after container start before the first probe.
+    initialDelaySeconds: 2
+    # -- Seconds between probe attempts.
+    periodSeconds: 3
+    # -- Consecutive failures tolerated before the probe is considered failed
+    # (with the values above, ~90s of startup grace).
+    failureThreshold: 30
   idleShutdown:
     # -- Whether to automatically stop idle workspaces.
     enabled: true

--- a/libs/jupyter-deploy/jupyter_deploy/cli/app.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/app.py
@@ -45,6 +45,7 @@ from jupyter_deploy.handlers.project.open_handler import OpenHandler
 from jupyter_deploy.handlers.project.show_handler import ShowHandler
 from jupyter_deploy.handlers.project.up_handler import UpHandler
 from jupyter_deploy.infrastructure.enum import AWSInfrastructureType, InfrastructureType
+from jupyter_deploy.manifest import JupyterDeployManifest
 from jupyter_deploy.provider.enum import ProviderType
 
 
@@ -656,6 +657,96 @@ def down(
             )
 
 
+def _print_single_tenant_open_hints(console: Console, manifest: JupyterDeployManifest) -> None:
+    """Troubleshooting hints for single-tenant templates (one host, one server).
+
+    Keyed purely on which host.*/server.* commands the manifest declares — the
+    original `jd open` behaviour, preserved verbatim for the base template.
+    """
+    has_host_status = manifest.has_command("host.status")
+    has_server_status = manifest.has_command("server.status")
+    has_host_restart = manifest.has_command("host.restart")
+    has_host_start = manifest.has_command("host.start")
+    has_server_restart = manifest.has_command("server.restart")
+    has_server_start = manifest.has_command("server.start")
+    has_host_connect = manifest.has_command("host.connect")
+
+    if not (has_host_status or has_server_status or has_host_connect):
+        return
+
+    console.line()
+    console.print("[bold]Having trouble?[/]")
+
+    if has_host_status:
+        console.print(":mag: verify that your host is running: [bold cyan]jd host status[/]")
+        if has_host_restart:
+            console.print(":wrench: try restarting it: [bold cyan]jd host restart[/]")
+        elif has_host_start:
+            console.print(":wrench: not running? Try starting it: [bold cyan]jd host start[/]")
+
+    if has_server_status:
+        console.print(":mag: verify that your server is running: [bold cyan]jd server status[/]")
+        if has_server_restart:
+            console.print(":wrench: try restarting it: [bold cyan]jd server restart[/]")
+        elif has_server_start:
+            console.print(":wrench: not running? Try starting it: [bold cyan]jd server start[/]")
+
+    if has_host_connect:
+        console.print(":bulb: or connect to your host (when running): [bold cyan]jd host connect[/]")
+    console.line()
+
+
+def _print_multi_tenant_open_hints(
+    console: Console, manifest: JupyterDeployManifest, server_name: str | None, scope: str
+) -> None:
+    """Troubleshooting hints for multi-tenant templates (shared cluster, many servers).
+
+    Branches on what the user asked to open so the hints match the target:
+    - a specific server (`--server-name`): how to check/find that server, then the stack;
+    - the default getting-started page (plain `jd open`): the stack health check.
+
+    Extensible: a future target (e.g. `--component-name`) adds another branch here.
+    Each hint is gated on the manifest actually declaring the underlying command.
+    """
+    has_health = manifest.health is not None
+    scope_suffix = f" --scope {scope}" if scope else ""
+
+    lines: list[str] = []
+    if server_name is not None:
+        # Opened a specific server: point at that server first, then broaden out.
+        if manifest.has_command("server.status"):
+            lines.append(
+                f":mag: verify the server is ready: [bold cyan]jd server status --name {server_name}{scope_suffix}[/]"
+            )
+        if manifest.has_command("server.list"):
+            lines.append(f":mag: list the available servers: [bold cyan]jd server list{scope_suffix}[/]")
+        if has_health:
+            lines.append(":mag: check the overall deployment health: [bold cyan]jd health[/]")
+    else:
+        # Opened the default getting-started page: the stack health check is the go-to.
+        if has_health:
+            lines.append(":mag: check the deployment health: [bold cyan]jd health[/]")
+
+    if not lines:
+        return
+
+    console.line()
+    console.print("[bold]Having trouble?[/]")
+    for line in lines:
+        console.print(line)
+    console.line()
+
+
+def _print_open_troubleshooting(
+    console: Console, manifest: JupyterDeployManifest, server_name: str | None, scope: str
+) -> None:
+    """Dispatch to tenant-appropriate `jd open` troubleshooting hints."""
+    if manifest.multi_server or manifest.multi_host:
+        _print_multi_tenant_open_hints(console, manifest, server_name, scope)
+    else:
+        _print_single_tenant_open_hints(console, manifest)
+
+
 @runner.app.command()
 def open(
     server_name: Annotated[str | None, typer.Option("--server-name", help="Name of the server to open.")] = None,
@@ -698,36 +789,7 @@ def open(
         finally:
             # Show troubleshooting help based on available commands in manifest (only if URL was available)
             if not url_unavailable:
-                manifest = handler.project_manifest
-                has_host_status = manifest.has_command("host.status")
-                has_server_status = manifest.has_command("server.status")
-                has_host_restart = manifest.has_command("host.restart")
-                has_host_start = manifest.has_command("host.start")
-                has_server_restart = manifest.has_command("server.restart")
-                has_server_start = manifest.has_command("server.start")
-                has_host_connect = manifest.has_command("host.connect")
-
-                if has_host_status or has_server_status or has_host_connect:
-                    console.line()
-                    console.print("[bold]Having trouble?[/]")
-
-                    if has_host_status:
-                        console.print(":mag: verify that your host is running: [bold cyan]jd host status[/]")
-                        if has_host_restart:
-                            console.print(":wrench: try restarting it: [bold cyan]jd host restart[/]")
-                        elif has_host_start:
-                            console.print(":wrench: not running? Try starting it: [bold cyan]jd host start[/]")
-
-                    if has_server_status:
-                        console.print(":mag: verify that your server is running: [bold cyan]jd server status[/]")
-                        if has_server_restart:
-                            console.print(":wrench: try restarting it: [bold cyan]jd server restart[/]")
-                        elif has_server_start:
-                            console.print(":wrench: not running? Try starting it: [bold cyan]jd server start[/]")
-
-                    if has_host_connect:
-                        console.print(":bulb: or connect to your host (when running): [bold cyan]jd host connect[/]")
-                    console.line()
+                _print_open_troubleshooting(console, handler.project_manifest, server_name, scope)
 
         # Exit with error code if browser failed
         if browser_failed:

--- a/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
+++ b/libs/jupyter-deploy/jupyter_deploy/cli/error_decorator.py
@@ -80,7 +80,7 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         yield
 
     except ManifestNotFoundError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(
             ":bulb: Change your working directory to a project directory or create one with [bold cyan]jd init PATH[/]"
@@ -88,37 +88,37 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except ReadManifestError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(":bulb: Check file permissions or disk space for the manifest file")
         raise typer.Exit(code=1) from None
 
     except InvalidManifestError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(":bulb: Review your manifest.yaml file for syntax errors or missing required fields")
         raise typer.Exit(code=1) from None
 
     except CommandNotImplementedError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         raise typer.Exit(code=1) from None
 
     except InvalidProviderCredentialsError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.original_message:
             console.line()
             console.print(e.original_message, style="dim")
         raise typer.Exit(code=1) from None
 
     except ProviderPermissionError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.original_message:
             console.line()
             console.print(e.original_message, style="dim")
         raise typer.Exit(code=1) from None
 
     except ToolRequiredError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.error_msg or e.installation_url:
             console.line()
 
@@ -129,31 +129,31 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except SupervisedExecutionError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(":bulb: To view the full logs, run: [bold cyan]jd history show[/]")
         raise typer.Exit(code=e.retcode) from None
 
     except InvalidPresetError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(f"Available presets: {', '.join(e.valid_presets)}")
         raise typer.Exit(code=1) from None
 
     except InvalidServiceError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(f"Available services: {', '.join(e.valid_services)}")
         raise typer.Exit(code=1) from None
 
     except InvalidStoreTypeError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(f"Available store types: {', '.join(e.valid_store_types)}")
         raise typer.Exit(code=1) from None
 
     except (UnreachableHostError, IncompatibleHostStateError) as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         if e.hint:
             # Use the specific hint if provided (e.g., from IncompatibleHostStateError)
@@ -165,7 +165,7 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except HostCommandInstructionError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.stdout:
             console.rule("stdout")
             console.print(e.stdout)
@@ -178,25 +178,25 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=e.retcode) from None
 
     except InvalidVariablesDotYamlError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(":bulb: Review your variables.yaml file for syntax errors", style="dim")
         raise typer.Exit(code=1) from None
 
     except LogNotFoundError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(":bulb: To see available logs: [bold cyan]jd history list CMD[/]")
         raise typer.Exit(code=1) from None
 
     except ResourceNameRequiredError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(f":bulb: Run [bold cyan]{e.list_command}[/] to see available {e.resource_type}s.")
         raise typer.Exit(code=1) from None
 
     except ComponentNotFoundError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(f"Available components: {', '.join(e.valid_components)}")
         console.print(":bulb: Run [bold cyan]jd component list[/] to see all components.")
@@ -228,7 +228,7 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except ResourceNotFoundError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         raise typer.Exit(code=1) from None
 
     except (
@@ -240,11 +240,11 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         InvalidInstructionResultError,
         LogCleanupError,
     ) as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         raise typer.Exit(code=1) from None
 
     except DownAutoApproveRequiredError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.persisting_resources:
             console.print("  Persisting resources:")
             for resource in e.persisting_resources:
@@ -252,12 +252,12 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except (VariableNotFoundError, OutputNotFoundError) as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         # check if next steps provided, if so print them
         raise typer.Exit(code=1) from None
 
     except UrlNotAvailableError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print("Make sure you have configured and deployed your project.")
         console.print(":bulb: To configure the project, run: [bold cyan]jd config[/]")
@@ -265,32 +265,32 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except UrlNotSecureError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print("Only HTTPS URLs are allowed for security reasons.", style="red")
         raise typer.Exit(code=1) from None
 
     except OpenWebBrowserError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(f"URL: [bold cyan]{e.url}[/]")
         console.print(":bulb: Copy the URL and open it manually in your browser.")
         raise typer.Exit(code=1) from None
 
     except (ReadConfigurationError, WriteConfigurationError) as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.print(f"  File: {e.file_path}", style="dim")
         raise typer.Exit(code=1) from None
 
     except ProjectIdNotAvailableError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.hint:
             console.line()
             console.print(f":bulb: {e.hint}")
         raise typer.Exit(code=1) from None
 
     except ProjectNotFoundInStoreError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         hint_cmd = "jd projects list --store-type"
         if e.store_type:
@@ -303,7 +303,7 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except ProjectStoreReadError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         if e.hint:
             console.print(f":bulb: {e.hint}", style="dim")
@@ -314,20 +314,20 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
         raise typer.Exit(code=1) from None
 
     except ProjectStoreAccessConfigurationError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         console.line()
         console.print(":bulb: Run [bold cyan]jd up[/] again to retry the backend migration.")
         raise typer.Exit(code=1) from None
 
     except ProjectStoreNotFoundError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.hint:
             console.line()
             console.print(f":bulb: {e.hint}")
         raise typer.Exit(code=1) from None
 
     except UnsupportedProviderRegionError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.hint:
             console.line()
             console.print(f":bulb: {e.hint}")
@@ -335,7 +335,7 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
 
     # Keep base classes below so that child classes special handling take precedence
     except ConfigurationError as e:
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         if e.hint:
             console.line()
             console.print(f":bulb: {e.hint}", style="dim")
@@ -343,7 +343,7 @@ def handle_cli_errors(console: Console) -> Generator[None, None, None]:
 
     except JupyterDeployError as e:
         # Catch-all for any JupyterDeployError not specifically handled above
-        console.print(f":x: {e}", style="bold red")
+        console.print(f":x: {e}", style="bold red", highlight=False)
         raise typer.Exit(code=1) from None
 
     # Let all other exceptions bubble up naturally - they will be caught by Typer's default handler

--- a/libs/jupyter-deploy/jupyter_deploy/engine/engine_open.py
+++ b/libs/jupyter-deploy/jupyter_deploy/engine/engine_open.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from jupyter_deploy.engine import outdefs
 from jupyter_deploy.engine.engine_outputs import EngineOutputsHandler
-from jupyter_deploy.exceptions import UrlNotAvailableError
+from jupyter_deploy.exceptions import CommandNotImplementedError, UrlNotAvailableError
 from jupyter_deploy.manifest import JupyterDeployManifest
 
 
@@ -27,14 +27,18 @@ class EngineOpenHandler:
             str: The URL to access the notebook app
 
         Raises:
+            CommandNotImplementedError: If the template does not declare an 'open_url' value
             UrlNotAvailableError: If URL cannot be retrieved or is empty
             ValueError: If the 'open_url' output is malformed in the manifest
-            NotImplementedError: If the 'open_url' output type is not implemented
             TypeError: If the 'open_url' output has incorrect type
-            KeyError: If the 'open_url' output is not defined in the manifest
         """
         try:
             url_outdef = self.output_handler.get_declared_output_def("open_url", outdefs.StrTemplateOutputDefinition)
+        except NotImplementedError:
+            # The manifest does not declare an 'open_url' value: this template has no
+            # single URL to open. Surface the standard "not implemented" error rather
+            # than letting the bare NotImplementedError escape as an uncaught traceback.
+            raise CommandNotImplementedError("open") from None
         except KeyError:
             raise UrlNotAvailableError("URL not available. Run 'jd config' then 'jd up'.") from None
 

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/aws-inspector-scanning.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/aws-inspector-scanning.md
@@ -1,0 +1,8 @@
+By default ECR uses basic scanning, which has no EPSS scores. For richer reports, enable
+Amazon Inspector enhanced scanning once per account and region (per-image cost applies):
+
+```bash
+aws inspector2 enable --resource-types ECR
+```
+
+`jd image vulnerabilities` then picks up Inspector findings automatically, adding EPSS.

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/image-management-instructions.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/image-management-instructions.md
@@ -1,0 +1,34 @@
+Images are the container images this template builds for its applications and pushes to an
+image registry. You address an image by `--name`; `jd image list` reports the images this
+template defines.
+
+```bash
+# list the images declared by this template
+jd image list
+
+# check whether an image has been built and pushed to its registry (available/missing)
+jd image status --name IMAGE-NAME
+```
+
+`jd image show` prints the registry location, the current tag, and the scanner backing
+vulnerability reporting. `jd image tags` lists the tags available in the registry with
+their push time and digest.
+
+```bash
+jd image show --name IMAGE-NAME
+jd image tags --name IMAGE-NAME
+```
+
+`jd image vulnerabilities` reports the HIGH and CRITICAL findings the scanner detected for
+an image. It uses the currently deployed tag unless you pass `--tag`. The EPSS column is
+the Exploit Prediction Scoring System probability (0–100%) that a CVE will be exploited
+within 30 days — higher is more urgent; it shows `n/a` for scanners that do not provide it
+(e.g. basic registry scanning).
+
+```bash
+# vulnerabilities for the deployed tag
+jd image vulnerabilities --name IMAGE-NAME
+
+# vulnerabilities for a specific tag
+jd image vulnerabilities --name IMAGE-NAME --tag TAG
+```

--- a/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/kubernetes-component-management-instructions.md
+++ b/libs/jupyter-deploy/jupyter_deploy/handlers/init_static/agent/kubernetes-component-management-instructions.md
@@ -1,29 +1,31 @@
 Components are the platform-level resources supporting your apps (e.g. router,
-identity provider, controllers). Each one is backed by a Kubernetes **Deployment** (a
-long-running workload), a **CronJob** (a scheduled job), or a **HelmRelease** (a chart
-managing a set of objects). You address a component by `--name`; `jd component list`
-reports each one's name and type.
+identity provider, controllers, node-level agents). Each one is backed by a Kubernetes
+**Deployment** (a long-running workload), a **DaemonSet** (one pod per node, e.g. a CNI
+or log shipper), a **StatefulSet**, a **CronJob** (a scheduled job), or a **HelmRelease**
+(a chart managing a set of objects). You address a component by `--name`; `jd component
+list` reports each one's name and type.
 
 ```bash
-# list the components declared by this template (with their Deployment/CronJob type)
+# list the components declared by this template (with their type)
 jd component list
 
 # check the status of a specific component
 jd component status --name COMPONENT-NAME
 ```
 
-`jd component show` reads the full Kubernetes resource and prints it as JSON — the
-equivalent of `kubectl describe`/`kubectl get -o json` for that Deployment or CronJob.
-Use it to inspect the spec, replica counts, conditions, and events.
+`jd component status` and `jd component show` work for every component type. `show` reads
+the full Kubernetes resource and prints it as JSON — the equivalent of `kubectl
+describe`/`kubectl get -o json`. Use it to inspect the spec, replica counts, conditions,
+and events.
 
 ```bash
 jd component show --name COMPONENT-NAME
 ```
 
-`jd component logs` fetches the logs of the component's pod. Anything after `--` is passed
-straight to `kubectl logs`, so you can use its flags — e.g. `--tail N` for the last N
-lines, `--since 10m`, `-f` to follow, `--previous` for a crashed container's prior run,
-or `-c CONTAINER` to select a container.
+`jd component logs` fetches the logs of the component's pod (Deployment- and CronJob-backed
+components only). Anything after `--` is passed straight to `kubectl logs`, so you can use
+its flags — e.g. `--tail N` for the last N lines, `--since 10m`, `-f` to follow,
+`--previous` for a crashed container's prior run, or `-c CONTAINER` to select a container.
 
 ```bash
 # last 100 lines
@@ -33,7 +35,8 @@ jd component logs --name COMPONENT-NAME -- --tail 100
 jd component logs --name COMPONENT-NAME -- --previous -f
 ```
 
-The remaining verbs depend on the component type:
+The remaining verbs depend on the component type (DaemonSet- and StatefulSet-backed
+components support only `status` and `show`):
 
 ```bash
 # restart a Deployment-backed component (rolling restart; not valid for a CronJob)

--- a/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
+++ b/libs/jupyter-deploy/tests/unit/cli/test_app_open.py
@@ -11,14 +11,24 @@ from jupyter_deploy.exceptions import OpenWebBrowserError, UrlNotAvailableError,
 class TestOpenCommand(unittest.TestCase):
     """Test cases for the open command."""
 
-    def get_mock_open_handler(self) -> tuple[Mock, dict[str, Mock]]:
-        """Return a mocked open handler with manifest commands."""
+    def get_mock_open_handler(
+        self, multi_server: bool = False, multi_host: bool = False
+    ) -> tuple[Mock, dict[str, Mock]]:
+        """Return a mocked open handler with manifest commands.
+
+        Defaults to a single-tenant manifest (multi_server/multi_host False). Pass
+        multi_server=True to exercise the multi-tenant troubleshooting branch.
+        """
         mock_open_handler = Mock()
         mock_open = Mock(return_value="https://example.com/jupyter")
         mock_manifest = Mock()
 
         # Default manifest with all commands available
         mock_manifest.has_command = Mock(return_value=True)
+        mock_manifest.multi_server = multi_server
+        mock_manifest.multi_host = multi_host
+        # Multi-tenant hints gate the health suggestion on a declared health block.
+        mock_manifest.health = object() if (multi_server or multi_host) else None
 
         mock_open_handler.open = mock_open
         mock_open_handler.project_manifest = mock_manifest
@@ -381,3 +391,104 @@ class TestOpenCommand(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0)
         mock_open_fns["open"].assert_called_once_with(name=None, scope="team-a")
+
+    # --- Multi-tenant troubleshooting hints ---
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_multi_tenant_default_shows_health(
+        self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock
+    ) -> None:
+        """Plain `jd open` on a multi-tenant template points at the health check, not host/server."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler(multi_server=True)
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Having trouble?", result.output)
+        self.assertIn("jd health", result.output)
+        # No single-tenant "your host"/"your server" hints on a shared cluster.
+        self.assertNotIn("jd host status", result.output)
+        self.assertNotIn("jd server status", result.output)
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_multi_tenant_server_name_shows_server_hints(
+        self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock
+    ) -> None:
+        """`jd open --server-name` on a multi-tenant template targets that server, then broadens out."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler(multi_server=True)
+        mock_open_fns["open"].return_value = "https://example.com/workspaces/default/my-ws/"
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open", "--server-name", "my-ws"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("Having trouble?", result.output)
+        self.assertIn("jd server status --name my-ws", result.output)
+        self.assertIn("jd server list", result.output)
+        self.assertIn("jd health", result.output)
+        # No --scope in the hint when the user did not pass one.
+        self.assertNotIn("--scope", result.output)
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_multi_tenant_server_name_threads_scope(
+        self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock
+    ) -> None:
+        """A user-supplied --scope is threaded into the server hints."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler(multi_server=True)
+        mock_open_fns["open"].return_value = "https://example.com/workspaces/team-a/my-ws/"
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open", "--server-name", "my-ws", "--scope", "team-a"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("jd server status --name my-ws --scope team-a", result.output)
+        self.assertIn("jd server list --scope team-a", result.output)
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_multi_tenant_gates_hints_on_declared_commands(
+        self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock
+    ) -> None:
+        """Multi-tenant server hints are gated on the manifest declaring the underlying commands."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler(multi_server=True)
+        mock_open_fns["open"].return_value = "https://example.com/workspaces/default/my-ws/"
+
+        # Only server.status is declared; no server.list and no health block.
+        def has_command(cmd: str) -> bool:
+            return cmd == "server.status"
+
+        mock_open_fns["project_manifest"].has_command = Mock(side_effect=has_command)
+        mock_open_fns["project_manifest"].health = None
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open", "--server-name", "my-ws"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("jd server status --name my-ws", result.output)
+        self.assertNotIn("jd server list", result.output)
+        self.assertNotIn("jd health", result.output)
+
+    @patch("jupyter_deploy.cli.app.OpenHandler")
+    @patch("jupyter_deploy.cmd_utils.project_dir")
+    def test_open_command_multi_tenant_no_hint_when_nothing_declared(
+        self, mock_project_ctx_manager: Mock, mock_open_handler_cls: Mock
+    ) -> None:
+        """No hint block on a multi-tenant template that declares no relevant commands or health."""
+        mock_open_handler_instance, mock_open_fns = self.get_mock_open_handler(multi_server=True)
+        mock_open_fns["project_manifest"].has_command = Mock(return_value=False)
+        mock_open_fns["project_manifest"].health = None
+        mock_open_handler_cls.return_value = mock_open_handler_instance
+
+        runner = CliRunner()
+        result = runner.invoke(app_runner.app, ["open"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertNotIn("Having trouble?", result.output)

--- a/libs/jupyter-deploy/tests/unit/engine/test_engine_open.py
+++ b/libs/jupyter-deploy/tests/unit/engine/test_engine_open.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 
 from jupyter_deploy.engine.engine_open import EngineOpenHandler
 from jupyter_deploy.engine.outdefs import StrTemplateOutputDefinition
-from jupyter_deploy.exceptions import UrlNotAvailableError
+from jupyter_deploy.exceptions import CommandNotImplementedError, UrlNotAvailableError
 
 
 class TestEngineOpen(unittest.TestCase):
@@ -63,8 +63,9 @@ class TestEngineOpen(unittest.TestCase):
             output_handler=mock_outputs_handler,
         )
 
-        # Act & Verify - NotImplementedError should bubble up
-        with self.assertRaises(NotImplementedError):
+        # Act & Verify - a template without an 'open_url' value surfaces the standard
+        # CommandNotImplementedError, not a bare NotImplementedError traceback.
+        with self.assertRaises(CommandNotImplementedError):
             handler.get_url()
 
         mock_outputs_handler_fns["get_declared_output_def"].assert_called_once()


### PR DESCRIPTION
This PR update the default `WorkspaceTemplate` in the `eks-oidc` template to use [readinessProbe](https://github.com/jupyter-infra/jupyter-k8s/blob/b52e003a9e535c00a2a18729b4818992f79f710e/api/v1alpha1/workspace_types.go#L195). The probes ensures the workspace pod is ready to accept traffic from the workspace service, which gates the workspace deployment readiness and in turn improve the accuracy of the `workspace.status.conditions`. Refer to [PR417](https://github.com/jupyter-infra/jupyter-k8s/pull/417) and [issue-416](https://github.com/jupyter-infra/jupyter-k8s/issues/416) for more details.

Also in this PR:
- improve `AGENT.md` of `eks-oidc` template: a/ image reference + scanning, b/ touch on platform daemonset/operator, c/ touch on autoscaling and logging
- improve `jd open` handling when a template does not declare an `open_url`
- improve `jd open` hints for multi-tenant templates, and when used with `--server-name <>`

### Implementation
1. add `defaultReadinessProbe` config to the `WorkspaceTemplate` defined in the `workspace-defaults` helm chart
2. expose readiness probe settings to helm chart knobs
3. update `OpenHandler` to raise special exception when `open_url` is not declared by the template manifest
4. update <jd>/app to tailor hints to the use case: a/ single tenant, b/ multi-tenant default or c/ multi-tenant for server
5. add template inserts for image and on how to turn on advanced scanning
6. update `AGENT.md.tempate` in the `eks-oidc` template to include 5/ and to describe logging and autoscaling

### Testing
- updated existing `eks-oidc` deployment, created new ws in the UI, verify become `Available` and that readiness probe was configured
- tested `jd open` hints for base template, `eks-oidc` template and with `--server-name <>`

### Screenshots
**jd open > base**
<img width="428" height="120" alt="Screenshot 2026-07-17 at 12 29 44 PM" src="https://github.com/user-attachments/assets/aaad4c51-6c80-4b35-86e3-fcf346af15df" />

**jd open > eks-oidc**
<img width="391" height="69" alt="Screenshot 2026-07-17 at 12 29 11 PM" src="https://github.com/user-attachments/assets/bf2a9401-f2f5-4116-8f08-38bec19353c9" />

**jd open > workspace**
<img width="591" height="89" alt="Screenshot 2026-07-17 at 12 30 35 PM" src="https://github.com/user-attachments/assets/3afacc4c-4f0c-4d60-809a-e7ec4c2b0fff" />

**jd open > non-existent ws**
<img width="512" height="114" alt="Screenshot 2026-07-17 at 12 31 01 PM" src="https://github.com/user-attachments/assets/42edcd4b-abb0-411b-aae8-156030b2e4ac" />

**jd open > non-existent ns**
<img width="616" height="115" alt="Screenshot 2026-07-17 at 12 31 33 PM" src="https://github.com/user-attachments/assets/3e9c35fe-7524-44ff-9d7e-529d25aba77b" />



