### PR TITLE
test: retry components-layer health to tolerate transient degraded DaemonSets

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import time
 
 import pytest
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
@@ -112,42 +113,59 @@ def test_health_components_layer(e2e_deployment: EndToEndDeployment) -> None:
         f"Expected aws-node + kube-proxy DaemonSet components, got {sorted(daemonset_names)}"
     )
 
-    for entry in layers:
-        assert entry["layer"] == "components"
-        name = entry["name"]
-        if name in EXPECTED_CRONJOBS:
-            assert entry["status_category"] in ("healthy", "in-progress"), (
-                f"CronJob '{name}' unexpected status_category: {entry['status_category']}"
-            )
-        else:
-            assert entry["status_category"] == "healthy", (
-                f"Component '{name}' not healthy: status_category={entry['status_category']}"
-            )
-        assert entry["status"] != ""
+    def _validate_entries(entries: list) -> None:
+        for entry in entries:
+            assert entry["layer"] == "components"
+            name = entry["name"]
+            if name in EXPECTED_CRONJOBS:
+                assert entry["status_category"] in ("healthy", "in-progress"), (
+                    f"CronJob '{name}' unexpected status_category: {entry['status_category']}"
+                )
+            else:
+                assert entry["status_category"] == "healthy", (
+                    f"Component '{name}' not healthy: status_category={entry['status_category']}"
+                )
+            assert entry["status"] != ""
 
-        if name in crd_names:
-            # CRD rows surface the served API version (e.g. v1alpha1) in details.
-            assert entry["status"] == "Present", f"CRD '{name}' status: {entry['status']}"
-            assert entry["detail"] == "v1alpha1", f"CRD '{name}' detail: {entry['detail']}"
+            if name in crd_names:
+                # CRD rows surface the served API version (e.g. v1alpha1) in details.
+                assert entry["status"] == "Present", f"CRD '{name}' status: {entry['status']}"
+                assert entry["detail"] == "v1alpha1", f"CRD '{name}' detail: {entry['detail']}"
 
-        if name in cr_names:
-            # Access-strategy / template rows surface their namespace in details and a labeled
-            # value (access-resources count / access-strategy ref) in the sub-component cell.
-            assert entry["status"] == "Present", f"CR '{name}' status: {entry['status']}"
-            assert entry["detail"] != "", f"CR '{name}' should surface its namespace in detail"
-            assert _LABELED_VALUE_RE.match(entry["sub_component"]), (
-                f"CR '{name}' sub-component should be a 'label: value' pair, got: {entry['sub_component']!r}"
-            )
+            if name in cr_names:
+                # Access-strategy / template rows surface their namespace in details and a labeled
+                # value (access-resources count / access-strategy ref) in the sub-component cell.
+                assert entry["status"] == "Present", f"CR '{name}' status: {entry['status']}"
+                assert entry["detail"] != "", f"CR '{name}' should surface its namespace in detail"
+                assert _LABELED_VALUE_RE.match(entry["sub_component"]), (
+                    f"CR '{name}' sub-component should be a 'label: value' pair, got: {entry['sub_component']!r}"
+                )
 
