### PR TITLE
test: make web-app deploy-verify retry-tolerant of warmup window

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_deployment.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_deployment.py
@@ -78,11 +78,34 @@ def test_web_app_accessible_after_deployment(
     dex_oauth_app: DexGitHubOAuth2ProxyApplication,
     getting_started_url: str,
 ) -> None:
-    """Web UI is accessible via OAuth after deploy."""
-    dex_oauth_app.ensure_authenticated()
-    dex_oauth_app.page.goto(getting_started_url, wait_until="load", timeout=60000)
-    content = dex_oauth_app.page.content()
-    assert "workspaces" in content.lower(), f"Expected web UI content, got:\n{content[:500]}"
+    """Web UI is accessible via OAuth after deploy.
+
+    Retries the full auth + load + assert to tolerate the post-deploy warmup
+    window: routing pods (oauth2-proxy/authmiddleware) can briefly CrashLoop on
+    first start, which makes the OAuth redirect inside ensure_authenticated()
+    (or the page load) transiently time out even though the deploy is healthy.
+    ensure_authenticated() re-navigates and re-evaluates cookies on each call,
+    so retrying is idempotent and self-correcting.
+    """
+    max_attempts = 5
+    backoff_s = 30
+    last_error: Exception | None = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            dex_oauth_app.ensure_authenticated()
+            dex_oauth_app.page.goto(getting_started_url, wait_until="load", timeout=60000)
+            content = dex_oauth_app.page.content()
+            assert "workspaces" in content.lower(), f"Expected web UI content, got:\n{content[:500]}"
+            return
+        except Exception as e:
+            last_error = e
+            if attempt < max_attempts:
+                dex_oauth_app.page.wait_for_timeout(backoff_s * 1000)
+
+    raise AssertionError(
+        f"Web UI not accessible after {max_attempts} attempts "
+        f"(~{(max_attempts - 1) * backoff_s}s warmup window): {last_error}"
+    )
 
 
 @pytest.mark.order(ORDER_DEPLOYMENT + 4)


### PR DESCRIPTION
## Summary

Makes `test_web_app_accessible_after_deployment` (EKS OIDC deploy-verify) retry-tolerant of the post-deploy warmup window, so a healthy deploy isn't failed by transient auth-path timing.

## Problem

On a fresh deploy, the test failed with a Playwright timeout in the OAuth redirect inside `ensure_authenticated()` (`dex._complete_oauth_flow` → `wait_for_url(hostname != "github.com")`). The deploy itself was healthy — Terraform `Apply complete! 118 added`, `All routing deployments are ready` — but `oauth2-proxy`/`authmiddleware` had just recovered from a transient startup `CrashLoopBackOff` (the deploy's `wait_for_routing_ready` step restarted them and they became ready ~54s later). The single-shot verify hit that window before the auth path was warm.

This is not a cookie/auth-state problem: `ensure_authenticated()` → `login_with_2fa()` tries cookie reuse first and falls back to full 2FA login if cookies are stale. The failure was purely warmup timing in the redirect.

## Fix

Wrap the full `ensure_authenticated()` + `goto` + content assert in a bounded retry (5 attempts, 30s backoff → ~2 min window). `ensure_authenticated()` re-navigates and re-evaluates cookies on each call, so retrying is idempotent and self-correcting — a partial cookie state from a failed attempt is re-resolved. Still raises with the last error if the UI is genuinely inaccessible, so real regressions aren't masked.

Localized to this one deploy-verify test; does not touch the shared OAuth helper (`github.py`/`dex.py`) that every other e2e test depends on.

## Context

This is the last blocker for the aws-oidc chart `v0.2.0` release. The release's E2E fresh-deploy gate checks out `jupyter-deploy` at `main`, so this must merge to `main` before the release run picks it up.

`ruff check` passes; no new lint suppressions (the lib doesn't select `BLE`).
