### PR TITLE
fix: nodeless daemonset health

### DIFF
--- a/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_apps_runner.py
+++ b/libs/jupyter-deploy/jupyter_deploy/provider/k8s/k8s_apps_runner.py
@@ -93,7 +93,13 @@ class K8sAppsRunner(InstructionRunner):
         self.display_manager.info(f"Getting daemonset status: {name_arg.value}")
         status = k8s_apps.get_daemonset_status(self.apps_api, name=name_arg.value, namespace=scope_arg.value)
 
-        if status.ready:
+        if status.desired_pods == 0:
+            # A DaemonSet can legitimately target zero nodes — e.g. a GPU-only DaemonSet
+            # (dcgm-exporter, nvidia-device-plugin) on a cluster with no GPU nodes up. It
+            # is idle, not failing, so surface it as healthy rather than Degraded (#337).
+            status_display = "Idle"
+            status_category = StatusCategory.HEALTHY
+        elif status.ready:
             status_display = "Ready"
             status_category = StatusCategory.HEALTHY
         elif status.ready_pods < status.desired_pods:

--- a/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_apps_runner.py
+++ b/libs/jupyter-deploy/tests/unit/provider/k8s/test_k8s_apps_runner.py
@@ -10,6 +10,7 @@ from jupyter_deploy.api.k8s.apps import (
     ResourceInfo,
     StatefulSetStatus,
 )
+from jupyter_deploy.enum import StatusCategory
 from jupyter_deploy.exceptions import InstructionNotFoundError
 from jupyter_deploy.provider.k8s.k8s_apps_runner import K8sAppsRunner
 from jupyter_deploy.provider.resolved_argdefs import StrResolvedInstructionArgument
@@ -118,6 +119,22 @@ class TestK8sAppsRunnerGetDaemonsetStatus(unittest.TestCase):
         result = runner.execute_instruction("get-daemonset-status", _build_args(name="aws-node"))
 
         self.assertEqual(result["Status"].value, "Degraded")
+
+    @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_daemonset_status")
+    def test_returns_idle_status_when_zero_desired(self, mock_get_status: Mock) -> None:
+        # A DaemonSet that legitimately targets zero nodes (e.g. a GPU-only DaemonSet on a
+        # cluster with no GPU nodes up) is idle, not failing — it must read healthy, not
+        # Degraded (#337).
+        mock_get_status.return_value = DaemonSetStatus(
+            name="nvidia-device-plugin", ready=False, ready_pods=0, desired_pods=0, updated_pods=0
+        )
+        runner = K8sAppsRunner(display_manager=Mock(), api_client=Mock())
+
+        result = runner.execute_instruction("get-daemonset-status", _build_args(name="nvidia-device-plugin"))
+
+        self.assertEqual(result["Status"].value, "Idle")
+        self.assertEqual(result["StatusCategory"].value, StatusCategory.HEALTHY)
+        self.assertEqual(result["Details"].value, "0/0 nodes")
 
     @patch("jupyter_deploy.provider.k8s.k8s_apps_runner.k8s_apps.get_daemonset_status")
     def test_api_exception_bubbles_up(self, mock_get_status: Mock) -> None:


### PR DESCRIPTION
This PR fixes the `jd health` DaemonSet classifier reporting `degraded` for a DaemonSet that legitimately targets zero nodes (`desiredNumberScheduled == 0`); e.g. a GPU-only DaemonSet (nvidia-device-plugin) on a cluster with no GPU nodes up. Such a DaemonSet is idle, not failing.

Closes: #337

### User experience
- `jd health --components` reports a zero-desired DaemonSet as `Idle` (healthy) instead of `degraded`

### Implementation
1. `<jd>/provider/k8s/k8s_apps_runner`: add a leading `desired_pods == 0` branch → `Idle`/`HEALTHY`, ahead of the `ready`/`ready_pods < desired_pods` checks that `0 == 0` would otherwise fall through to Degraded

### Testing
- manual: `jd health` against a live GPU-less `eks-karpenter` cluster; GPU DaemonSets now read `Idle`; regression-checked against a live `eks-oidc` cluster where the node-targeting DaemonSets (aws-node, kube-proxy, fluent-bit) still read `Ready`