-        if name in helm_names:
-            # HelmRelease rows report the release status, the target namespace in details,
-            # and a "resources: <count>" sub-component with a positive object count. In JSON
-            # output sub_component is the raw payload; the table renders it as "resources: N".
-            assert entry["status"] == "deployed", f"HelmRelease '{name}' status: {entry['status']}"
-            assert entry["detail"] != "", f"HelmRelease '{name}' should surface its namespace in detail"
-            sub = json.loads(entry["sub_component"])
-            assert sub["name"] == "resources", f"HelmRelease '{name}' sub-component label: {sub['name']!r}"
-            assert int(sub["status"]) > 0, f"HelmRelease '{name}' should track at least one resource: {sub!r}"
+            if name in helm_names:
+                # HelmRelease rows report the release status, the target namespace in details,
+                # and a "resources: <count>" sub-component with a positive object count. In JSON
+                # output sub_component is the raw payload; the table renders it as "resources: N".
+                assert entry["status"] == "deployed", f"HelmRelease '{name}' status: {entry['status']}"
+                assert entry["detail"] != "", f"HelmRelease '{name}' should surface its namespace in detail"
+                sub = json.loads(entry["sub_component"])
+                assert sub["name"] == "resources", f"HelmRelease '{name}' sub-component label: {sub['name']!r}"
+                assert int(sub["status"]) > 0, f"HelmRelease '{name}' should track at least one resource: {sub!r}"
+
+    # Core add-on DaemonSets (aws-node, kube-proxy) can transiently report 'degraded' while
+    # Karpenter scales nodes and their pods start on a newly-joined node — not a deploy failure.
+    # Retry the per-component validation (re-fetching health) to let them settle; the final
+    # attempt re-raises, so a component that stays unhealthy still fails the test.
+    max_attempts = 5
+    for attempt in range(1, max_attempts + 1):
+        try:
+            _validate_entries(layers)
+            break
+        except AssertionError:
+            if attempt == max_attempts:
+                raise
+            time.sleep(15)
+            result = e2e_deployment.cli.run_command(["jupyter-deploy", "health", "--components", "--json"])
+            layers = json.loads(result.stdout)["layers"]
 
 
 def test_health_load_balancer_layer(e2e_deployment: EndToEndDeployment) -> None:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
@@ -155,7 +155,10 @@ def test_health_components_layer(e2e_deployment: EndToEndDeployment) -> None:
     # Karpenter scales nodes and their pods start on a newly-joined node — not a deploy failure.
     # Retry the per-component validation (re-fetching health) to let them settle; the final
     # attempt re-raises, so a component that stays unhealthy still fails the test.
+    # 5 attempts x 45s = ~3 min window, enough to cover a Karpenter node provision +
+    # CNI (aws-node) pod init cycle, which can take 1-2 min.
     max_attempts = 5
+    retry_interval_s = 45
     for attempt in range(1, max_attempts + 1):
         try:
             _validate_entries(layers)
@@ -163,7 +166,7 @@ def test_health_components_layer(e2e_deployment: EndToEndDeployment) -> None:
         except AssertionError:
             if attempt == max_attempts:
                 raise
-            time.sleep(15)
+            time.sleep(retry_interval_s)
             result = e2e_deployment.cli.run_command(["jupyter-deploy", "health", "--components", "--json"])
             layers = json.loads(result.stdout)["layers"]
 


### PR DESCRIPTION
## Summary

Makes `test_health_components_layer` retry-tolerant of the post-deploy warmup window, so a healthy fresh deploy isn't failed by a transiently-degraded CNI DaemonSet.

## Problem

A fresh deploy failed with:

```
AssertionError: Component 'aws-node' not healthy: status_category=degraded
1 failed, 158 passed
```

`aws-node` and `kube-proxy` are EKS core add-on DaemonSets. They transiently report `degraded` while Karpenter scales nodes and their pods start on a newly-joined node — the deploy was healthy (Terraform apply complete, all routing deployments ready). The single-shot check hit that window. The sibling `test_health_all_layers` already tolerates `degraded` for the same reason.

## Fix

Extract the per-component validation into a nested helper and retry it (5 attempts, 15s apart, re-fetching `jd health --components --json` each time) so the DaemonSets can settle. The final attempt re-raises, so a component that stays unhealthy past the ~1 min window still fails the test — **the strict signal is preserved** (a genuinely broken CNI is still caught; we do not permanently accept `degraded`).

Structural assertions (component count, names, type sets) stay outside the retry since they don't change over time.

## Context

Follow-up to #327 (same class of post-deploy warmup flake, same repo pattern). This is the last known blocker for the aws-oidc chart `v0.2.0` release, whose E2E fresh-deploy gate checks out `jupyter-deploy` at `main`.

`ruff check` passes; no new lint suppressions.
