### PR TITLE
fix: k8s daemonset status, harden e2e tests

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_deployment.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_deployment.py
@@ -14,10 +14,6 @@ from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 
 ORDER_DEPLOYMENT = 1
 
-EXPECTED_CRONJOBS = [
-    "jwt-rotator",
-]
-
 
 @pytest.mark.order(ORDER_DEPLOYMENT)
 @pytest.mark.full_deployment
@@ -30,6 +26,7 @@ def test_cluster_active_after_deployment(e2e_deployment: EndToEndDeployment) -> 
 
 @pytest.mark.order(ORDER_DEPLOYMENT + 2)
 @pytest.mark.full_deployment
+@pytest.mark.usefixtures("kubernetes_cluster_login")
 def test_health_all_pass_after_deployment(e2e_deployment: EndToEndDeployment) -> None:
     """All health layers pass after a fresh deploy."""
     e2e_deployment.ensure_deployed()
@@ -57,8 +54,20 @@ def test_health_all_pass_after_deployment(e2e_deployment: EndToEndDeployment) ->
     for name in manifest_components:
         assert name in component_names, f"Expected component '{name}' in health output"
 
+    # Skip DaemonSet status here (aws-node, kube-proxy, fluent-bit): they can sit in a
+    # transient 'in-progress' state while Karpenter scales a node and its pod starts on the
+    # newly-joined node, which a single-shot assertion can't distinguish from a stuck pod.
+    # This is a smoke gate, not the exhaustive check — DaemonSet health is fully validated
+    # by test_health.py::test_health_components_layer, which retries until they converge to
+    # healthy (same workflow, same cluster). CronJobs may legitimately report 'in-progress'
+    # (not yet fired) rather than 'healthy'. Both sets are derived from the manifest types.
+    daemonset_names = {n for n, c in manifest_components.items() if c.type == "DaemonSet"}
+    cronjob_names = {n for n, c in manifest_components.items() if c.type == "CronJob"}
+
     for entry in layers:
