### PR TITLE
fix: set ebs as default storageClass

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/helm.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/helm.tf
@@ -123,6 +123,14 @@ resource "helm_release" "workspace_router" {
         name  = "storageClass.ebs.create"
         value = "true"
       },
+      # Mark ebs-sc the cluster default StorageClass so PVCs with no explicit
+      # storageClassName bind; e.g. a no-template Workspace, which sends storage
+      # without a class (#321). Template-backed workspaces set the class
+      # explicitly and are unaffected.
+      {
+        name  = "storageClass.ebs.isDefault"
+        value = "true"
+      },
       {
         name  = "storageClass.efs.create"
         value = "false"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/resources/classless-pvc.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/resources/classless-pvc.yaml
@@ -1,0 +1,13 @@
+# A PVC with no storageClassName — what a no-template Workspace produces.
+# With ebs-sc marked the cluster default StorageClass, the default-class admission
+# plugin stamps spec.storageClassName=ebs-sc on it at creation (#321).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: e2e-classless-pvc
+  namespace: default
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.kubernetes.kubectl import run_kubectl
 from pytest_jupyter_deploy.kubernetes.nodes import assert_pods_on_node_pool
 from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
@@ -32,6 +33,10 @@ pytestmark = pytest.mark.usefixtures("kubernetes_cluster_login")
 
 NAMESPACE = "default"
 WORKSPACES_DIR = Path(__file__).parent / "workspaces"
+RESOURCES_DIR = Path(__file__).parent / "resources"
+
+# The template provisions ebs-sc and marks it the cluster default StorageClass.
+DEFAULT_STORAGE_CLASS = "ebs-sc"
 
 USER_B = "github:e2e-other-user"
 
@@ -54,6 +59,53 @@ def _get_impersonation_group() -> str:
     if not org or not team:
         raise RuntimeError("JD_E2E_ORG and JD_E2E_RBAC_TEAM must be set")
     return f"github:{org}:{team}"
+
+
+def test_no_template_workspace_pvc_binds_to_default_storage_class(e2e_deployment: EndToEndDeployment) -> None:
+    """A PVC with no storageClassName inherits the cluster default (ebs-sc).
+
+    A no-template ("bare") Workspace sends storage without a storageClassName; with
+    no default StorageClass its PVC stays unbound and the pod hangs Pending forever
+    (GitHub issue #321). The template marks ebs-sc the default so such claims bind.
+
+    Asserts both halves of the fix: ebs-sc carries the default-class annotation, and
+    a classless PVC gets ebs-sc stamped on it by the default-class admission plugin at
+    creation. (A template-backed Workspace is unaffected — the operator injects the
+    template's storageClassName, so this classless case is the one the default guards.)
+    """
+    e2e_deployment.ensure_deployed()
+
+    # ebs-sc must be marked the cluster default StorageClass.
+    result = run_kubectl(
+        "get",
+        "storageclass",
+        DEFAULT_STORAGE_CLASS,
+        "-o",
+        r"jsonpath={.metadata.annotations.storageclass\.kubernetes\.io/is-default-class}",
+    )
+    assert result.returncode == 0, f"StorageClass '{DEFAULT_STORAGE_CLASS}' not found:\n{result.stderr}"
+    assert result.stdout.strip() == "true", (
+        f"'{DEFAULT_STORAGE_CLASS}' must be the default StorageClass, got is-default-class={result.stdout.strip()!r}"
+    )
+
+    # A classless PVC - what a no-template Workspace produces — must inherit ebs-sc.
+    pvc_name = "e2e-classless-pvc"
+    pvc_manifest = RESOURCES_DIR / "classless-pvc.yaml"
+    try:
+        result = run_kubectl("apply", "-f", str(pvc_manifest))
+        assert result.returncode == 0, f"Failed to create classless PVC:\n{result.stderr}"
+
+        # The default-class admission plugin stamps spec.storageClassName at creation.
+        # No consumer pod is needed — ebs-sc is WaitForFirstConsumer, so the PVC stays
+        # Pending, but the stamped class is what proves classless claims now bind.
+        result = run_kubectl("get", "pvc", pvc_name, "-n", NAMESPACE, "-o", "jsonpath={.spec.storageClassName}")
+        assert result.returncode == 0, f"Failed to read PVC '{pvc_name}':\n{result.stderr}"
+        assert result.stdout.strip() == DEFAULT_STORAGE_CLASS, (
+            f"classless PVC did not inherit the default StorageClass; "
+            f"expected '{DEFAULT_STORAGE_CLASS}', got {result.stdout.strip()!r}"
+        )
+    finally:
+        run_kubectl("delete", "pvc", pvc_name, "-n", NAMESPACE, "--wait=false", "--ignore-not-found")
 
 
 # ── Self-contained workspace tests (User A owns) ─────────────────────────────

--- a/libs/jupyter-deploy/jupyter_deploy/api/aws/sts/eks_token.py
+++ b/libs/jupyter-deploy/jupyter_deploy/api/aws/sts/eks_token.py
@@ -6,6 +6,9 @@ from botocore.auth import SigV4QueryAuth
 from botocore.awsrequest import AWSRequest
 from botocore.session import Session as BotocoreSession
 
+from jupyter_deploy.enum import ProviderType
+from jupyter_deploy.exceptions import InvalidProviderCredentialsError
+
 _TOKEN_PREFIX = "k8s-aws-v1."
 _TOKEN_EXPIRY_SECONDS = 60
 _CLUSTER_ID_HEADER = "x-k8s-aws-id"
@@ -18,12 +21,17 @@ def get_eks_bearer_token(cluster_name: str, region: str) -> str:
     Uses the default credential chain (env vars, profile, IMDS, etc.).
     """
     session = BotocoreSession()
-    credentials = session.get_credentials().get_frozen_credentials()
+    credentials = session.get_credentials()
+    if credentials is None:
+        raise InvalidProviderCredentialsError(
+            ProviderType.AWS, "no AWS credentials found in the default credential chain"
+        )
+    frozen_credentials = credentials.get_frozen_credentials()
 
     endpoint = f"https://sts.{region}.amazonaws.com/?{_STS_ACTION}"
     request = AWSRequest(method="GET", url=endpoint, headers={_CLUSTER_ID_HEADER: cluster_name})
 
-    signer = SigV4QueryAuth(credentials, "sts", region, expires=_TOKEN_EXPIRY_SECONDS)
+    signer = SigV4QueryAuth(frozen_credentials, "sts", region, expires=_TOKEN_EXPIRY_SECONDS)
     signer.add_auth(request)
 
     signed_url: str = request.url  # type: ignore[assignment]

--- a/libs/jupyter-deploy/tests/unit/api/aws/sts/test_eks_token.py
+++ b/libs/jupyter-deploy/tests/unit/api/aws/sts/test_eks_token.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from jupyter_deploy.api.aws.sts.eks_token import get_eks_bearer_token
+from jupyter_deploy.exceptions import InvalidProviderCredentialsError
 
 
 class TestGetEksBearerToken(unittest.TestCase):
@@ -33,3 +34,12 @@ class TestGetEksBearerToken(unittest.TestCase):
         request_arg = mock_signer_cls.return_value.add_auth.call_args[0][0]
         self.assertIn("sts.eu-west-1.amazonaws.com", request_arg.url)
         self.assertEqual(request_arg.headers["x-k8s-aws-id"], "my-cluster")
+
+    @patch("jupyter_deploy.api.aws.sts.eks_token.BotocoreSession")
+    def test_raises_when_no_credentials_in_chain(self, mock_session_cls: Mock) -> None:
+        mock_session: Mock = Mock()
+        mock_session_cls.return_value = mock_session
+        mock_session.get_credentials.return_value = None
+
+        with self.assertRaises(InvalidProviderCredentialsError):
+            get_eks_bearer_token("my-cluster", "us-west-2")


### PR DESCRIPTION
This PR fixes no-template Workspaces on the `eks-oidc` template hanging `Pending` forever on an unbound PVC. The cluster shipped `ebs-sc` and `gp2` but marked neither default, so a Workspace whose PVC has no `storageClassName` had no class to fall back on (`FailedBinding … no storage class is set`). Marking `ebs-sc` the default StorageClass makes such classless PVCs bind.

**Note:** Template-backed Workspaces set the class explicitly and are unaffected.

Closes: #321

Also in this PR:
- tighten eks get-token method to satify new `mypy` requirements

### User experience
- a no-template Workspace's PVC now inherits `ebs-sc` and binds, instead of the pod hanging `Pending` forever

### Implementation
1. `<eks-oidc>/engine/helm.tf`: set `storageClass.ebs.isDefault=true` to router chart: the aws-oidc chart stamps `storageclass.kubernetes.io/is-default-class: "true"` on `ebs-sc`

### Testing
- e2e: update `test_workspace.py` in `eks-oidc` template; asserts `ebs-sc` is the default StorageClass and a classless PVC inherits it
- manual: on a live `eks-oidc` cluster, reproduced `FailedBinding … no storage class is set`; after `jd up`, both a raw classless PVC and the operator-created PVC of a storage-less-template Workspace get `ebs-sc` stamped