### PR TITLE
fix: autoscaler, fluentbit to depend on access entries

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_cluster_autoscaler.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_cluster_autoscaler.tf
@@ -171,11 +171,15 @@ resource "helm_release" "cluster_autoscaler" {
     },
   ]
 
+  # Access-policy associations must outlive this release — without them the Helm/K8s
+  # provider loses authorization and destroy fails with "Unauthorized".
   depends_on = [
     null_resource.cluster_addons,
     aws_eks_node_group.platform,
     aws_eks_pod_identity_association.cluster_autoscaler,
     aws_autoscaling_group_tag.ca_enabled,
     aws_autoscaling_group_tag.ca_owned,
+    aws_eks_access_policy_association.admin_role,
+    aws_eks_access_policy_association.admin_user,
   ]
 }

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_logging.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_logging.tf
@@ -30,7 +30,15 @@ resource "kubernetes_service_account_v1" "fluent_bit" {
     }
   }
 
-  depends_on = [null_resource.cluster_addons, aws_eks_node_group.platform]
+  # Access-policy associations must outlive this SA — without them the K8s provider
+  # loses authorization and destroy fails with "Unauthorized" (mirrors the guard on
+  # kubernetes_namespace_v1.shared in helm.tf).
+  depends_on = [
+    null_resource.cluster_addons,
+    aws_eks_node_group.platform,
+    aws_eks_access_policy_association.admin_role,
+    aws_eks_access_policy_association.admin_user,
+  ]
 }
 
 # Pod Identity: bind the fluent-bit SA to the CloudWatch-logs role.

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -111,6 +111,122 @@ def test_all_eks_addons_gated_by_cluster_addons() -> None:
     )
 
 