-        if entry["name"] in EXPECTED_CRONJOBS:
+        if entry["name"] in daemonset_names:
+            continue
+        if entry["name"] in cronjob_names:
             assert entry["status_category"] in ("healthy", "in-progress"), (
                 f"CronJob '{entry['name']}' unexpected status: "
                 f"status_category={entry['status_category']}, detail={entry['detail']}"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_health.py
@@ -10,11 +10,6 @@ from pytest_jupyter_deploy.deployment import EndToEndDeployment
 # A CR sub-component renders as a non-empty "label: value" pair (e.g. "access-resources: 2").
 _LABELED_VALUE_RE = re.compile(r"^\S.*: \S.*$")
 
-EXPECTED_CRONJOBS = [
-    "jwt-rotator",
-    "web-app-session-rotator",
-]
-
 
 @pytest.mark.usefixtures("kubernetes_cluster_login")
 def test_health_all_layers(e2e_deployment: EndToEndDeployment) -> None:
@@ -100,6 +95,7 @@ def test_health_components_layer(e2e_deployment: EndToEndDeployment) -> None:
     cr_names = {n for n, c in manifest_components.items() if c.type == "CustomResourceWithoutStatus"}
     helm_names = {n for n, c in manifest_components.items() if c.type == "HelmRelease"}
     daemonset_names = {n for n, c in manifest_components.items() if c.type == "DaemonSet"}
+    cronjob_names = {n for n, c in manifest_components.items() if c.type == "CronJob"}
     # The eks-oidc template declares the 3 Workspace CRDs + the access-strategy and template CRs.
     assert len(crd_names) >= 3, f"Expected >= 3 CustomResourceDefinition components, got {sorted(crd_names)}"
     assert len(cr_names) >= 2, f"Expected >= 2 CustomResourceWithoutStatus components, got {sorted(cr_names)}"
@@ -117,7 +113,7 @@ def test_health_components_layer(e2e_deployment: EndToEndDeployment) -> None:
         for entry in entries:
             assert entry["layer"] == "components"
             name = entry["name"]
-            if name in EXPECTED_CRONJOBS:
+            if name in cronjob_names:
                 assert entry["status_category"] in ("healthy", "in-progress"), (
                     f"CronJob '{name}' unexpected status_category: {entry['status_category']}"
                 )

--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_apps_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_apps_runner.py
@@ -96,10 +96,17 @@ class K8sAppsRunner(InstructionRunner):
         if status.ready:
             status_display = "Ready"
             status_category = StatusCategory.HEALTHY
-        elif status.updated_pods < status.desired_pods:
+        elif status.ready_pods < status.desired_pods:
+            # Some scheduled pods are not ready yet: either a node just scaled up
+            # (Karpenter) and its pod is still starting, or a rolling update is in
+            # flight. Both are the DaemonSet converging, not a failure. The earlier
+            # `updated_pods < desired_pods` check only caught rolling updates and
+            # mislabeled fresh-node scale-ups as Degraded (source of E2E health flakes).
             status_display = "Updating"
             status_category = StatusCategory.IN_PROGRESS
         else:
+            # ready_pods == desired_pods but not all available (e.g. minReadySeconds
+            # not yet elapsed, or pods flapping) — surface a genuinely stuck DaemonSet.
             status_display = "Degraded"
             status_category = StatusCategory.DEGRADED
         details = f"{status.ready_pods}/{status.desired_pods} nodes"

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_apps_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_apps_runner.py
@@ -80,7 +80,8 @@ class TestK8sAppsRunnerGetDaemonsetStatus(unittest.TestCase):
         self.assertIn("SubComponent", result)
 
     @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_daemonset_status")
-    def test_returns_updating_status(self, mock_get_status: Mock) -> None:
+    def test_returns_updating_status_rolling_update(self, mock_get_status: Mock) -> None:
+        # Rolling update in flight: not all pods carry the new spec yet.
         mock_get_status.return_value = DaemonSetStatus(
             name="aws-node", ready=False, ready_pods=2, desired_pods=3, updated_pods=2
         )
@@ -92,9 +93,25 @@ class TestK8sAppsRunnerGetDaemonsetStatus(unittest.TestCase):
         self.assertEqual(result["Details"].value, "2/3 nodes")
 
     @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_daemonset_status")
-    def test_returns_degraded_status(self, mock_get_status: Mock) -> None:
+    def test_returns_updating_status_scale_up(self, mock_get_status: Mock) -> None:
+        # Node just scaled up: the new node's pod is scheduled with the current spec
+        # (updated == desired) but still starting (ready < desired). This must read as
+        # Updating, not Degraded — the DaemonSet is converging on a fresh node.
         mock_get_status.return_value = DaemonSetStatus(
             name="aws-node", ready=False, ready_pods=2, desired_pods=3, updated_pods=3
+        )
+        runner = K8sAppsRunner(display_manager=Mock(), api_client=Mock())
+
+        result = runner.execute_instruction("get-daemonset-status", _build_args(name="aws-node"))
+
+        self.assertEqual(result["Status"].value, "Updating")
+
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_daemonset_status")
+    def test_returns_degraded_status(self, mock_get_status: Mock) -> None:
+        # All scheduled pods are ready in count but the DaemonSet is not ready overall
+        # (e.g. availability lagging / pods flapping) — a genuinely degraded state.
+        mock_get_status.return_value = DaemonSetStatus(
+            name="aws-node", ready=False, ready_pods=3, desired_pods=3, updated_pods=3
         )
         runner = K8sAppsRunner(display_manager=Mock(), api_client=Mock())
 


### PR DESCRIPTION
This PR fixes two things behind the recurring `eks-oidc` fresh-deploy health flake: a/ the DaemonSet status classifier mislabeling a scaling-up DaemonSet as `degraded`, and b/ the `test_deployment` health check aborting because no kubeconfig context was set.

Refs: #329

### User experience
- `jd health` reports a DaemonSet whose pods are still starting on a freshly-joined node as `in-progress` (Updating) rather than `degraded` — `degraded` now means genuinely stuck

### Implementation
1. `<jd>/provider/k8s/k8s_apps_runner` `_get_daemonset_status`: key the in-progress branch on `ready_pods < desired_pods` (was `updated_pods`), so fresh-node scale-ups read `in-progress`, not `degraded`
2. add `kubernetes_cluster_login` to health test in `test_deployment`: the fresh-deploy flow never runs `jd cluster login`, see failed [run](https://github.com/jupyter-infra/jupyter-deploy/actions/runs/30863155630/job/91852524935)
3. skip DaemonSet status in that smoke test; `test_health.py` validates them exhaustively with a retry loop
4. derive `cronjob_names`/`daemonset_names` from the manifest `c.type` in both test files, removing static list

### Testing
- e2e: ran `test_deployment` and `test_health` sequentially against a live `eks-oidc` deployment