+def _iter_resource_blocks(content: str) -> list[tuple[str, str, str]]:
+    """Yield (resource_type, resource_name, body) for every resource block in content."""
+    blocks: list[tuple[str, str, str]] = []
+    for m in re.finditer(r'resource\s+"([\w-]+)"\s+"([\w-]+)"\s*\{', content):
+        depth = 1
+        idx = m.end()
+        while idx < len(content) and depth > 0:
+            if content[idx] == "{":
+                depth += 1
+            elif content[idx] == "}":
+                depth -= 1
+            idx += 1
+        blocks.append((m.group(1), m.group(2), content[m.end() : idx - 1]))
+    return blocks
+
+
+def _depends_on_refs(body: str) -> set[str]:
+    """Return the set of `<type>.<name>` refs in a block's depends_on list (empty if none)."""
+    m = re.search(r"depends_on\s*=\s*\[(.*?)\]", body, re.DOTALL)
+    if not m:
+        return set()
+    return {f"{t}.{n}" for t, n in re.findall(r"([\w-]+)\.(\w+)", m.group(1))}
+
+
+# Resources whose destroy needs the cluster to still be usable — they run against the
+# cluster API (K8s provider) or evict pods/finalizers (Helm uninstall). Each MUST keep
+# both the admin authorization AND the node groups alive until it is deleted.
+_AUTH_AT_DESTROY_TYPES = ("kubernetes_", "helm_release")
+
+# The only access-policy associations that grant a caller (human/CI, i.e. the identity
+# Terraform's kubernetes/helm provider authenticates as) cluster API authorization.
+_ADMIN_AUTH_NODES = frozenset(
+    {
+        "aws_eks_access_policy_association.admin_role",
+        "aws_eks_access_policy_association.admin_user",
+    }
+)
+
+# Node groups must outlive every K8s/Helm resource on destroy: Helm uninstall evicts
+# pods and runs finalizers, which need nodes to schedule on (see CLAUDE.md destroy order).
+_NODE_GROUP_NODES = frozenset({"aws_eks_node_group.platform"})
+
+
+def _build_depends_on_graph() -> tuple[dict[str, set[str]], list[str]]:
+    """Return (graph, k8s_nodes): the depends_on graph across engine/*.tf and the list
+    of kubernetes_*/helm_release resource nodes within it."""
+    engine_dir = TEMPLATE_PATH / "engine"
+    graph: dict[str, set[str]] = {}
+    k8s_nodes: list[str] = []
+    for tf_file in sorted(engine_dir.glob("*.tf")):
+        for rtype, rname, body in _iter_resource_blocks(tf_file.read_text()):
+            node = f"{rtype}.{rname}"
+            graph[node] = _depends_on_refs(body)
+            if rtype.startswith(_AUTH_AT_DESTROY_TYPES):
+                k8s_nodes.append(node)
+    return graph, k8s_nodes
+
+
+def _reaches(graph: dict[str, set[str]], start: str, targets: frozenset[str]) -> bool:
+    """True if any target is reachable from start by following depends_on edges."""
+    seen: set[str] = set()
+    stack = [start]
+    while stack:
+        cur = stack.pop()
+        if cur in seen:
+            continue
+        seen.add(cur)
+        if cur in targets:
+            return True
+        stack.extend(graph.get(cur, set()))
+    return False
+
+
+def test_k8s_resources_guard_admin_auth_through_destroy() -> None:
+    """Every kubernetes_*/helm_release resource MUST reach an admin access-policy
+    association via its depends_on chain, so admin authorization outlives it on destroy.
+
+    The chain may be transitive: e.g. helm_release.jupyter_k8s depends on
+    kubernetes_namespace_v1.shared, which depends on the associations directly. This is
+    the invariant that broke when the fluent-bit SA and cluster-autoscaler lacked the
+    guard — a concurrent/interrupted destroy tore down the access entry first and the
+    provider lost authorization. Guard against that drift for any newly-added resource.
+    """
+    graph, k8s_nodes = _build_depends_on_graph()
+    assert k8s_nodes, "no kubernetes_*/helm_release resources found in engine/*.tf"
+
+    unguarded = sorted(n for n in k8s_nodes if not _reaches(graph, n, _ADMIN_AUTH_NODES))
+    assert not unguarded, (
+        f"resource(s) {unguarded} do not reach an admin access-policy association "
+        f"({sorted(_ADMIN_AUTH_NODES)}) via depends_on — the K8s/Helm provider can lose "
+        "authorization mid-destroy and `jd down` fails with 'Unauthorized'. Add the "
+        "associations to the resource's depends_on (directly or via an already-guarded "
+        "resource like kubernetes_namespace_v1.shared)."
+    )
+
+
+def test_k8s_resources_guard_node_group_through_destroy() -> None:
+    """Every kubernetes_*/helm_release resource MUST reach a node group via its
+    depends_on chain, so the nodes outlive it on destroy.
+
+    Helm uninstall evicts pods and runs finalizers, which need a node to schedule on;
+    if the node groups are torn down first the uninstall hangs and `jd down` stalls
+    (see the load-bearing destroy order in CLAUDE.md). The chain may be transitive.
+    """
+    graph, k8s_nodes = _build_depends_on_graph()
+    assert k8s_nodes, "no kubernetes_*/helm_release resources found in engine/*.tf"
+
+    unguarded = sorted(n for n in k8s_nodes if not _reaches(graph, n, _NODE_GROUP_NODES))
+    assert not unguarded, (
+        f"resource(s) {unguarded} do not reach a node group ({sorted(_NODE_GROUP_NODES)}) "
+        "via depends_on — the nodes can be torn down mid-destroy and the Helm uninstall "
+        "hangs (pods/finalizers have nowhere to run). Add the node group to the "
+        "resource's depends_on (directly or via an already-guarded resource)."
+    )
+
+
 def test_main_tf_version_matches_template_version() -> None:
     manifest_path = TEMPLATE_PATH / "manifest.yaml"
     manifest = yaml.safe_load(manifest_path.read_text())


### PR DESCRIPTION
This PR fixes incorrectly configured dependency in the `eks-oidc` template resources: a/ fluent-bit and b/ cluster autoscaler _must_ depend on the eks access entry, otherwise on destroy the access entries _may_ get destroy first, preventing terraform to then authenticate to the cluster.

Closes: #333 

Also in this PR:
- template unit test to ensure k8s resource `depend_on` the eks access entry points

In practice, this rarely happens because other leaf resources hold the eks access entries, but it did in a rare race condition I observed locally.
