### PR TITLE
feat: gpu workspace support for eks-oidc template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,7 @@ test-results/
 # E2E test temporary files
 docker-compose.e2e-override.yml
 results*.log
+
+# terraform working dirs and lock files (deployment dirs and template engines initialize locally)
+**/.terraform/
+**/.terraform.lock.hcl

--- a/.yamllint
+++ b/.yamllint
@@ -78,5 +78,7 @@ ignore: |
   build/
   *.egg-info/
   **/charts/*/templates/
+  # helm-rendered goldens, byte-compared in tests — must match helm output exactly
+  **/tests/unit/chart_render_data/golden_*.yaml
   # string.Template manifests (templated blocks, not valid YAML until rendered)
   **/kubernetes/ballast-pod.yaml

--- a/docs/source/templates/aws-eks-oidc-template/autoscaling.md
+++ b/docs/source/templates/aws-eks-oidc-template/autoscaling.md
@@ -72,25 +72,47 @@ You control node pools through admin variables:
 | `routing_instance_categories` | `["c", "m"]` | Instance categories Karpenter may pick for routing nodes. |
 | `routing_max_cpu` / `routing_max_memory` | `32` / `128Gi` | Ceiling on total routing-pool capacity. |
 | `workspace_nodepools` | one `workspace-cpu` pool | List of workspace pools, each with its own instance families and CPU/memory ceilings. |
-| `enable_default_gpu_pool` | `false` | Appends the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, the NVIDIA device plugin, and the `jupyterlab-gpu` template all derive from it. |
+| `workspace_templates` | `[]` | Named workspace template configs; a pool entry offers them as cards through its `templates` key. |
+| `enable_default_gpu_pool` | `false` | Appends the built-in `workspace-gpu` entry and its `jupyterlab-gpu` template config; the pool, the NVIDIA device plugin, and the GPU card all derive from them. |
 | `node_expire_after` | `504h` | Maximum node lifetime before Karpenter recycles it. |
 
 Add a CPU workspace pool by appending an entry to `workspace_nodepools`: no new
-variables required. GPU capacity works the same way, and `enable_default_gpu_pool: true`
-is the shortcut: it appends a built-in `workspace-gpu` entry (`g4dn,g5,g6,g6e`
-on-demand instances, fleet ceiling `max_gpus: "4"`) unless you define your own
-entry by that name, which then takes precedence. Everything GPU derives from
-the entries: any entry with `gpu: "true"` installs the NVIDIA device plugin and
-gets the `nvidia.com/gpu.present` label the plugin selects on, `role` sets the
-label/taint value that fences the pool, `max_gpus` caps the fleet, and the
-`template_*` keys (`template_gpus`, `template_cpu`, `template_memory`,
-`template_idle_minutes`, `template_name`) yield a workspace template pinned to
-the pool: a fixed shape (one GPU with pinned cpu/memory) fenced by the pool's
-role taint. The built-in entry carries the `jupyterlab-gpu` template this way,
-and a second GPU pool with its own template and idle rule is just one more
-entry. Delete GPU workspaces before removing their entry or turning the flag
-off: doing so removes the pool and the template they depend on. First GPU use
-on an account without prior GPU usage requires raising the
+variables required. For GPU capacity, `enable_default_gpu_pool: true` is the
+one-line path: it appends a built-in `workspace-gpu` entry (`g4dn,g5,g6,g6e`
+on-demand instances, fleet ceiling `max_gpus: "4"`) plus its `jupyterlab-gpu`
+template config. To configure GPU support yourself, leave the flag off and
+write the entries directly (combining both is a plan-time error): an entry with
+`accelerator: nvidia` installs the NVIDIA device plugin, gets the
+`nvidia.com/gpu.present` label the plugin selects on, and is fenced by its
+`role` (defaulting to the pool name); the optional `max_gpus` caps the fleet
+(absent means unbounded, up to the account's service quota); and the entry's
+`templates` key lists `workspace_templates` configs to offer as cards, each
+rendered as a workspace template pinned to the pool's role. A config with
+pinned `cpu`/`memory`/`gpus` renders one fixed shape; a config with only
+`idle_minutes` inherits the standard adjustable shape. A second GPU pool with
+its own card and idle rule is one more entry plus one more config, for example:
+
+```yaml
+workspace_templates:
+  - name: jupyterlab-gpu-p
+    gpus: "1"
+    cpu: "22"
+    memory: "200Gi"
+    idle_minutes: "30"
+workspace_nodepools:
+  # ... the CPU pool ...
+  - name: workspace-gpu-p
+    instance_families: p4d,p5,p5en
+    disk_size_gb: "200"
+    max_cpu: "384"
+    max_memory: "3000Gi"
+    accelerator: nvidia
+    templates: jupyterlab-gpu-p
+```
+
+Delete GPU workspaces before removing their entry or turning the flag off:
+doing so removes the pool and the template they depend on. First GPU use on an
+account without prior GPU usage requires raising the
 `Running On-Demand G and VT instances` service quota (see the troubleshooting
 guide). Inspect pools at runtime with `jd pool list`,
 `jd pool show --name <pool>`, and `jd pool status --name <pool>`.

--- a/docs/source/templates/aws-eks-oidc-template/autoscaling.md
+++ b/docs/source/templates/aws-eks-oidc-template/autoscaling.md
@@ -72,10 +72,23 @@ You control node pools through admin variables:
 | `routing_instance_categories` | `["c", "m"]` | Instance categories Karpenter may pick for routing nodes. |
 | `routing_max_cpu` / `routing_max_memory` | `32` / `128Gi` | Ceiling on total routing-pool capacity. |
 | `workspace_nodepools` | one `workspace-cpu` pool | List of workspace pools, each with its own instance families and CPU/memory ceilings. |
+| `enable_gpu_pool` | `false` | Adds the built-in GPU pool, the NVIDIA device plugin, and the `jupyterlab-gpu` template. |
 | `node_expire_after` | `504h` | Maximum node lifetime before Karpenter recycles it. |
 
-Add a workspace pool (for example, a GPU pool) by appending an entry to
-`workspace_nodepools`: no new variables required. Inspect pools at runtime with
+Add a CPU workspace pool by appending an entry to `workspace_nodepools`: no new
+variables required. For GPU capacity, set `enable_gpu_pool: true` instead: the
+template adds a built-in `workspace-gpu` pool (`g4dn,g5` on-demand instances,
+fleet ceiling `max_gpus: "4"`), installs the NVIDIA device plugin, and ships the
+`jupyterlab-gpu` workspace template, a fixed shape (one GPU with pinned
+cpu/memory) fenced to the pool by its role taint. To customize the GPU pool,
+define your own `workspace-gpu` entry in `workspace_nodepools`, which takes
+precedence over the built-in; the optional per-entry keys are `role` (the
+label/taint value), `max_gpus` (fleet GPU ceiling), and `gpu` (`"true"` adds the
+`nvidia.com/gpu.present` label the device plugin selects on). Delete GPU
+workspaces before turning the flag off: disabling removes the pool and the
+template they depend on. First GPU use on an account without prior GPU usage
+requires raising the `Running On-Demand G and VT instances` service quota (see
+the troubleshooting guide). Inspect pools at runtime with
 `jd pool list`, `jd pool show --name <pool>`, and `jd pool status --name <pool>`.
 
 ```{note}

--- a/docs/source/templates/aws-eks-oidc-template/autoscaling.md
+++ b/docs/source/templates/aws-eks-oidc-template/autoscaling.md
@@ -78,7 +78,7 @@ You control node pools through admin variables:
 
 Add a CPU workspace pool by appending an entry to `workspace_nodepools`: no new
 variables required. For GPU capacity, `enable_default_gpu_pool: true` is the
-one-line path: it appends a built-in `workspace-gpu` entry (`g4dn,g5,g6,g6e`
+one-line path: it appends a built-in `workspace-gpu` entry (`g4dn,g5,g6,g6e,g7,g7e`
 on-demand instances, fleet ceiling `max_gpus: "4"`) plus its `jupyterlab-gpu`
 template config. To configure GPU support yourself, leave the flag off and
 write the entries directly (combining both is a plan-time error): an entry with

--- a/docs/source/templates/aws-eks-oidc-template/autoscaling.md
+++ b/docs/source/templates/aws-eks-oidc-template/autoscaling.md
@@ -72,11 +72,11 @@ You control node pools through admin variables:
 | `routing_instance_categories` | `["c", "m"]` | Instance categories Karpenter may pick for routing nodes. |
 | `routing_max_cpu` / `routing_max_memory` | `32` / `128Gi` | Ceiling on total routing-pool capacity. |
 | `workspace_nodepools` | one `workspace-cpu` pool | List of workspace pools, each with its own instance families and CPU/memory ceilings. |
-| `enable_gpu_pool` | `false` | Appends the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, the NVIDIA device plugin, and the `jupyterlab-gpu` template all derive from it. |
+| `enable_default_gpu_pool` | `false` | Appends the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, the NVIDIA device plugin, and the `jupyterlab-gpu` template all derive from it. |
 | `node_expire_after` | `504h` | Maximum node lifetime before Karpenter recycles it. |
 
 Add a CPU workspace pool by appending an entry to `workspace_nodepools`: no new
-variables required. GPU capacity works the same way, and `enable_gpu_pool: true`
+variables required. GPU capacity works the same way, and `enable_default_gpu_pool: true`
 is the shortcut: it appends a built-in `workspace-gpu` entry (`g4dn,g5`
 on-demand instances, fleet ceiling `max_gpus: "4"`) unless you define your own
 entry by that name, which then takes precedence. Everything GPU derives from

--- a/docs/source/templates/aws-eks-oidc-template/autoscaling.md
+++ b/docs/source/templates/aws-eks-oidc-template/autoscaling.md
@@ -72,24 +72,28 @@ You control node pools through admin variables:
 | `routing_instance_categories` | `["c", "m"]` | Instance categories Karpenter may pick for routing nodes. |
 | `routing_max_cpu` / `routing_max_memory` | `32` / `128Gi` | Ceiling on total routing-pool capacity. |
 | `workspace_nodepools` | one `workspace-cpu` pool | List of workspace pools, each with its own instance families and CPU/memory ceilings. |
-| `enable_gpu_pool` | `false` | Adds the built-in GPU pool, the NVIDIA device plugin, and the `jupyterlab-gpu` template. |
+| `enable_gpu_pool` | `false` | Appends the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, the NVIDIA device plugin, and the `jupyterlab-gpu` template all derive from it. |
 | `node_expire_after` | `504h` | Maximum node lifetime before Karpenter recycles it. |
 
 Add a CPU workspace pool by appending an entry to `workspace_nodepools`: no new
-variables required. For GPU capacity, set `enable_gpu_pool: true` instead: the
-template adds a built-in `workspace-gpu` pool (`g4dn,g5` on-demand instances,
-fleet ceiling `max_gpus: "4"`), installs the NVIDIA device plugin, and ships the
-`jupyterlab-gpu` workspace template, a fixed shape (one GPU with pinned
-cpu/memory) fenced to the pool by its role taint. To customize the GPU pool,
-define your own `workspace-gpu` entry in `workspace_nodepools`, which takes
-precedence over the built-in; the optional per-entry keys are `role` (the
-label/taint value), `max_gpus` (fleet GPU ceiling), and `gpu` (`"true"` adds the
-`nvidia.com/gpu.present` label the device plugin selects on). Delete GPU
-workspaces before turning the flag off: disabling removes the pool and the
-template they depend on. First GPU use on an account without prior GPU usage
-requires raising the `Running On-Demand G and VT instances` service quota (see
-the troubleshooting guide). Inspect pools at runtime with
-`jd pool list`, `jd pool show --name <pool>`, and `jd pool status --name <pool>`.
+variables required. GPU capacity works the same way, and `enable_gpu_pool: true`
+is the shortcut: it appends a built-in `workspace-gpu` entry (`g4dn,g5`
+on-demand instances, fleet ceiling `max_gpus: "4"`) unless you define your own
+entry by that name, which then takes precedence. Everything GPU derives from
+the entries: any entry with `gpu: "true"` installs the NVIDIA device plugin and
+gets the `nvidia.com/gpu.present` label the plugin selects on, `role` sets the
+label/taint value that fences the pool, `max_gpus` caps the fleet, and the
+`template_*` keys (`template_gpus`, `template_cpu`, `template_memory`,
+`template_idle_minutes`, `template_name`) yield a workspace template pinned to
+the pool: a fixed shape (one GPU with pinned cpu/memory) fenced by the pool's
+role taint. The built-in entry carries the `jupyterlab-gpu` template this way,
+and a second GPU pool with its own template and idle rule is just one more
+entry. Delete GPU workspaces before removing their entry or turning the flag
+off: doing so removes the pool and the template they depend on. First GPU use
+on an account without prior GPU usage requires raising the
+`Running On-Demand G and VT instances` service quota (see the troubleshooting
+guide). Inspect pools at runtime with `jd pool list`,
+`jd pool show --name <pool>`, and `jd pool status --name <pool>`.
 
 ```{note}
 The Cluster Autoscaler's image version tracks the cluster's Kubernetes minor version.

--- a/docs/source/templates/aws-eks-oidc-template/autoscaling.md
+++ b/docs/source/templates/aws-eks-oidc-template/autoscaling.md
@@ -77,7 +77,7 @@ You control node pools through admin variables:
 
 Add a CPU workspace pool by appending an entry to `workspace_nodepools`: no new
 variables required. GPU capacity works the same way, and `enable_default_gpu_pool: true`
-is the shortcut: it appends a built-in `workspace-gpu` entry (`g4dn,g5`
+is the shortcut: it appends a built-in `workspace-gpu` entry (`g4dn,g5,g6,g6e`
 on-demand instances, fleet ceiling `max_gpus: "4"`) unless you define your own
 entry by that name, which then takes precedence. Everything GPU derives from
 the entries: any entry with `gpu: "true"` installs the NVIDIA device plugin and

--- a/docs/source/templates/aws-eks-oidc-template/details.md
+++ b/docs/source/templates/aws-eks-oidc-template/details.md
@@ -67,7 +67,7 @@ The template installs the following Helm releases:
 | cluster-autoscaler | `kube-system` | Autoscaler for the platform managed node group |
 | prometheus | `monitoring` | Metrics server (scaling source for KEDA) |
 | aws-for-fluent-bit | `kube-system` | Pod log shipping to CloudWatch (optional, `enable_component_logging`) |
-| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, `enable_gpu_pool`) |
+| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, installed when a pool entry sets `gpu = "true"`) |
 | github-rbac (local) | Shared namespace | Namespace-scoped RBAC for the `oauth_allowed_teams` GitHub teams |
 | workspace-defaults (local) | Shared namespace | Default `WorkspaceTemplate` and workspace-ingress NetworkPolicies |
 
@@ -158,8 +158,8 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_app_type | `string` | `jupyterlab` | Application type identifier for the workspace template |
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
-| enable_gpu_pool | `bool` | `false` | Provision GPU workspace capacity: built-in `workspace-gpu` pool, NVIDIA device plugin, and the `jupyterlab-gpu` template |
-| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (used when `enable_gpu_pool` is true) |
+| enable_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
+| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `gpu = "true"`) |
 
 ## Outputs
 

--- a/docs/source/templates/aws-eks-oidc-template/details.md
+++ b/docs/source/templates/aws-eks-oidc-template/details.md
@@ -67,7 +67,7 @@ The template installs the following Helm releases:
 | cluster-autoscaler | `kube-system` | Autoscaler for the platform managed node group |
 | prometheus | `monitoring` | Metrics server (scaling source for KEDA) |
 | aws-for-fluent-bit | `kube-system` | Pod log shipping to CloudWatch (optional, `enable_component_logging`) |
-| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, installed when a pool entry sets `gpu = "true"`) |
+| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, installed when a pool entry sets `accelerator = "nvidia"`) |
 | github-rbac (local) | Shared namespace | Namespace-scoped RBAC for the `oauth_allowed_teams` GitHub teams |
 | workspace-defaults (local) | Shared namespace | Default `WorkspaceTemplate` and workspace-ingress NetworkPolicies |
 
@@ -159,7 +159,7 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
 | enable_default_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
-| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `gpu = "true"`) |
+| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `accelerator = "nvidia"`) |
 
 ## Outputs
 

--- a/docs/source/templates/aws-eks-oidc-template/details.md
+++ b/docs/source/templates/aws-eks-oidc-template/details.md
@@ -67,6 +67,7 @@ The template installs the following Helm releases:
 | cluster-autoscaler | `kube-system` | Autoscaler for the platform managed node group |
 | prometheus | `monitoring` | Metrics server (scaling source for KEDA) |
 | aws-for-fluent-bit | `kube-system` | Pod log shipping to CloudWatch (optional, `enable_component_logging`) |
+| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, `enable_gpu_pool`) |
 | github-rbac (local) | Shared namespace | Namespace-scoped RBAC for the `oauth_allowed_teams` GitHub teams |
 | workspace-defaults (local) | Shared namespace | Default `WorkspaceTemplate` and workspace-ingress NetworkPolicies |
 
@@ -157,6 +158,8 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_app_type | `string` | `jupyterlab` | Application type identifier for the workspace template |
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
+| enable_gpu_pool | `bool` | `false` | Provision GPU workspace capacity: built-in `workspace-gpu` pool, NVIDIA device plugin, and the `jupyterlab-gpu` template |
+| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (used when `enable_gpu_pool` is true) |
 
 ## Outputs
 

--- a/docs/source/templates/aws-eks-oidc-template/details.md
+++ b/docs/source/templates/aws-eks-oidc-template/details.md
@@ -158,7 +158,8 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_app_type | `string` | `jupyterlab` | Application type identifier for the workspace template |
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
-| enable_default_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
+| workspace_templates | `list(map(string))` | `[]` | Named workspace template configs offered as cards by pool entries via their `templates` key |
+| enable_default_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry and its `jupyterlab-gpu` template config; a plan-time error when combined with your own accelerator entries |
 | nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `accelerator = "nvidia"`) |
 
 ## Outputs

--- a/docs/source/templates/aws-eks-oidc-template/details.md
+++ b/docs/source/templates/aws-eks-oidc-template/details.md
@@ -158,7 +158,7 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_app_type | `string` | `jupyterlab` | Application type identifier for the workspace template |
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
-| enable_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
+| enable_default_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
 | nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `gpu = "true"`) |
 
 ## Outputs

--- a/env.example
+++ b/env.example
@@ -98,9 +98,9 @@ JD_E2E_GPU_INSTANCE=
 # --- GPU TESTS (eks-oidc) ---
 # Whether the eks-oidc test deployment provisions the GPU pool (rendered into
 # variables.yaml; true/false).
-JD_E2E_VAR_ENABLE_GPU_POOL=false
+JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL=false
 
 # Set to 1 to run the eks-oidc GPU e2e tests. Needs a deployment with
-# enable_gpu_pool: true and G/VT on-demand quota in the account.
+# enable_default_gpu_pool: true and G/VT on-demand quota in the account.
 JD_E2E_GPU_ENABLED=
 # ---

--- a/env.example
+++ b/env.example
@@ -94,4 +94,13 @@ JD_E2E_CPU_INSTANCE=
 
 # GPU instance type for testing GPU deployment (e.g., g6.xlarge).
 JD_E2E_GPU_INSTANCE=
+
+# --- GPU TESTS (eks-oidc) ---
+# Whether the eks-oidc test deployment provisions the GPU pool (rendered into
+# variables.yaml; true/false).
+JD_E2E_VAR_ENABLE_GPU_POOL=false
+
+# Set to 1 to run the eks-oidc GPU e2e tests. Needs a deployment with
+# enable_gpu_pool: true and G/VT on-demand quota in the account.
+JD_E2E_GPU_ENABLED=
 # ---

--- a/env.example
+++ b/env.example
@@ -102,5 +102,6 @@ JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL=false
 
 # Set to 1 to run the eks-oidc GPU e2e tests. Needs a deployment with
 # enable_default_gpu_pool: true and G/VT on-demand quota in the account.
+# Leave EMPTY to skip: any non-empty value (including 0) enables them.
 JD_E2E_GPU_ENABLED=
 # ---

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -245,6 +245,7 @@ The template creates several IAM roles:
 | cluster-autoscaler | `kube-system` | Autoscaler for the platform managed node group |
 | prometheus | `monitoring` | Metrics server (scaling source for KEDA) |
 | aws-for-fluent-bit | `kube-system` | Pod log shipping to CloudWatch (optional, `enable_component_logging`) |
+| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, `enable_gpu_pool`) |
 | github-rbac (local) | Shared namespace | Namespace-scoped RBAC for the `oauth_allowed_teams` GitHub teams |
 | workspace-defaults (local) | Shared namespace | Default `WorkspaceTemplate` and workspace-ingress NetworkPolicies |
 
@@ -295,6 +296,8 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_app_type | `string` | `jupyterlab` | Application type identifier for the workspace template |
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
+| enable_gpu_pool | `bool` | `false` | Provision GPU workspace capacity: built-in `workspace-gpu` pool, NVIDIA device plugin, and the `jupyterlab-gpu` template |
+| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (used when `enable_gpu_pool` is true) |
 
 ## Outputs
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -296,7 +296,8 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_app_type | `string` | `jupyterlab` | Application type identifier for the workspace template |
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
-| enable_default_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
+| workspace_templates | `list(map(string))` | `[]` | Named workspace template configs offered as cards by pool entries via their `templates` key |
+| enable_default_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry and its `jupyterlab-gpu` template config; a plan-time error when combined with your own accelerator entries |
 | nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `accelerator = "nvidia"`) |
 
 ## Outputs

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -296,7 +296,7 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_app_type | `string` | `jupyterlab` | Application type identifier for the workspace template |
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
-| enable_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
+| enable_default_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
 | nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `gpu = "true"`) |
 
 ## Outputs

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -245,7 +245,7 @@ The template creates several IAM roles:
 | cluster-autoscaler | `kube-system` | Autoscaler for the platform managed node group |
 | prometheus | `monitoring` | Metrics server (scaling source for KEDA) |
 | aws-for-fluent-bit | `kube-system` | Pod log shipping to CloudWatch (optional, `enable_component_logging`) |
-| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, installed when a pool entry sets `gpu = "true"`) |
+| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, installed when a pool entry sets `accelerator = "nvidia"`) |
 | github-rbac (local) | Shared namespace | Namespace-scoped RBAC for the `oauth_allowed_teams` GitHub teams |
 | workspace-defaults (local) | Shared namespace | Default `WorkspaceTemplate` and workspace-ingress NetworkPolicies |
 
@@ -297,7 +297,7 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
 | enable_default_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
-| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `gpu = "true"`) |
+| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `accelerator = "nvidia"`) |
 
 ## Outputs
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/README.md
@@ -245,7 +245,7 @@ The template creates several IAM roles:
 | cluster-autoscaler | `kube-system` | Autoscaler for the platform managed node group |
 | prometheus | `monitoring` | Metrics server (scaling source for KEDA) |
 | aws-for-fluent-bit | `kube-system` | Pod log shipping to CloudWatch (optional, `enable_component_logging`) |
-| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, `enable_gpu_pool`) |
+| nvidia-device-plugin | `kube-system` | Registers GPU capacity on GPU pool nodes (optional, installed when a pool entry sets `gpu = "true"`) |
 | github-rbac (local) | Shared namespace | Namespace-scoped RBAC for the `oauth_allowed_teams` GitHub teams |
 | workspace-defaults (local) | Shared namespace | Default `WorkspaceTemplate` and workspace-ingress NetworkPolicies |
 
@@ -296,8 +296,8 @@ The template provides two variable presets:
 | workspace_app_jupyterlab_app_type | `string` | `jupyterlab` | Application type identifier for the workspace template |
 | workspace_app_jupyterlab_image_name | `string` | See preset | ECR repository name for the JupyterLab image |
 | workspace_app_jupyterlab_image_build | `string` | `v1` | Build tag (increment to trigger rebuild) |
-| enable_gpu_pool | `bool` | `false` | Provision GPU workspace capacity: built-in `workspace-gpu` pool, NVIDIA device plugin, and the `jupyterlab-gpu` template |
-| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (used when `enable_gpu_pool` is true) |
+| enable_gpu_pool | `bool` | `false` | Append the built-in `workspace-gpu` entry to `workspace_nodepools`; the pool, NVIDIA device plugin, and `jupyterlab-gpu` template derive from it |
+| nvidia_device_plugin_version | `string` | `0.19.3` | Version of the NVIDIA device plugin chart (installed when any pool entry sets `gpu = "true"`) |
 
 ## Outputs
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
@@ -184,8 +184,9 @@ jd server logs --name <workspace-name> --scope <namespace>
 ```
 
 A workspace stuck in `Starting` is often waiting on a node. GPU workspaces require
-`enable_gpu_pool: true` (the `workspace-gpu` Karpenter pool plus the NVIDIA device
-plugin) and sufficient G/VT vCPU quota (see above). The `nvidia-device-plugin`
+a GPU pool entry in `workspace_nodepools` (`enable_gpu_pool: true` provides the
+built-in one: the `workspace-gpu` Karpenter pool plus the NVIDIA device plugin)
+and sufficient G/VT vCPU quota (see above). The `nvidia-device-plugin`
 component reads `Degraded` in `jd health` while the GPU pool is scaled to zero:
 a DaemonSet with desired count 0 is idle, not failing.
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
@@ -184,9 +184,10 @@ jd server logs --name <workspace-name> --scope <namespace>
 ```
 
 A workspace stuck in `Starting` is often waiting on a node. GPU workspaces require
-a GPU pool entry in `workspace_nodepools` (`enable_default_gpu_pool: true` provides the
-built-in one: the `workspace-gpu` Karpenter pool plus the NVIDIA device plugin)
-and sufficient G/VT vCPU quota (see above). The `nvidia-device-plugin`
+an accelerator pool entry in `workspace_nodepools` with a template config offered
+through its `templates` key (`enable_default_gpu_pool: true` provides the built-in
+pair: the `workspace-gpu` Karpenter pool, the NVIDIA device plugin, and the
+`jupyterlab-gpu` card) and sufficient G/VT vCPU quota (see above). The `nvidia-device-plugin`
 component reads `Degraded` in `jd health` while the GPU pool is scaled to zero:
 a DaemonSet with desired count 0 is idle, not failing.
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
@@ -19,8 +19,9 @@ this template:
 
 - **EC2 vCPUs** — node group scaling fails with `VcpuLimitExceeded`. New accounts
   start with a low On-Demand vCPU limit per region, and `0` for accelerated
-  families (GPU/Neuron), which blocks `workspaces` node groups that use GPU
-  instance types. Quotas are measured in vCPUs, not instance counts.
+  families (GPU/Neuron), which blocks the workspace pools' GPU nodes
+  (Karpenter provisions one per GPU workspace). Quotas are measured in vCPUs,
+  not instance counts.
 - **Elastic IPs** — `AllocateAddress` fails with `AddressLimitExceeded`. The VPC
   provisions one NAT gateway (and therefore one EIP) per availability zone — two by
   default. The per-region limit defaults to 5.
@@ -40,9 +41,9 @@ Relevant quota codes:
 
 To resolve:
 
-- Pick smaller `instance_type` values in `node_groups`, reduce `desired_size`, or
-  free resources by destroying stale deployments (`jd down --path <project-dir>`),
-  then re-run `jd config` and `jd up`.
+- Pick smaller instance families or lower `max_cpu`/`max_gpus` in
+  `workspace_nodepools`, or free resources by destroying stale deployments
+  (`jd down --path <project-dir>`), then re-run `jd config` and `jd up`.
 - Or request a higher limit.
 
 {{ request-quota-increase-instructions }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
@@ -187,8 +187,9 @@ A workspace stuck in `Starting` is often waiting on a node. GPU workspaces requi
 an accelerator pool entry in `workspace_nodepools` with a template config offered
 through its `templates` key (`enable_default_gpu_pool: true` provides the built-in
 pair: the `workspace-gpu` Karpenter pool, the NVIDIA device plugin, and the
-`jupyterlab-gpu` card) and sufficient G/VT vCPU quota (see above). The `nvidia-device-plugin`
-component reads `Degraded` in `jd health` while the GPU pool is scaled to zero:
-a DaemonSet with desired count 0 is idle, not failing.
+`jupyterlab-gpu` card) and sufficient G/VT vCPU quota (see above). Inspect the
+device plugin with `kubectl get daemonset nvidia-device-plugin -n kube-system`;
+it reports desired count 0 while the GPU pool is scaled to zero, which is idle,
+not failing.
 
 {{ generated-by-footer }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
@@ -184,7 +184,7 @@ jd server logs --name <workspace-name> --scope <namespace>
 ```
 
 A workspace stuck in `Starting` is often waiting on a node. GPU workspaces require
-a GPU pool entry in `workspace_nodepools` (`enable_gpu_pool: true` provides the
+a GPU pool entry in `workspace_nodepools` (`enable_default_gpu_pool: true` provides the
 built-in one: the `workspace-gpu` Karpenter pool plus the NVIDIA device plugin)
 and sufficient G/VT vCPU quota (see above). The `nvidia-device-plugin`
 component reads `Degraded` in `jd health` while the GPU pool is scaled to zero:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/TROUBLESHOOT.md.template
@@ -183,8 +183,10 @@ jd server show --name <workspace-name> --scope <namespace>
 jd server logs --name <workspace-name> --scope <namespace>
 ```
 
-A workspace stuck in `Starting` is often waiting on a node. GPU workspaces require a
-`workspaces` node group with GPU capacity and sufficient vCPU quota (see above). If the
-node group `desired_size` is `0`, scale it up in `node_groups` and run `jd up`.
+A workspace stuck in `Starting` is often waiting on a node. GPU workspaces require
+`enable_gpu_pool: true` (the `workspace-gpu` Karpenter pool plus the NVIDIA device
+plugin) and sufficient G/VT vCPU quota (see above). The `nvidia-device-plugin`
+component reads `Degraded` in `jd health` while the GPU pool is scaled to zero:
+a DaemonSet with desired count 0 is idle, not failing.
 
 {{ generated-by-footer }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
@@ -2,6 +2,9 @@
 # Routing pool: always-on, conservative consolidation, small instances.
 # Workspace pools: scale-to-zero, aggressive consolidation, diverse instances.
 # Both carry taints so only pods with matching tolerations can land here.
+# A workspace pool may set a per-pool role (label + taint value) so that only
+# workspace templates tolerating that role reach it — this is what keeps CPU
+# workspaces off GPU nodes and GPU workspaces on nodes that advertise a device.
 #
 # Disruption budget: nodes: "1" (absolute, not percentage).
 # Karpenter applies the MINIMUM of all active budgets. A percentage budget
@@ -63,7 +66,14 @@ spec:
   template:
     metadata:
       labels:
-        jupyter-deploy/role: workspaces
+        # Default preserves the exact pre-GPU bytes: Karpenter hashes
+        # spec.template, so any change here drift-replaces the pool's nodes
+        # and restarts every workspace on them.
+        jupyter-deploy/role: {{ .role | default "workspaces" }}
+        {{- if .gpu }}
+        # Satisfies the NVIDIA device plugin's default nodeAffinity without NFD.
+        nvidia.com/gpu.present: "true"
+        {{- end }}
     spec:
       nodeClassRef:
         group: karpenter.k8s.aws
@@ -71,7 +81,7 @@ spec:
         name: {{ .name }}
       taints:
         - key: jupyter-deploy/role
-          value: workspaces
+          value: {{ .role | default "workspaces" }}
           effect: NoSchedule
       expireAfter: {{ $.Values.expireAfter }}
       requirements:
@@ -90,6 +100,9 @@ spec:
   limits:
     cpu: {{ .maxCpu | quote }}
     memory: {{ .maxMemory | quote }}
+    {{- if .maxGpus }}
+    nvidia.com/gpu: {{ .maxGpus | quote }}
+    {{- end }}
   disruption:
     # WhenEmpty (not WhenEmptyOrUnderutilized): workspace pods carry no PDB and
     # no karpenter.sh/do-not-disrupt annotation, so underutilized-consolidation

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
@@ -68,8 +68,9 @@ spec:
       labels:
         # Default preserves the exact pre-GPU bytes: Karpenter hashes
         # spec.template, so any change here drift-replaces the pool's nodes
-        # and restarts every workspace on them.
-        jupyter-deploy/role: {{ .role | default "workspaces" }}
+        # and restarts every workspace on them. Set values render quoted: an
+        # unquoted role like "on" would parse as a YAML boolean and fail apply.
+        jupyter-deploy/role: {{ if .role }}{{ .role | quote }}{{ else }}workspaces{{ end }}
         {{- if .gpu }}
         # Satisfies the NVIDIA device plugin's default nodeAffinity without NFD.
         nvidia.com/gpu.present: "true"
@@ -81,7 +82,7 @@ spec:
         name: {{ .name }}
       taints:
         - key: jupyter-deploy/role
-          value: {{ .role | default "workspaces" }}
+          value: {{ if .role }}{{ .role | quote }}{{ else }}workspaces{{ end }}
           effect: NoSchedule
       expireAfter: {{ $.Values.expireAfter }}
       requirements:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/values.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/values.yaml
@@ -22,4 +22,7 @@ routingLimitsMemory: "128Gi"
 # ── Workspace NodePools ───────────────────────────────────────────────────────
 # Each entry creates one NodePool + EC2NodeClass pair.
 # Injected by platform_karpenter.tf from var.workspace_nodepools.
+# Optional per-entry keys: role (label/taint value, defaults to "workspaces"),
+# maxGpus (renders a nvidia.com/gpu NodePool limit), gpu ("true" adds the
+# nvidia.com/gpu.present node label the NVIDIA device plugin selects on).
 workspaceNodepools: []

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
@@ -1,62 +1,51 @@
+{{- range .Values.workspaceTemplates }}
+---
 apiVersion: workspace.jupyter.org/v1alpha1
 kind: WorkspaceTemplate
 metadata:
-  name: {{ .Values.workspaceTemplate.name }}
-  namespace: {{ .Values.sharedNamespace }}
+  name: {{ .name }}
+  namespace: {{ $.Values.sharedNamespace }}
   labels:
-    workspace.jupyter.org/default-template: {{ .Values.workspaceTemplate.isDefault | quote }}
+    workspace.jupyter.org/default-template: {{ .isDefault | quote }}
 spec:
-  displayName: {{ .Values.workspaceTemplate.displayName }}
-  description: {{ .Values.workspaceTemplate.description }}
-  defaultImage: {{ .Values.workspaceTemplate.imageUri }}
-  appType: {{ .Values.workspaceTemplate.appType }}
-  defaultAccessType: {{ .Values.workspaceTemplate.accessType }}
-  defaultOwnershipType: {{ .Values.workspaceTemplate.ownershipType }}
+  displayName: {{ .displayName }}
+  description: {{ .description }}
+  defaultImage: {{ .imageUri }}
+  appType: {{ .appType }}
+  defaultAccessType: {{ .accessType }}
+  defaultOwnershipType: {{ .ownershipType }}
   defaultAccessStrategy:
-    name: {{ .Values.accessStrategy.name }}
-    namespace: {{ .Values.sharedNamespace }}
+    name: {{ $.Values.accessStrategy.name }}
+    namespace: {{ $.Values.sharedNamespace }}
   defaultResources:
-    requests:
-      cpu: "500m"
-      memory: "1Gi"
-    limits:
-      cpu: "2"
-      memory: "4Gi"
+    {{- .defaultResources | toYaml | nindent 4 }}
   resourceBounds:
     resources:
-      cpu:
-        min: "100m"
-        max: "8"
-      memory:
-        min: "256Mi"
-        max: "32Gi"
+      {{- .resourceBounds | toYaml | nindent 6 }}
   primaryStorage:
     defaultSize: "10Gi"
     minSize: "1Gi"
     maxSize: "100Gi"
-    defaultStorageClassName: {{ .Values.workspaceTemplate.storageClassName }}
+    defaultStorageClassName: {{ .storageClassName }}
     defaultMountPath: "/home/jovyan"
   # Gate workspace readiness on the app actually accepting connections, so the
   # operator does not flip status.condition[Available]=True before the server is
   # up. Complements the access-strategy startupProbe.
   defaultReadinessProbe:
     tcpSocket:
-      port: {{ .Values.workspaceTemplate.readinessProbe.port }}
-    initialDelaySeconds: {{ .Values.workspaceTemplate.readinessProbe.initialDelaySeconds }}
-    periodSeconds: {{ .Values.workspaceTemplate.readinessProbe.periodSeconds }}
-    failureThreshold: {{ .Values.workspaceTemplate.readinessProbe.failureThreshold }}
+      port: {{ .readinessProbe.port }}
+    initialDelaySeconds: {{ .readinessProbe.initialDelaySeconds }}
+    periodSeconds: {{ .readinessProbe.periodSeconds }}
+    failureThreshold: {{ .readinessProbe.failureThreshold }}
   defaultPodSecurityContext:
     fsGroup: 1000
   defaultNodeSelector:
-    jupyter-deploy/role: workspaces
+    {{- .nodeSelector | toYaml | nindent 4 }}
   defaultTolerations:
-    - key: jupyter-deploy/role
-      operator: Equal
-      value: workspaces
-      effect: NoSchedule
+    {{- .tolerations | toYaml | nindent 4 }}
   defaultIdleShutdown:
-    enabled: {{ .Values.workspaceTemplate.idleShutdown.enabled }}
-    idleTimeoutInMinutes: {{ .Values.workspaceTemplate.idleShutdown.timeoutMinutes }}
+    enabled: {{ .idleShutdown.enabled }}
+    idleTimeoutInMinutes: {{ .idleShutdown.timeoutMinutes }}
     detection:
       httpGet:
         path: /api/status
@@ -67,5 +56,6 @@ spec:
           format: RFC3339
   idleShutdownOverrides:
     allow: true
-    minIdleTimeoutInMinutes: {{ .Values.workspaceTemplate.idleShutdown.minTimeoutMinutes }}
-    maxIdleTimeoutInMinutes: {{ .Values.workspaceTemplate.idleShutdown.maxTimeoutMinutes }}
+    minIdleTimeoutInMinutes: {{ .idleShutdown.minTimeoutMinutes }}
+    maxIdleTimeoutInMinutes: {{ .idleShutdown.maxTimeoutMinutes }}
+{{- end }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
@@ -3,7 +3,7 @@
 apiVersion: workspace.jupyter.org/v1alpha1
 kind: WorkspaceTemplate
 metadata:
-  name: {{ .name }}
+  name: {{ .name | quote }}
   namespace: {{ $.Values.sharedNamespace }}
   labels:
     workspace.jupyter.org/default-template: {{ .isDefault | quote }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/templates/workspace-template.yaml
@@ -8,8 +8,8 @@ metadata:
   labels:
     workspace.jupyter.org/default-template: {{ .isDefault | quote }}
 spec:
-  displayName: {{ .displayName }}
-  description: {{ .description }}
+  displayName: {{ .displayName | quote }}
+  description: {{ .description | quote }}
   defaultImage: {{ .imageUri }}
   appType: {{ .appType }}
   defaultAccessType: {{ .accessType }}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/values.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/workspace-defaults/values.yaml
@@ -6,49 +6,58 @@ sharedNamespace: jupyter-k8s-shared
 accessStrategy:
   name: oauth-access-strategy
 
-# -- Default WorkspaceTemplate definition. Configures the workspace image, storage,
-# access controls, and idle shutdown behavior for new workspaces.
-workspaceTemplate:
-  # -- Kubernetes resource name for the WorkspaceTemplate.
-  name: jupyterlab
-  # -- Whether this is the default template for new workspaces.
-  isDefault: "true"
-  # -- Human-readable name shown in the workspace UI.
-  displayName: JupyterLab
-  # -- Human-readable description shown in the workspace UI.
-  description: "JupyterLab workspace with persistent EBS storage"
-  # -- Container image URI for workspace pods.
-  imageUri: ""
-  # -- Application type identifier (e.g. jupyterlab, code-server).
-  appType: jupyterlab
-  # -- Who can access the workspace: OwnerOnly or TeamShared.
-  accessType: OwnerOnly
-  # -- Who owns the workspace: OwnerOnly or TeamShared.
-  ownershipType: OwnerOnly
-  # -- StorageClass for the workspace persistent volume.
-  storageClassName: ebs-sc
-  # -- TCP readiness probe applied to workspace pods. The operator waits for this
-  # probe to pass before marking the workspace Available, so the app is reachable
-  # by the time users are redirected to it.
-  readinessProbe:
-    # -- Container port the probe connects to (the workspace app port).
-    port: 8888
-    # -- Seconds to wait after container start before the first probe.
-    initialDelaySeconds: 2
-    # -- Seconds between probe attempts.
-    periodSeconds: 3
-    # -- Consecutive failures tolerated before the probe is considered failed
-    # (with the values above, ~90s of startup grace).
-    failureThreshold: 30
-  idleShutdown:
-    # -- Whether to automatically stop idle workspaces.
-    enabled: true
-    # -- Default idle timeout in minutes before a workspace is stopped.
-    timeoutMinutes: 60
-    # -- Minimum idle timeout users can configure, in minutes.
-    minTimeoutMinutes: 15
-    # -- Maximum idle timeout users can configure, in minutes.
-    maxTimeoutMinutes: 480
+# -- WorkspaceTemplate definitions, one card in the workspace UI per entry.
+# A values-file list replaces this default wholesale (helm list semantics), so
+# terraform always injects the full list; the entry here serves standalone
+# renders and unit tests. Per-entry fields:
+#   name/isDefault/displayName/description/imageUri/appType - identity + card copy
+#   accessType/ownershipType/storageClassName               - workspace defaults
+#   defaultResources/resourceBounds                          - per-resource-key
+#     requests/limits and min/max (extended keys like nvidia.com/gpu included)
+#   nodeSelector/tolerations                                 - placement; must match
+#     the role of the Karpenter pool the template targets
+#   readinessProbe/idleShutdown                              - probe + idle policy
+workspaceTemplates:
+  - name: jupyterlab
+    isDefault: "true"
+    displayName: JupyterLab
+    description: "JupyterLab workspace with persistent EBS storage"
+    imageUri: ""
+    appType: jupyterlab
+    accessType: OwnerOnly
+    ownershipType: OwnerOnly
+    storageClassName: ebs-sc
+    defaultResources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+    resourceBounds:
+      cpu:
+        min: "100m"
+        max: "8"
+      memory:
+        min: "256Mi"
+        max: "32Gi"
+    nodeSelector:
+      jupyter-deploy/role: workspaces
+    tolerations:
+      - key: jupyter-deploy/role
+        operator: Equal
+        value: workspaces
+        effect: NoSchedule
+    readinessProbe:
+      port: 8888
+      initialDelaySeconds: 2
+      periodSeconds: 3
+      failureThreshold: 30
+    idleShutdown:
+      enabled: true
+      timeoutMinutes: 60
+      minTimeoutMinutes: 15
+      maxTimeoutMinutes: 480
 
 # -- Namespace-scoped NetworkPolicy governing ingress to workspace pods. One
 # policy is created per workspace namespace, replacing the per-workspace policy

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform.tf
@@ -24,6 +24,7 @@ resource "null_resource" "platform" {
     null_resource.cluster_addons,
     helm_release.cluster_autoscaler,
     helm_release.fluent_bit,
+    helm_release.nvidia_device_plugin,
     # Karpenter + KEDA + Prometheus must be ready before any workspace service starts:
     # NodePools must exist so workspace pods can be scheduled on Karpenter nodes,
     # and KEDA/Prometheus must be up so ScaledObjects can activate immediately.

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -217,7 +217,7 @@ resource "null_resource" "karpenter_nodepools_finalizer_cleanup" {
 }
 
 # ── GPU pool synthesis ────────────────────────────────────────────────────────
-# enable_gpu_pool alone yields working GPU capacity: when on and no entry named
+# enable_default_gpu_pool alone yields working GPU capacity: when on and no entry named
 # workspace-gpu exists, the built-in entry below is appended. A user-defined
 # workspace-gpu entry takes precedence as the customization path (issue #336).
 locals {
@@ -246,7 +246,7 @@ locals {
   }
   workspace_nodepools_effective = concat(
     var.workspace_nodepools,
-    var.enable_gpu_pool && !contains([for p in var.workspace_nodepools : p["name"]], local.gpu_pool_name)
+    var.enable_default_gpu_pool && !contains([for p in var.workspace_nodepools : p["name"]], local.gpu_pool_name)
     ? [local.gpu_pool_builtin] : [],
   )
 }

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -226,7 +226,7 @@ locals {
   gpu_pool_name = "workspace-gpu"
   gpu_pool_builtin = {
     name              = local.gpu_pool_name
-    instance_families = "g4dn,g5,g6,g6e"
+    instance_families = "g4dn,g5,g6,g6e,g7,g7e"
     disk_size_gb      = "100"
     max_cpu           = "64"
     max_memory        = "256Gi"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -224,7 +224,7 @@ locals {
   gpu_pool_name = "workspace-gpu"
   gpu_pool_builtin = {
     name              = local.gpu_pool_name
-    instance_families = "g4dn,g5"
+    instance_families = "g4dn,g5,g6,g6e"
     disk_size_gb      = "100"
     max_cpu           = "64"
     max_memory        = "256Gi"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -348,6 +348,15 @@ resource "helm_release" "karpenter_nodepools" {
       condition     = length(distinct([for p in local.workspace_nodepools_effective : p["name"]])) == length(local.workspace_nodepools_effective)
       error_message = "workspace_nodepools names must be unique, including the built-in \"workspace-gpu\" entry injected by enable_default_gpu_pool."
     }
+    precondition {
+      # Re-checks the variable-level role-collision rule over the effective
+      # list: the validation cannot see the entry enable_default_gpu_pool injects.
+      condition = length(setintersection(
+        toset([for p in local.workspace_nodepools_normalized : p["role"] if lookup(p, "accelerator", "") != ""]),
+        toset([for p in local.workspace_nodepools_normalized : lookup(p, "role", "workspaces") if lookup(p, "accelerator", "") == ""]),
+      )) == 0
+      error_message = "An accelerator pool must not share a role with a non-accelerator pool, including the built-in \"workspaces-gpu\" role injected by enable_default_gpu_pool: a shared role would let CPU workspaces onto GPU nodes."
+    }
   }
 
   depends_on = [

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -249,11 +249,6 @@ locals {
     var.enable_gpu_pool && !contains([for p in var.workspace_nodepools : p["name"]], local.gpu_pool_name)
     ? [local.gpu_pool_builtin] : [],
   )
-  # Role label of the GPU pool; the device plugin selects on it.
-  gpu_pool_role = try(
-    [for p in local.workspace_nodepools_effective : lookup(p, "role", "workspaces") if p["name"] == local.gpu_pool_name][0],
-    "workspaces-gpu",
-  )
 }
 
 resource "helm_release" "karpenter_nodepools" {

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -237,8 +237,9 @@ locals {
     accelerator = "nvidia"
     templates   = "jupyterlab-gpu"
   }
-  # cpu/memory target the g4dn.xlarge allocatable (an over-pin is permanently
-  # unschedulable; finalize against a live node, issue #336). Idle follows the
+  # cpu/memory sit under the g4dn.xlarge allocatable with headroom, so kubelet
+  # reservation or DaemonSet growth cannot leave the pod permanently
+  # unschedulable on the smallest family. Idle follows the
   # deployment default: a literal here could fall outside the admin's idle
   # window and fail every plan mentioning a config the admin never wrote.
   gpu_template_builtin = {
@@ -246,8 +247,8 @@ locals {
     display_name = "JupyterLab GPU"
     description  = "JupyterLab workspace with one NVIDIA GPU and persistent EBS storage"
     gpus         = "1"
-    cpu          = "3500m"
-    memory       = "13Gi"
+    cpu          = "3"
+    memory       = "12Gi"
     idle_minutes = tostring(var.workspaces_idle_shutdown_timeout_default)
   }
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -229,8 +229,10 @@ locals {
     max_cpu           = "64"
     max_memory        = "256Gi"
     max_gpus          = "4"
-    role              = "workspaces-gpu"
-    gpu               = "true"
+    # Explicit: the accelerator role default would yield "workspace-gpu" (the
+    # pool name), and tests, fixtures, and docs pin "workspaces-gpu".
+    role        = "workspaces-gpu"
+    accelerator = "nvidia"
     # Template keys: workspaces.tf derives the jupyterlab-gpu WorkspaceTemplate
     # from this entry. cpu/memory target the g4dn.xlarge allocatable (an
     # over-pin is permanently unschedulable — finalize against a live node,
@@ -249,6 +251,13 @@ locals {
     var.enable_default_gpu_pool && !contains([for p in var.workspace_nodepools : p["name"]], local.gpu_pool_name)
     ? [local.gpu_pool_builtin] : [],
   )
+  # Accelerator entries default role to the pool name, fencing each accelerator
+  # pool by construction. Non-accelerator entries keep the key absent so the
+  # chart's `default "workspaces"` path renders the exact pre-GPU bytes.
+  workspace_nodepools_normalized = [
+    for p in local.workspace_nodepools_effective :
+    (lookup(p, "accelerator", "") != "" && !contains(keys(p), "role")) ? merge(p, { role = p["name"] }) : p
+  ]
 }
 
 resource "helm_release" "karpenter_nodepools" {
@@ -297,17 +306,20 @@ resource "helm_release" "karpenter_nodepools" {
       # NodePools byte-identical (a changed rendered pool drift-replaces its
       # nodes and restarts the workspaces on them).
       workspaceNodepools = [
-        for p in local.workspace_nodepools_effective : merge(
+        for p in local.workspace_nodepools_normalized : merge(
           {
             name             = p["name"]
-            instanceFamilies = split(",", p["instance_families"])
+            instanceFamilies = [for f in split(",", p["instance_families"]) : trimspace(f)]
             diskSizeGi       = tonumber(p["disk_size_gb"])
             maxCpu           = p["max_cpu"]
             maxMemory        = p["max_memory"]
           },
           contains(keys(p), "role") ? { role = p["role"] } : {},
           contains(keys(p), "max_gpus") ? { maxGpus = p["max_gpus"] } : {},
-          contains(keys(p), "gpu") ? { gpu = p["gpu"] } : {},
+          # The chart's gpu value adds the nvidia.com/gpu.present node label;
+          # the key stays at the chart boundary so rendered pool bytes are
+          # untouched by the accelerator rename.
+          lookup(p, "accelerator", "") == "nvidia" ? { gpu = "true" } : {},
         )
       ]
     })

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -353,9 +353,9 @@ resource "helm_release" "karpenter_nodepools" {
       # list: the validation cannot see the entry enable_default_gpu_pool injects.
       condition = length(setintersection(
         toset([for p in local.workspace_nodepools_normalized : p["role"] if lookup(p, "accelerator", "") != ""]),
-        toset([for p in local.workspace_nodepools_normalized : lookup(p, "role", "workspaces") if lookup(p, "accelerator", "") == ""]),
+        toset(concat([for p in local.workspace_nodepools_normalized : lookup(p, "role", "workspaces") if lookup(p, "accelerator", "") == ""], ["workspaces"])),
       )) == 0
-      error_message = "An accelerator pool must not share a role with a non-accelerator pool, including the built-in \"workspaces-gpu\" role injected by enable_default_gpu_pool: a shared role would let CPU workspaces onto GPU nodes."
+      error_message = "An accelerator pool must not share a role with a non-accelerator pool or use \"workspaces\" (the base jupyterlab template's role), including the built-in \"workspaces-gpu\" role injected by enable_default_gpu_pool: a shared role would let CPU workspaces onto GPU nodes."
     }
   }
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -238,8 +238,9 @@ locals {
     templates   = "jupyterlab-gpu"
   }
   # cpu/memory target the g4dn.xlarge allocatable (an over-pin is permanently
-  # unschedulable; finalize against a live node, issue #336). Idle 30 is half
-  # the jupyterlab default: an idle hour on the cheapest GPU node costs $0.53.
+  # unschedulable; finalize against a live node, issue #336). Idle follows the
+  # deployment default: a literal here could fall outside the admin's idle
+  # window and fail every plan mentioning a config the admin never wrote.
   gpu_template_builtin = {
     name         = "jupyterlab-gpu"
     display_name = "JupyterLab GPU"
@@ -247,7 +248,7 @@ locals {
     gpus         = "1"
     cpu          = "3500m"
     memory       = "13Gi"
-    idle_minutes = "30"
+    idle_minutes = tostring(var.workspaces_idle_shutdown_timeout_default)
   }
 
   workspace_nodepools_accelerated = [

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -231,13 +231,25 @@ locals {
     max_gpus          = "4"
     role              = "workspaces-gpu"
     gpu               = "true"
+    # Template keys: workspaces.tf derives the jupyterlab-gpu WorkspaceTemplate
+    # from this entry. cpu/memory target the g4dn.xlarge allocatable (an
+    # over-pin is permanently unschedulable — finalize against a live node,
+    # issue #336). Idle 30 is half the jupyterlab default: an idle hour on the
+    # cheapest GPU node costs $0.53.
+    template_name         = "jupyterlab-gpu"
+    template_display_name = "JupyterLab GPU"
+    template_description  = "JupyterLab workspace with one NVIDIA GPU and persistent EBS storage"
+    template_gpus         = "1"
+    template_cpu          = "3500m"
+    template_memory       = "13Gi"
+    template_idle_minutes = "30"
   }
   workspace_nodepools_effective = concat(
     var.workspace_nodepools,
     var.enable_gpu_pool && !contains([for p in var.workspace_nodepools : p["name"]], local.gpu_pool_name)
     ? [local.gpu_pool_builtin] : [],
   )
-  # Role label of the GPU pool; the device plugin and the GPU template select on it.
+  # Role label of the GPU pool; the device plugin selects on it.
   gpu_pool_role = try(
     [for p in local.workspace_nodepools_effective : lookup(p, "role", "workspaces") if p["name"] == local.gpu_pool_name][0],
     "workspaces-gpu",

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -217,9 +217,11 @@ resource "null_resource" "karpenter_nodepools_finalizer_cleanup" {
 }
 
 # ── GPU pool synthesis ────────────────────────────────────────────────────────
-# enable_default_gpu_pool alone yields working GPU capacity: when on and no entry named
-# workspace-gpu exists, the built-in entry below is appended. A user-defined
-# workspace-gpu entry takes precedence as the customization path (issue #336).
+# enable_default_gpu_pool alone yields working GPU capacity: the built-in pool
+# entry and its template config below are appended. Admins with their own
+# accelerator entries configure GPU support through workspace_nodepools plus
+# workspace_templates instead; combining that with the flag is a plan-time
+# error (precondition on helm_release.karpenter_nodepools), per issue #336.
 locals {
   gpu_pool_name = "workspace-gpu"
   gpu_pool_builtin = {
@@ -233,23 +235,35 @@ locals {
     # pool name), and tests, fixtures, and docs pin "workspaces-gpu".
     role        = "workspaces-gpu"
     accelerator = "nvidia"
-    # Template keys: workspaces.tf derives the jupyterlab-gpu WorkspaceTemplate
-    # from this entry. cpu/memory target the g4dn.xlarge allocatable (an
-    # over-pin is permanently unschedulable — finalize against a live node,
-    # issue #336). Idle 30 is half the jupyterlab default: an idle hour on the
-    # cheapest GPU node costs $0.53.
-    template_name         = "jupyterlab-gpu"
-    template_display_name = "JupyterLab GPU"
-    template_description  = "JupyterLab workspace with one NVIDIA GPU and persistent EBS storage"
-    template_gpus         = "1"
-    template_cpu          = "3500m"
-    template_memory       = "13Gi"
-    template_idle_minutes = "30"
+    templates   = "jupyterlab-gpu"
   }
+  # cpu/memory target the g4dn.xlarge allocatable (an over-pin is permanently
+  # unschedulable; finalize against a live node, issue #336). Idle 30 is half
+  # the jupyterlab default: an idle hour on the cheapest GPU node costs $0.53.
+  gpu_template_builtin = {
+    name         = "jupyterlab-gpu"
+    display_name = "JupyterLab GPU"
+    description  = "JupyterLab workspace with one NVIDIA GPU and persistent EBS storage"
+    gpus         = "1"
+    cpu          = "3500m"
+    memory       = "13Gi"
+    idle_minutes = "30"
+  }
+
+  workspace_nodepools_accelerated = [
+    for p in var.workspace_nodepools : p if lookup(p, "accelerator", "") != ""
+  ]
+
+  # Injection is unconditional on the flag; the precondition on
+  # helm_release.karpenter_nodepools hard-errors the flag + hand-written
+  # accelerator overlap at plan time.
   workspace_nodepools_effective = concat(
     var.workspace_nodepools,
-    var.enable_default_gpu_pool && !contains([for p in var.workspace_nodepools : p["name"]], local.gpu_pool_name)
-    ? [local.gpu_pool_builtin] : [],
+    var.enable_default_gpu_pool ? [local.gpu_pool_builtin] : [],
+  )
+  workspace_templates_effective = concat(
+    var.workspace_templates,
+    var.enable_default_gpu_pool ? [local.gpu_template_builtin] : [],
   )
   # Accelerator entries default role to the pool name, fencing each accelerator
   # pool by construction. Non-accelerator entries keep the key absent so the
@@ -324,6 +338,17 @@ resource "helm_release" "karpenter_nodepools" {
       ]
     })
   ]
+
+  lifecycle {
+    precondition {
+      condition     = !(var.enable_default_gpu_pool && length(local.workspace_nodepools_accelerated) > 0)
+      error_message = "enable_default_gpu_pool conflicts with accelerator entries in workspace_nodepools (${join(", ", [for p in local.workspace_nodepools_accelerated : p["name"]])}): the entries already provision GPU capacity, disable the flag."
+    }
+    precondition {
+      condition     = length(distinct([for p in local.workspace_nodepools_effective : p["name"]])) == length(local.workspace_nodepools_effective)
+      error_message = "workspace_nodepools names must be unique, including the built-in \"workspace-gpu\" entry injected by enable_default_gpu_pool."
+    }
+  }
 
   depends_on = [
     helm_release.karpenter,

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -216,6 +216,34 @@ resource "null_resource" "karpenter_nodepools_finalizer_cleanup" {
   ]
 }
 
+# ── GPU pool synthesis ────────────────────────────────────────────────────────
+# enable_gpu_pool alone yields working GPU capacity: when on and no entry named
+# workspace-gpu exists, the built-in entry below is appended. A user-defined
+# workspace-gpu entry takes precedence as the customization path (issue #336).
+locals {
+  gpu_pool_name = "workspace-gpu"
+  gpu_pool_builtin = {
+    name              = local.gpu_pool_name
+    instance_families = "g4dn,g5"
+    disk_size_gb      = "100"
+    max_cpu           = "64"
+    max_memory        = "256Gi"
+    max_gpus          = "4"
+    role              = "workspaces-gpu"
+    gpu               = "true"
+  }
+  workspace_nodepools_effective = concat(
+    var.workspace_nodepools,
+    var.enable_gpu_pool && !contains([for p in var.workspace_nodepools : p["name"]], local.gpu_pool_name)
+    ? [local.gpu_pool_builtin] : [],
+  )
+  # Role label of the GPU pool; the device plugin and the GPU template select on it.
+  gpu_pool_role = try(
+    [for p in local.workspace_nodepools_effective : lookup(p, "role", "workspaces") if p["name"] == local.gpu_pool_name][0],
+    "workspaces-gpu",
+  )
+}
+
 resource "helm_release" "karpenter_nodepools" {
   name             = "karpenter-nodepools"
   chart            = "${path.module}/../charts/karpenter-nodepools"
@@ -257,14 +285,23 @@ resource "helm_release" "karpenter_nodepools" {
         instanceCategories    = var.routing_instance_categories
         instanceGenerationMin = var.routing_instance_generation_min
       }
+      # Optional keys are emitted only when present: an absent key makes the
+      # chart render the pre-GPU bytes for that pool, keeping existing
+      # NodePools byte-identical (a changed rendered pool drift-replaces its
+      # nodes and restarts the workspaces on them).
       workspaceNodepools = [
-        for p in var.workspace_nodepools : {
-          name             = p["name"]
-          instanceFamilies = split(",", p["instance_families"])
-          diskSizeGi       = tonumber(p["disk_size_gb"])
-          maxCpu           = p["max_cpu"]
-          maxMemory        = p["max_memory"]
-        }
+        for p in local.workspace_nodepools_effective : merge(
+          {
+            name             = p["name"]
+            instanceFamilies = split(",", p["instance_families"])
+            diskSizeGi       = tonumber(p["disk_size_gb"])
+            maxCpu           = p["max_cpu"]
+            maxMemory        = p["max_memory"]
+          },
+          contains(keys(p), "role") ? { role = p["role"] } : {},
+          contains(keys(p), "max_gpus") ? { maxGpus = p["max_gpus"] } : {},
+          contains(keys(p), "gpu") ? { gpu = p["gpu"] } : {},
+        )
       ]
     })
   ]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_nvidia_device_plugin.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_nvidia_device_plugin.tf
@@ -1,13 +1,23 @@
 # === NVIDIA device plugin (GPU workspaces) ===
 #
 # Deploys the NVIDIA device plugin DaemonSet, which registers nvidia.com/gpu
-# capacity with the kubelet on GPU pool nodes. Gated by enable_gpu_pool, so
-# non-GPU clusters run no extra workload. The AL2023 NVIDIA AMI already ships
-# the driver and container toolkit; this plugin is the one GPU piece EKS does
-# not install.
+# capacity with the kubelet on GPU pool nodes. Installed when any workspace
+# pool entry sets gpu = "true", so non-GPU clusters run no extra workload.
+# The AL2023 NVIDIA AMI already ships the driver and container toolkit; this
+# plugin is the one GPU piece EKS does not install.
+
+locals {
+  gpu_nodepools = [
+    for p in local.workspace_nodepools_effective : p if lookup(p, "gpu", "") == "true"
+  ]
+  # Sorted for a stable rendered order across plans.
+  gpu_nodepool_roles = distinct(sort([
+    for p in local.gpu_nodepools : lookup(p, "role", "workspaces")
+  ]))
+}
 
 resource "helm_release" "nvidia_device_plugin" {
-  count = var.enable_gpu_pool ? 1 : 0
+  count = length(local.gpu_nodepools) > 0 ? 1 : 0
 
   name       = "nvidia-device-plugin"
   repository = "https://nvidia.github.io/k8s-device-plugin"
@@ -18,20 +28,22 @@ resource "helm_release" "nvidia_device_plugin" {
   values = [
     yamlencode({
       # Pin the daemonset to GPU pool nodes. Scheduling needs all three of this
-      # nodeSelector, the toleration below, and the pool's nvidia.com/gpu.present
-      # node label (the chart's default nodeAffinity requires it when NFD is
-      # absent); missing any one leaves the daemonset unscheduled, nvidia.com/gpu
-      # never advertised, and every GPU workspace Pending with no error.
+      # nodeSelector, a toleration below, and the pool's nvidia.com/gpu.present
+      # node label (which every gpu = "true" pool sets, and which the chart's
+      # default nodeAffinity requires when NFD is absent); missing any one
+      # leaves the daemonset unscheduled, nvidia.com/gpu never advertised, and
+      # every GPU workspace Pending with no error.
       nodeSelector = {
-        "jupyter-deploy/role" = local.gpu_pool_role
+        "nvidia.com/gpu.present" = "true"
       }
       # Replaces the chart's default tolerations (CriticalAddonsOnly and
-      # nvidia.com/gpu), which do not cover the pool's jupyter-deploy/role taint.
+      # nvidia.com/gpu), which do not cover the pools' jupyter-deploy/role
+      # taints: one toleration per distinct GPU pool role.
       tolerations = [
-        {
+        for role in local.gpu_nodepool_roles : {
           key      = "jupyter-deploy/role"
           operator = "Equal"
-          value    = local.gpu_pool_role
+          value    = role
           effect   = "NoSchedule"
         }
       ]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_nvidia_device_plugin.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_nvidia_device_plugin.tf
@@ -10,9 +10,10 @@ locals {
   gpu_nodepools = [
     for p in local.workspace_nodepools_normalized : p if lookup(p, "accelerator", "") == "nvidia"
   ]
-  # Sorted for a stable rendered order across plans.
+  # Sorted for a stable rendered order across plans. Direct index: accelerator
+  # entries always carry role after normalization.
   gpu_nodepool_roles = distinct(sort([
-    for p in local.gpu_nodepools : lookup(p, "role", "workspaces")
+    for p in local.gpu_nodepools : p["role"]
   ]))
 }
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_nvidia_device_plugin.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_nvidia_device_plugin.tf
@@ -1,0 +1,47 @@
+# === NVIDIA device plugin (GPU workspaces) ===
+#
+# Deploys the NVIDIA device plugin DaemonSet, which registers nvidia.com/gpu
+# capacity with the kubelet on GPU pool nodes. Gated by enable_gpu_pool, so
+# non-GPU clusters run no extra workload. The AL2023 NVIDIA AMI already ships
+# the driver and container toolkit; this plugin is the one GPU piece EKS does
+# not install.
+
+resource "helm_release" "nvidia_device_plugin" {
+  count = var.enable_gpu_pool ? 1 : 0
+
+  name       = "nvidia-device-plugin"
+  repository = "https://nvidia.github.io/k8s-device-plugin"
+  chart      = "nvidia-device-plugin"
+  version    = var.nvidia_device_plugin_version
+  namespace  = "kube-system"
+
+  values = [
+    yamlencode({
+      # Pin the daemonset to GPU pool nodes. Scheduling needs all three of this
+      # nodeSelector, the toleration below, and the pool's nvidia.com/gpu.present
+      # node label (the chart's default nodeAffinity requires it when NFD is
+      # absent); missing any one leaves the daemonset unscheduled, nvidia.com/gpu
+      # never advertised, and every GPU workspace Pending with no error.
+      nodeSelector = {
+        "jupyter-deploy/role" = local.gpu_pool_role
+      }
+      # Replaces the chart's default tolerations (CriticalAddonsOnly and
+      # nvidia.com/gpu), which do not cover the pool's jupyter-deploy/role taint.
+      tolerations = [
+        {
+          key      = "jupyter-deploy/role"
+          operator = "Equal"
+          value    = local.gpu_pool_role
+          effect   = "NoSchedule"
+        }
+      ]
+    })
+  ]
+
+  depends_on = [
+    null_resource.cluster_addons,
+    aws_eks_node_group.platform,
+    aws_eks_access_policy_association.admin_role,
+    aws_eks_access_policy_association.admin_user,
+  ]
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_nvidia_device_plugin.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_nvidia_device_plugin.tf
@@ -2,13 +2,13 @@
 #
 # Deploys the NVIDIA device plugin DaemonSet, which registers nvidia.com/gpu
 # capacity with the kubelet on GPU pool nodes. Installed when any workspace
-# pool entry sets gpu = "true", so non-GPU clusters run no extra workload.
+# pool entry sets accelerator = "nvidia", so non-GPU clusters run no extra workload.
 # The AL2023 NVIDIA AMI already ships the driver and container toolkit; this
 # plugin is the one GPU piece EKS does not install.
 
 locals {
   gpu_nodepools = [
-    for p in local.workspace_nodepools_effective : p if lookup(p, "gpu", "") == "true"
+    for p in local.workspace_nodepools_normalized : p if lookup(p, "accelerator", "") == "nvidia"
   ]
   # Sorted for a stable rendered order across plans.
   gpu_nodepool_roles = distinct(sort([
@@ -29,7 +29,7 @@ resource "helm_release" "nvidia_device_plugin" {
     yamlencode({
       # Pin the daemonset to GPU pool nodes. Scheduling needs all three of this
       # nodeSelector, a toleration below, and the pool's nvidia.com/gpu.present
-      # node label (which every gpu = "true" pool sets, and which the chart's
+      # node label (which every accelerator pool sets, and which the chart's
       # default nodeAffinity requires when NFD is absent); missing any one
       # leaves the daemonset unscheduled, nvidia.com/gpu never advertised, and
       # every GPU workspace Pending with no error.

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
@@ -59,3 +59,5 @@ workspace_nodepools = [
     max_memory        = "2048Gi"
   }
 ]
+
+enable_gpu_pool = false

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
@@ -60,5 +60,6 @@ workspace_nodepools = [
   }
 ]
 
+workspace_templates          = []
 enable_default_gpu_pool      = false
 nvidia_device_plugin_version = "0.19.3"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
@@ -60,4 +60,5 @@ workspace_nodepools = [
   }
 ]
 
-enable_gpu_pool = false
+enable_gpu_pool              = false
+nvidia_device_plugin_version = "0.19.3"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/presets/defaults-all.tfvars
@@ -60,5 +60,5 @@ workspace_nodepools = [
   }
 ]
 
-enable_gpu_pool              = false
+enable_default_gpu_pool      = false
 nvidia_device_plugin_version = "0.19.3"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -262,13 +262,25 @@ variable "workspace_nodepools" {
                  role schedule onto the pool (defaults to "workspaces")
       max_gpus - fleet GPU ceiling, the NodePool limit for nvidia.com/gpu (e.g. "4")
       gpu      - "true" to add the nvidia.com/gpu.present node label the NVIDIA
-                 device plugin selects on
+                 device plugin selects on; any entry with this key installs the plugin
+
+    Template keys per entry (all strings; an entry with template_gpus yields one
+    WorkspaceTemplate pinned to this pool via its role):
+      template_gpus         - nvidia.com/gpu count the template requests (e.g. "1")
+      template_cpu          - pinned cpu request/limit/bounds (required with template_gpus)
+      template_memory       - pinned memory request/limit/bounds (required with template_gpus)
+      template_idle_minutes - idle-shutdown default in minutes (defaults to
+                              workspaces_idle_shutdown_timeout_default)
+      template_name         - WorkspaceTemplate name (defaults to the pool name)
+      template_display_name - UI card title (defaults to the template name)
+      template_description  - UI card description (defaults to a generic line)
 
     Example (a customized GPU pool; enable_gpu_pool = true with no workspace-gpu
     entry provides this shape built in):
       workspace_nodepools = [
         { name = "workspace-cpu", instance_families = "c6i,m6i,r6i", disk_size_gb = "50", max_cpu = "512", max_memory = "2048Gi" },
-        { name = "workspace-gpu", instance_families = "g4dn,g5", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi", max_gpus = "4", role = "workspaces-gpu", gpu = "true" },
+        { name = "workspace-gpu", instance_families = "g4dn,g5", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi", max_gpus = "4", role = "workspaces-gpu", gpu = "true",
+          template_name = "jupyterlab-gpu", template_gpus = "1", template_cpu = "3500m", template_memory = "13Gi", template_idle_minutes = "30" },
       ]
   EOT
   type        = list(map(string))
@@ -313,17 +325,55 @@ variable "workspace_nodepools" {
     ])
     error_message = "Each workspace NodePool role, when set, must be a valid Kubernetes label value (alphanumeric plus -_., max 63 chars)."
   }
+
+  validation {
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      !contains(keys(p), "template_gpus") || can(tonumber(p["template_gpus"]))
+    ])
+    error_message = "Each workspace NodePool template_gpus, when set, must be a numeric string."
+  }
+
+  validation {
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      !contains(keys(p), "template_idle_minutes") || can(tonumber(p["template_idle_minutes"]))
+    ])
+    error_message = "Each workspace NodePool template_idle_minutes, when set, must be a numeric string."
+  }
+
+  validation {
+    # No hardware-agnostic default exists for the pinned shape: the right values
+    # depend on the pool's instance families (allocatable of the smallest size).
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      !contains(keys(p), "template_gpus") || (contains(keys(p), "template_cpu") && contains(keys(p), "template_memory"))
+    ])
+    error_message = "A workspace NodePool with template_gpus must also set template_cpu and template_memory."
+  }
+
+  validation {
+    # Rendered as the WorkspaceTemplate metadata.name.
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      !contains(keys(p), "template_name") || can(regex("^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$", p["template_name"]))
+    ])
+    error_message = "Each workspace NodePool template_name, when set, must be a valid Kubernetes resource name (lowercase alphanumeric and dashes, max 63 chars)."
+  }
 }
 
 variable "enable_gpu_pool" {
   description = <<-EOT
     Whether to provision GPU workspace capacity.
 
-    When true, the template adds a built-in workspace-gpu Karpenter pool
-    (define your own workspace-gpu entry in workspace_nodepools to customize
-    it), installs the NVIDIA device plugin, and ships the jupyterlab-gpu
-    workspace template. Delete GPU workspaces before turning this off:
-    disabling removes the pool and the template they depend on.
+    When true, the template appends a built-in workspace-gpu entry to
+    workspace_nodepools (define your own workspace-gpu entry to customize it,
+    which then takes precedence). The Karpenter pool, the NVIDIA device
+    plugin, and the jupyterlab-gpu workspace template all derive from that
+    entry; a hand-written entry with gpu and template keys yields the same
+    stack without this flag. Delete GPU workspaces before removing their
+    entry or turning this off: doing so removes the pool and the template
+    they depend on.
 
     First GPU use on an AWS account without prior GPU usage requires raising
     the "Running On-Demand G and VT instances" service quota (defaults to 0).
@@ -335,8 +385,8 @@ variable "enable_gpu_pool" {
 
 variable "nvidia_device_plugin_version" {
   description = <<-EOT
-    Helm chart version of the NVIDIA device plugin, installed only when
-    enable_gpu_pool is true.
+    Helm chart version of the NVIDIA device plugin, installed when any
+    workspace_nodepools entry sets gpu = "true" (the built-in GPU pool does).
 
     Refer to: https://github.com/NVIDIA/k8s-device-plugin/releases
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -275,7 +275,7 @@ variable "workspace_nodepools" {
       template_display_name - UI card title (defaults to the template name)
       template_description  - UI card description (defaults to a generic line)
 
-    Example (a customized GPU pool; enable_gpu_pool = true with no workspace-gpu
+    Example (a customized GPU pool; enable_default_gpu_pool = true with no workspace-gpu
     entry provides this shape built in):
       workspace_nodepools = [
         { name = "workspace-cpu", instance_families = "c6i,m6i,r6i", disk_size_gb = "50", max_cpu = "512", max_memory = "2048Gi" },
@@ -362,7 +362,7 @@ variable "workspace_nodepools" {
   }
 }
 
-variable "enable_gpu_pool" {
+variable "enable_default_gpu_pool" {
   description = <<-EOT
     Whether to provision GPU workspace capacity.
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -278,7 +278,7 @@ variable "workspace_nodepools" {
     equivalent built in):
       workspace_nodepools = [
         { name = "workspace-cpu", instance_families = "c6i,m6i,r6i", disk_size_gb = "50", max_cpu = "512", max_memory = "2048Gi" },
-        { name = "workspace-gpu", instance_families = "g4dn,g5,g6,g6e", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi",
+        { name = "workspace-gpu", instance_families = "g4dn,g5,g6,g6e,g7,g7e", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi",
           max_gpus = "4", accelerator = "nvidia", templates = "jupyterlab-gpu" },
       ]
   EOT

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -269,23 +269,17 @@ variable "workspace_nodepools" {
                     (e.g. "4"); optional, absent means unbounded (the account's
                     G/VT service quota is the backstop); requires accelerator
 
-    Template keys per entry (all strings; an entry with template_gpus yields one
-    WorkspaceTemplate pinned to this pool via its role):
-      template_gpus         - nvidia.com/gpu count the template requests (e.g. "1")
-      template_cpu          - pinned cpu request/limit/bounds (required with template_gpus)
-      template_memory       - pinned memory request/limit/bounds (required with template_gpus)
-      template_idle_minutes - idle-shutdown default in minutes (defaults to
-                              workspaces_idle_shutdown_timeout_default)
-      template_name         - WorkspaceTemplate name (defaults to the pool name)
-      template_display_name - UI card title (defaults to the template name)
-      template_description  - UI card description (defaults to a generic line)
+      templates   - comma-separated workspace_templates config names this pool
+                    offers as cards; each referenced config renders one
+                    WorkspaceTemplate pinned to this pool's role (see the
+                    workspace_templates variable)
 
-    Example (a customized GPU pool; enable_default_gpu_pool = true with no workspace-gpu
-    entry provides this shape built in):
+    Example (a customized GPU pool; enable_default_gpu_pool = true provides the
+    equivalent built in):
       workspace_nodepools = [
         { name = "workspace-cpu", instance_families = "c6i,m6i,r6i", disk_size_gb = "50", max_cpu = "512", max_memory = "2048Gi" },
-        { name = "workspace-gpu", instance_families = "g4dn,g5", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi", max_gpus = "4", accelerator = "nvidia",
-          template_name = "jupyterlab-gpu", template_gpus = "1", template_cpu = "3500m", template_memory = "13Gi", template_idle_minutes = "30" },
+        { name = "workspace-gpu", instance_families = "g4dn,g5,g6,g6e", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi",
+          max_gpus = "4", accelerator = "nvidia", templates = "jupyterlab-gpu" },
       ]
   EOT
   type        = list(map(string))
@@ -342,51 +336,119 @@ variable "workspace_nodepools" {
   validation {
     condition = alltrue([
       for p in var.workspace_nodepools :
-      !contains(keys(p), "template_gpus") || can(tonumber(p["template_gpus"]))
+      !contains(keys(p), "templates") || alltrue([for raw in split(",", p["templates"]) : trimspace(raw) != ""])
     ])
-    error_message = "Each workspace NodePool template_gpus, when set, must be a numeric string."
+    error_message = "Each workspace NodePool templates key, when set, must be a comma-separated list of non-empty workspace_templates config names."
   }
+}
 
-  validation {
-    condition = alltrue([
-      for p in var.workspace_nodepools :
-      !contains(keys(p), "template_idle_minutes") || can(tonumber(p["template_idle_minutes"]))
-    ])
-    error_message = "Each workspace NodePool template_idle_minutes, when set, must be a numeric string."
-  }
+variable "workspace_templates" {
+  description = <<-EOT
+    Named workspace template configurations. A workspace_nodepools entry adopts
+    a config by listing its name in the entry's templates key; each (entry,
+    config) pairing renders one WorkspaceTemplate card, where the config
+    supplies the shape and card copy and the entry supplies placement (its
+    role). A config referenced by no entry renders nothing. Entries sharing a
+    role may share a config; entries with different roles need distinct
+    configs, since a WorkspaceTemplate pins one node selector.
 
-  validation {
-    # No hardware-agnostic default exists for the pinned shape: the right values
-    # depend on the pool's instance families (allocatable of the smallest size).
-    condition = alltrue([
-      for p in var.workspace_nodepools :
-      !contains(keys(p), "template_gpus") || (contains(keys(p), "template_cpu") && contains(keys(p), "template_memory"))
-    ])
-    error_message = "A workspace NodePool with template_gpus must also set template_cpu and template_memory."
-  }
+    Required keys per entry (all strings):
+      name         - WorkspaceTemplate name (e.g. "jupyterlab-gpu-p"); unique,
+                     "jupyterlab" is reserved for the built-in default template
+    Optional keys per entry (all strings):
+      gpus         - nvidia.com/gpu count the template pins (e.g. "1");
+                     requires cpu and memory
+      cpu          - pinned cpu request/limit/bounds (e.g. "22"); set with memory
+      memory       - pinned memory request/limit/bounds (e.g. "200Gi"); set with cpu
+      idle_minutes - idle-shutdown default in minutes (defaults to
+                     workspaces_idle_shutdown_timeout_default)
+      display_name - UI card title (defaults to the config name)
+      description  - UI card description (defaults to a generic line)
+
+    A config without cpu/memory (legal only without gpus) inherits the base
+    jupyterlab shape: the card is the standard adjustable workspace, pinned to
+    the pool that lists it, with its own idle policy.
+
+    Example (a P-family pool with its own template; enable_default_gpu_pool
+    provides the equivalent G-family stack built in):
+      workspace_templates = [
+        { name = "jupyterlab-gpu-p", gpus = "1", cpu = "22", memory = "200Gi", idle_minutes = "30" },
+      ]
+      workspace_nodepools = [
+        { name = "workspace-cpu", instance_families = "c6i,m6i,r6i", disk_size_gb = "50", max_cpu = "512", max_memory = "2048Gi" },
+        { name = "workspace-gpu-p", instance_families = "p4d,p5,p5en", disk_size_gb = "200",
+          max_cpu = "384", max_memory = "3000Gi", accelerator = "nvidia", templates = "jupyterlab-gpu-p" },
+      ]
+  EOT
+  type        = list(map(string))
 
   validation {
     # Rendered as the WorkspaceTemplate metadata.name.
     condition = alltrue([
-      for p in var.workspace_nodepools :
-      !contains(keys(p), "template_name") || can(regex("^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$", p["template_name"]))
+      for t in var.workspace_templates :
+      can(regex("^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$", lookup(t, "name", "")))
     ])
-    error_message = "Each workspace NodePool template_name, when set, must be a valid Kubernetes resource name (lowercase alphanumeric and dashes, max 63 chars)."
+    error_message = "Each workspace_templates entry must set name to a valid Kubernetes resource name (lowercase alphanumeric and dashes, max 63 chars)."
+  }
+
+  validation {
+    condition     = length(distinct([for t in var.workspace_templates : lookup(t, "name", "")])) == length(var.workspace_templates)
+    error_message = "workspace_templates names must be unique."
+  }
+
+  validation {
+    condition     = !contains([for t in var.workspace_templates : lookup(t, "name", "")], "jupyterlab")
+    error_message = "\"jupyterlab\" is reserved for the built-in default template."
+  }
+
+  validation {
+    condition = alltrue([
+      for t in var.workspace_templates :
+      !contains(keys(t), "gpus") || can(tonumber(t["gpus"]))
+    ])
+    error_message = "Each workspace_templates gpus, when set, must be a numeric string."
+  }
+
+  validation {
+    condition = alltrue([
+      for t in var.workspace_templates :
+      !contains(keys(t), "idle_minutes") || can(tonumber(t["idle_minutes"]))
+    ])
+    error_message = "Each workspace_templates idle_minutes, when set, must be a numeric string."
+  }
+
+  validation {
+    # No hardware-agnostic default exists for a GPU card's pinned shape: the
+    # right values depend on the pool's instance families (allocatable of the
+    # smallest size).
+    condition = alltrue([
+      for t in var.workspace_templates :
+      !contains(keys(t), "gpus") || (contains(keys(t), "cpu") && contains(keys(t), "memory"))
+    ])
+    error_message = "A workspace_templates entry with gpus must also set cpu and memory."
+  }
+
+  validation {
+    condition = alltrue([
+      for t in var.workspace_templates :
+      contains(keys(t), "cpu") == contains(keys(t), "memory")
+    ])
+    error_message = "workspace_templates cpu and memory must be set together."
   }
 }
 
 variable "enable_default_gpu_pool" {
   description = <<-EOT
-    Whether to provision GPU workspace capacity.
+    Whether to provision the built-in default GPU workspace stack.
 
-    When true, the template appends a built-in workspace-gpu entry to
-    workspace_nodepools (define your own workspace-gpu entry to customize it,
-    which then takes precedence). The Karpenter pool, the NVIDIA device
-    plugin, and the jupyterlab-gpu workspace template all derive from that
-    entry; a hand-written entry with gpu and template keys yields the same
-    stack without this flag. Delete GPU workspaces before removing their
-    entry or turning this off: doing so removes the pool and the template
-    they depend on.
+    When true, the template appends the built-in workspace-gpu entry to
+    workspace_nodepools and its jupyterlab-gpu config to workspace_templates:
+    one GPU pool, the NVIDIA device plugin, and one GPU workspace card.
+    Combining the flag with your own accelerator entries is a plan-time
+    error: configure GPU support either through this flag or through
+    workspace_nodepools + workspace_templates, not both. Delete GPU
+    workspaces before turning this off: disabling removes the pool and the
+    template they depend on.
 
     First GPU use on an AWS account without prior GPU usage requires raising
     the "Running On-Demand G and VT instances" service quota (defaults to 0).

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -264,7 +264,8 @@ variable "workspace_nodepools" {
                     pool name so accelerator pools are fenced by construction
       role        - node label/taint value; only workspace templates tolerating this
                     role schedule onto the pool (defaults to "workspaces", or to the
-                    pool name when accelerator is set)
+                    pool name when accelerator is set; an accelerator entry must not
+                    use "workspaces", the base jupyterlab template's role)
       max_gpus    - fleet GPU ceiling, the NodePool limit for nvidia.com/gpu
                     (e.g. "4"); optional, absent means unbounded (the account's
                     G/VT service quota is the backstop); requires accelerator
@@ -287,6 +288,11 @@ variable "workspace_nodepools" {
   validation {
     condition     = length(var.workspace_nodepools) >= 1
     error_message = "workspace_nodepools must contain at least one NodePool definition."
+  }
+
+  validation {
+    condition     = alltrue([for p in var.workspace_nodepools : trimspace(lookup(p, "name", "")) != ""])
+    error_message = "Each workspace NodePool entry must set name."
   }
 
   validation {
@@ -342,12 +348,13 @@ variable "workspace_nodepools" {
   }
 
   validation {
-    # A shared role would let plain CPU workspaces schedule onto GPU nodes.
+    # A shared role would let plain CPU workspaces schedule onto GPU nodes;
+    # "workspaces" is always taken, the base jupyterlab template pins it.
     condition = length(setintersection(
-      toset([for p in var.workspace_nodepools : lookup(p, "role", p["name"]) if lookup(p, "accelerator", "") != ""]),
-      toset([for p in var.workspace_nodepools : lookup(p, "role", "workspaces") if lookup(p, "accelerator", "") == ""]),
+      toset([for p in var.workspace_nodepools : lookup(p, "role", lookup(p, "name", "")) if lookup(p, "accelerator", "") != ""]),
+      toset(concat([for p in var.workspace_nodepools : lookup(p, "role", "workspaces") if lookup(p, "accelerator", "") == ""], ["workspaces"])),
     )) == 0
-    error_message = "An accelerator entry must not share a role with a non-accelerator entry (\"workspaces\" is the non-accelerator default)."
+    error_message = "An accelerator entry must not share a role with a non-accelerator entry or use \"workspaces\" (the non-accelerator default and the base jupyterlab template's role)."
   }
 }
 
@@ -366,7 +373,8 @@ variable "workspace_templates" {
                      "jupyterlab" is reserved for the built-in default template
     Optional keys per entry (all strings):
       gpus         - nvidia.com/gpu count the template pins (e.g. "1");
-                     requires cpu and memory
+                     requires cpu and memory, and only accelerator pools may
+                     offer the config
       cpu          - pinned cpu request/limit/bounds (e.g. "22"); set with memory
       memory       - pinned memory request/limit/bounds (e.g. "200Gi"); set with cpu
       idle_minutes - idle-shutdown default in minutes (defaults to

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -316,7 +316,9 @@ variable "workspace_nodepools" {
   validation {
     condition = alltrue([
       for p in var.workspace_nodepools :
-      !contains(keys(p), "accelerator") || p["accelerator"] == "nvidia"
+      # lookup, not p["accelerator"]: || is eager pre-TF-1.10 and the index
+      # would error on entries without the key.
+      !contains(keys(p), "accelerator") || lookup(p, "accelerator", "") == "nvidia"
     ])
     error_message = "Each workspace NodePool accelerator, when set, must be \"nvidia\" (the only supported device stack)."
   }
@@ -342,7 +344,7 @@ variable "workspace_nodepools" {
   validation {
     condition = alltrue([
       for p in var.workspace_nodepools :
-      !contains(keys(p), "templates") || alltrue([for raw in split(",", p["templates"]) : trimspace(raw) != ""])
+      !contains(keys(p), "templates") || alltrue([for raw in split(",", lookup(p, "templates", "")) : trimspace(raw) != ""])
     ])
     error_message = "Each workspace NodePool templates key, when set, must be a comma-separated list of non-empty workspace_templates config names."
   }

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -265,7 +265,8 @@ variable "workspace_nodepools" {
       role        - node label/taint value; only workspace templates tolerating this
                     role schedule onto the pool (defaults to "workspaces", or to the
                     pool name when accelerator is set; an accelerator entry must not
-                    use "workspaces", the base jupyterlab template's role)
+                    use "workspaces", the base jupyterlab template's role, and no
+                    entry may use "routing", the routing pool's role)
       max_gpus    - fleet GPU ceiling, the NodePool limit for nvidia.com/gpu
                     (e.g. "4"); optional, absent means unbounded (the account's
                     G/VT service quota is the backstop); requires accelerator
@@ -347,6 +348,18 @@ variable "workspace_nodepools" {
       !contains(keys(p), "templates") || alltrue([for raw in split(",", lookup(p, "templates", "")) : trimspace(raw) != ""])
     ])
     error_message = "Each workspace NodePool templates key, when set, must be a comma-separated list of non-empty workspace_templates config names."
+  }
+
+  validation {
+    # The routing pool's nodes carry this label/taint value; a workspace pool
+    # sharing it would let workspace pods onto the always-on routing nodes.
+    # Resolved role, not the raw key: an accelerator entry without an explicit
+    # role takes its pool name as the role.
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      (contains(keys(p), "role") ? p["role"] : (lookup(p, "accelerator", "") != "" ? lookup(p, "name", "") : "workspaces")) != "routing"
+    ])
+    error_message = "\"routing\" is reserved for the routing pool: no workspace pool may use it as its role, and an accelerator entry named \"routing\" must set an explicit role."
   }
 
   validation {

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -340,6 +340,15 @@ variable "workspace_nodepools" {
     ])
     error_message = "Each workspace NodePool templates key, when set, must be a comma-separated list of non-empty workspace_templates config names."
   }
+
+  validation {
+    # A shared role would let plain CPU workspaces schedule onto GPU nodes.
+    condition = length(setintersection(
+      toset([for p in var.workspace_nodepools : lookup(p, "role", p["name"]) if lookup(p, "accelerator", "") != ""]),
+      toset([for p in var.workspace_nodepools : lookup(p, "role", "workspaces") if lookup(p, "accelerator", "") == ""]),
+    )) == 0
+    error_message = "An accelerator entry must not share a role with a non-accelerator entry (\"workspaces\" is the non-accelerator default)."
+  }
 }
 
 variable "workspace_templates" {

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -257,10 +257,18 @@ variable "workspace_nodepools" {
       max_cpu           - fleet CPU ceiling (e.g. "512")
       max_memory        - fleet memory ceiling (e.g. "2048Gi")
 
-    Example (add a GPU pool by appending an entry):
+    Optional keys per entry (all strings):
+      role     - node label/taint value; only workspace templates tolerating this
+                 role schedule onto the pool (defaults to "workspaces")
+      max_gpus - fleet GPU ceiling, the NodePool limit for nvidia.com/gpu (e.g. "4")
+      gpu      - "true" to add the nvidia.com/gpu.present node label the NVIDIA
+                 device plugin selects on
+
+    Example (a customized GPU pool; enable_gpu_pool = true with no workspace-gpu
+    entry provides this shape built in):
       workspace_nodepools = [
         { name = "workspace-cpu", instance_families = "c6i,m6i,r6i", disk_size_gb = "50", max_cpu = "512", max_memory = "2048Gi" },
-        { name = "workspace-gpu", instance_families = "g4dn,g5", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi" },
+        { name = "workspace-gpu", instance_families = "g4dn,g5", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi", max_gpus = "4", role = "workspaces-gpu", gpu = "true" },
       ]
   EOT
   type        = list(map(string))
@@ -279,6 +287,50 @@ variable "workspace_nodepools" {
     ])
     error_message = "Each workspace NodePool disk_size_gb must be a numeric string between 20 and 16384."
   }
+
+  validation {
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      !contains(keys(p), "max_gpus") || can(tonumber(p["max_gpus"]))
+    ])
+    error_message = "Each workspace NodePool max_gpus, when set, must be a numeric string."
+  }
+
+  validation {
+    # "true" only: any non-empty string is truthy in the chart's {{ if .gpu }}.
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      !contains(keys(p), "gpu") || p["gpu"] == "true"
+    ])
+    error_message = "Each workspace NodePool gpu key, when set, must be the string \"true\" (omit the key otherwise)."
+  }
+
+  validation {
+    # Rendered as a node label value and taint value, which Kubernetes bounds.
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      !contains(keys(p), "role") || can(regex("^[a-zA-Z0-9]([-a-zA-Z0-9_.]{0,61}[a-zA-Z0-9])?$", p["role"]))
+    ])
+    error_message = "Each workspace NodePool role, when set, must be a valid Kubernetes label value (alphanumeric plus -_., max 63 chars)."
+  }
+}
+
+variable "enable_gpu_pool" {
+  description = <<-EOT
+    Whether to provision GPU workspace capacity.
+
+    When true, the template adds a built-in workspace-gpu Karpenter pool
+    (define your own workspace-gpu entry in workspace_nodepools to customize
+    it), installs the NVIDIA device plugin, and ships the jupyterlab-gpu
+    workspace template. Delete GPU workspaces before turning this off:
+    disabling removes the pool and the template they depend on.
+
+    First GPU use on an AWS account without prior GPU usage requires raising
+    the "Running On-Demand G and VT instances" service quota (defaults to 0).
+
+    Recommended: false
+  EOT
+  type        = bool
 }
 
 variable "routing_instance_categories" {

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -258,11 +258,16 @@ variable "workspace_nodepools" {
       max_memory        - fleet memory ceiling (e.g. "2048Gi")
 
     Optional keys per entry (all strings):
-      role     - node label/taint value; only workspace templates tolerating this
-                 role schedule onto the pool (defaults to "workspaces")
-      max_gpus - fleet GPU ceiling, the NodePool limit for nvidia.com/gpu (e.g. "4")
-      gpu      - "true" to add the nvidia.com/gpu.present node label the NVIDIA
-                 device plugin selects on; any entry with this key installs the plugin
+      accelerator - device stack the pool provides; "nvidia" is the only supported
+                    value. Installs the NVIDIA device plugin, adds the
+                    nvidia.com/gpu.present node label, and defaults role to the
+                    pool name so accelerator pools are fenced by construction
+      role        - node label/taint value; only workspace templates tolerating this
+                    role schedule onto the pool (defaults to "workspaces", or to the
+                    pool name when accelerator is set)
+      max_gpus    - fleet GPU ceiling, the NodePool limit for nvidia.com/gpu
+                    (e.g. "4"); optional, absent means unbounded (the account's
+                    G/VT service quota is the backstop); requires accelerator
 
     Template keys per entry (all strings; an entry with template_gpus yields one
     WorkspaceTemplate pinned to this pool via its role):
@@ -279,7 +284,7 @@ variable "workspace_nodepools" {
     entry provides this shape built in):
       workspace_nodepools = [
         { name = "workspace-cpu", instance_families = "c6i,m6i,r6i", disk_size_gb = "50", max_cpu = "512", max_memory = "2048Gi" },
-        { name = "workspace-gpu", instance_families = "g4dn,g5", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi", max_gpus = "4", role = "workspaces-gpu", gpu = "true",
+        { name = "workspace-gpu", instance_families = "g4dn,g5", disk_size_gb = "100", max_cpu = "64", max_memory = "256Gi", max_gpus = "4", accelerator = "nvidia",
           template_name = "jupyterlab-gpu", template_gpus = "1", template_cpu = "3500m", template_memory = "13Gi", template_idle_minutes = "30" },
       ]
   EOT
@@ -309,12 +314,20 @@ variable "workspace_nodepools" {
   }
 
   validation {
-    # "true" only: any non-empty string is truthy in the chart's {{ if .gpu }}.
     condition = alltrue([
       for p in var.workspace_nodepools :
-      !contains(keys(p), "gpu") || p["gpu"] == "true"
+      !contains(keys(p), "accelerator") || p["accelerator"] == "nvidia"
     ])
-    error_message = "Each workspace NodePool gpu key, when set, must be the string \"true\" (omit the key otherwise)."
+    error_message = "Each workspace NodePool accelerator, when set, must be \"nvidia\" (the only supported device stack)."
+  }
+
+  validation {
+    # A GPU cap on a pool that provisions no GPUs would never bind.
+    condition = alltrue([
+      for p in var.workspace_nodepools :
+      !contains(keys(p), "max_gpus") || contains(keys(p), "accelerator")
+    ])
+    error_message = "max_gpus is only valid on an entry that also sets accelerator."
   }
 
   validation {
@@ -386,7 +399,8 @@ variable "enable_default_gpu_pool" {
 variable "nvidia_device_plugin_version" {
   description = <<-EOT
     Helm chart version of the NVIDIA device plugin, installed when any
-    workspace_nodepools entry sets gpu = "true" (the built-in GPU pool does).
+    workspace_nodepools entry sets accelerator = "nvidia" (the built-in GPU
+    pool does).
 
     Refer to: https://github.com/NVIDIA/k8s-device-plugin/releases
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -302,9 +302,9 @@ variable "workspace_nodepools" {
   validation {
     condition = alltrue([
       for p in var.workspace_nodepools :
-      !contains(keys(p), "max_gpus") || can(tonumber(p["max_gpus"]))
+      !contains(keys(p), "max_gpus") || can(regex("^[1-9][0-9]*$", p["max_gpus"]))
     ])
-    error_message = "Each workspace NodePool max_gpus, when set, must be a numeric string."
+    error_message = "Each workspace NodePool max_gpus, when set, must be a positive integer string."
   }
 
   validation {
@@ -413,17 +413,17 @@ variable "workspace_templates" {
   validation {
     condition = alltrue([
       for t in var.workspace_templates :
-      !contains(keys(t), "gpus") || can(tonumber(t["gpus"]))
+      !contains(keys(t), "gpus") || can(regex("^[1-9][0-9]*$", t["gpus"]))
     ])
-    error_message = "Each workspace_templates gpus, when set, must be a numeric string."
+    error_message = "Each workspace_templates gpus, when set, must be a positive integer string."
   }
 
   validation {
     condition = alltrue([
       for t in var.workspace_templates :
-      !contains(keys(t), "idle_minutes") || can(tonumber(t["idle_minutes"]))
+      !contains(keys(t), "idle_minutes") || can(regex("^[1-9][0-9]*$", t["idle_minutes"]))
     ])
-    error_message = "Each workspace_templates idle_minutes, when set, must be a numeric string."
+    error_message = "Each workspace_templates idle_minutes, when set, must be a positive integer string."
   }
 
   validation {

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf
@@ -333,6 +333,18 @@ variable "enable_gpu_pool" {
   type        = bool
 }
 
+variable "nvidia_device_plugin_version" {
+  description = <<-EOT
+    Helm chart version of the NVIDIA device plugin, installed only when
+    enable_gpu_pool is true.
+
+    Refer to: https://github.com/NVIDIA/k8s-device-plugin/releases
+
+    Recommended: 0.19.3
+  EOT
+  type        = string
+}
+
 variable "routing_instance_categories" {
   description = <<-EOT
     EC2 instance categories (karpenter.k8s.aws/instance-category) for routing nodes.

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -293,6 +293,12 @@ resource "helm_release" "workspace_defaults" {
       error_message = "no workspace pool serves the built-in jupyterlab template: one non-accelerator workspace_nodepools entry must keep the default \"workspaces\" role."
     }
     precondition {
+      # The default flows into every built-in template; variable validations
+      # cannot reference other variables, so the window check sits here.
+      condition     = var.workspaces_idle_shutdown_timeout_default >= var.workspaces_idle_shutdown_timeout_min && var.workspaces_idle_shutdown_timeout_default <= var.workspaces_idle_shutdown_timeout_max
+      error_message = "workspaces_idle_shutdown_timeout_default (${var.workspaces_idle_shutdown_timeout_default}) must lie within the idle-shutdown window [${var.workspaces_idle_shutdown_timeout_min}, ${var.workspaces_idle_shutdown_timeout_max}]."
+    }
+    precondition {
       # A default outside the template's own override window would reject
       # every workspace from that card at creation time.
       condition = alltrue([

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -85,16 +85,104 @@ resource "helm_release" "github_rbac" {
   depends_on = [kubernetes_namespace_v1.shared, helm_release.workspace_router]
 }
 
+# ── Workspace templates ───────────────────────────────────────────────────────
+# One entry per UI card, rendered by charts/workspace-defaults. The GPU template
+# is fenced to the GPU pool by its nodeSelector/toleration on the pool's role;
+# without that pairing, CPU workspaces could bind GPU nodes or GPU pods could
+# land where no device is advertised.
+locals {
+  jupyterlab_template_values = {
+    name             = "jupyterlab"
+    isDefault        = "true"
+    displayName      = "JupyterLab"
+    description      = "JupyterLab workspace with persistent EBS storage"
+    imageUri         = module.app_jupyterlab[0].image_uri
+    appType          = var.workspace_app_jupyterlab_app_type
+    accessType       = var.workspaces_default_access_type
+    ownershipType    = var.workspaces_default_ownership_type
+    storageClassName = local.workspace_storage_class
+    defaultResources = {
+      requests = { cpu = "500m", memory = "1Gi" }
+      limits   = { cpu = "2", memory = "4Gi" }
+    }
+    resourceBounds = {
+      cpu    = { min = "100m", max = "8" }
+      memory = { min = "256Mi", max = "32Gi" }
+    }
+    nodeSelector = { "jupyter-deploy/role" = "workspaces" }
+    tolerations = [
+      { key = "jupyter-deploy/role", operator = "Equal", value = "workspaces", effect = "NoSchedule" }
+    ]
+    readinessProbe = { port = 8888, initialDelaySeconds = 2, periodSeconds = 3, failureThreshold = 30 }
+    idleShutdown = {
+      enabled           = var.workspaces_idle_shutdown_enabled
+      timeoutMinutes    = var.workspaces_idle_shutdown_timeout_default
+      minTimeoutMinutes = var.workspaces_idle_shutdown_timeout_min
+      maxTimeoutMinutes = var.workspaces_idle_shutdown_timeout_max
+    }
+  }
+
+  jupyterlab_gpu_template_values = {
+    name             = "jupyterlab-gpu"
+    isDefault        = "false"
+    displayName      = "JupyterLab GPU"
+    description      = "JupyterLab workspace with one NVIDIA GPU and persistent EBS storage"
+    imageUri         = module.app_jupyterlab[0].image_uri
+    appType          = var.workspace_app_jupyterlab_app_type
+    accessType       = var.workspaces_default_access_type
+    ownershipType    = var.workspaces_default_ownership_type
+    storageClassName = local.workspace_storage_class
+    # The card is one fixed shape: every size the GPU pool admits carries
+    # exactly one GPU and the workspace owns its node, so cpu/memory choice
+    # would only change which instance Karpenter buys. min == max pins all
+    # axes; cpu/memory target the g4dn.xlarge allocatable (an over-pin is
+    # permanently unschedulable — finalize against a live node, issue #336).
+    defaultResources = {
+      requests = { cpu = "3500m", memory = "13Gi", "nvidia.com/gpu" = "1" }
+      limits   = { cpu = "3500m", memory = "13Gi", "nvidia.com/gpu" = "1" }
+    }
+    resourceBounds = {
+      cpu              = { min = "3500m", max = "3500m" }
+      memory           = { min = "13Gi", max = "13Gi" }
+      "nvidia.com/gpu" = { min = "1", max = "1" }
+    }
+    nodeSelector = { "jupyter-deploy/role" = local.gpu_pool_role }
+    tolerations = [
+      { key = "jupyter-deploy/role", operator = "Equal", value = local.gpu_pool_role, effect = "NoSchedule" }
+    ]
+    readinessProbe = { port = 8888, initialDelaySeconds = 2, periodSeconds = 3, failureThreshold = 30 }
+    idleShutdown = {
+      enabled = var.workspaces_idle_shutdown_enabled
+      # Half the jupyterlab default: an idle hour on the cheapest GPU node
+      # costs $0.53. Users can still adjust within the min/max window.
+      timeoutMinutes    = 30
+      minTimeoutMinutes = var.workspaces_idle_shutdown_timeout_min
+      maxTimeoutMinutes = var.workspaces_idle_shutdown_timeout_max
+    }
+  }
+
+  workspace_templates_values = concat(
+    [local.jupyterlab_template_values],
+    var.enable_gpu_pool ? [local.jupyterlab_gpu_template_values] : [],
+  )
+}
+
 resource "helm_release" "workspace_defaults" {
   name             = "workspace-defaults"
   chart            = "${path.module}/../charts/workspace-defaults"
   namespace        = var.workspace_shared_namespace
   create_namespace = false
-  # Ships the jupyterlab WorkspaceTemplate (operator-finalized). Install waits on
-  # the operator reconciling it. Uninstall is ~seconds now that destroy_workspaces
+  # Ships the WorkspaceTemplates (operator-finalized). Install waits on
+  # the operator reconciling them. Uninstall is ~seconds now that destroy_workspaces
   # clears the CRs first and the addon/node ordering keeps the operator alive, so
   # this 600s (vs 5-min default) is no longer strictly necessary.
   timeout = 600
+
+  values = [
+    yamlencode({
+      workspaceTemplates = local.workspace_templates_values
+    })
+  ]
 
   set = concat([
     {
@@ -104,58 +192,6 @@ resource "helm_release" "workspace_defaults" {
     {
       name  = "accessStrategy.name"
       value = local.access_strategy_name
-    },
-    {
-      name  = "workspaceTemplate.name"
-      value = "jupyterlab"
-    },
-    {
-      name  = "workspaceTemplate.isDefault"
-      value = "true"
-    },
-    {
-      name  = "workspaceTemplate.displayName"
-      value = "JupyterLab"
-    },
-    {
-      name  = "workspaceTemplate.description"
-      value = "JupyterLab workspace with persistent EBS storage"
-    },
-    {
-      name  = "workspaceTemplate.imageUri"
-      value = module.app_jupyterlab[0].image_uri
-    },
-    {
-      name  = "workspaceTemplate.appType"
-      value = var.workspace_app_jupyterlab_app_type
-    },
-    {
-      name  = "workspaceTemplate.accessType"
-      value = var.workspaces_default_access_type
-    },
-    {
-      name  = "workspaceTemplate.ownershipType"
-      value = var.workspaces_default_ownership_type
-    },
-    {
-      name  = "workspaceTemplate.storageClassName"
-      value = local.workspace_storage_class
-    },
-    {
-      name  = "workspaceTemplate.idleShutdown.enabled"
-      value = tostring(var.workspaces_idle_shutdown_enabled)
-    },
-    {
-      name  = "workspaceTemplate.idleShutdown.timeoutMinutes"
-      value = tostring(var.workspaces_idle_shutdown_timeout_default)
-    },
-    {
-      name  = "workspaceTemplate.idleShutdown.minTimeoutMinutes"
-      value = tostring(var.workspaces_idle_shutdown_timeout_min)
-    },
-    {
-      name  = "workspaceTemplate.idleShutdown.maxTimeoutMinutes"
-      value = tostring(var.workspaces_idle_shutdown_timeout_max)
     },
     {
       name  = "networkPolicy.routerNamespace"
@@ -246,6 +282,43 @@ resource "null_resource" "repair_workspace_template" {
       release_namespace = var.workspace_shared_namespace
       cr_kind           = "WorkspaceTemplate"
       cr_name           = "jupyterlab"
+      cr_namespace      = var.workspace_shared_namespace
+    })
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = self.triggers.script
+  }
+
+  depends_on = [helm_release.workspace_defaults, kubernetes_namespace_v1.shared]
+}
+
+data "kubernetes_resource" "jupyterlab_gpu_template" {
+  count = var.enable_gpu_pool ? 1 : 0
+
+  api_version = "workspace.jupyter.org/v1alpha1"
+  kind        = "WorkspaceTemplate"
+  metadata {
+    name      = "jupyterlab-gpu"
+    namespace = var.workspace_shared_namespace
+  }
+
+  depends_on = [helm_release.workspace_defaults, kubernetes_namespace_v1.shared]
+}
+
+resource "null_resource" "repair_workspace_gpu_template" {
+  count = var.enable_gpu_pool ? 1 : 0
+
+  triggers = {
+    present = data.kubernetes_resource.jupyterlab_gpu_template[0].object == null ? "missing" : "present"
+    script = templatefile("${path.module}/local-repair-cr.sh.tftpl", {
+      cluster_name      = local.cluster_name
+      region            = var.region
+      release_name      = "workspace-defaults"
+      release_namespace = var.workspace_shared_namespace
+      cr_kind           = "WorkspaceTemplate"
+      cr_name           = "jupyterlab-gpu"
       cr_namespace      = var.workspace_shared_namespace
     })
   }

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -124,7 +124,10 @@ locals {
     }
   }
 
-  workspace_template_configs = { for t in local.workspace_templates_effective : t["name"] => t }
+  # Grouped (t...) so a name collision between a user config and the built-in
+  # one reaches the uniqueness precondition below instead of crashing this
+  # comprehension with a raw "Duplicate object key" error.
+  workspace_template_configs = { for t in local.workspace_templates_effective : t["name"] => t... }
 
   workspace_template_refs = flatten([
     for p in local.workspace_nodepools_normalized : [
@@ -150,7 +153,7 @@ locals {
   workspace_template_bindings = {
     for name, refs in { for r in local.workspace_template_refs : r.config_name => r... } :
     name => {
-      config      = local.workspace_template_configs[name]
+      config      = local.workspace_template_configs[name][0]
       role        = refs[0].pool_role
       roles       = distinct([for r in refs : r.pool_role])
       pools       = distinct([for r in refs : r.pool_name])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -86,10 +86,12 @@ resource "helm_release" "github_rbac" {
 }
 
 # ── Workspace templates ───────────────────────────────────────────────────────
-# One entry per UI card, rendered by charts/workspace-defaults. The GPU template
-# is fenced to the GPU pool by its nodeSelector/toleration on the pool's role;
-# without that pairing, CPU workspaces could bind GPU nodes or GPU pods could
-# land where no device is advertised.
+# One entry per UI card, rendered by charts/workspace-defaults. The jupyterlab
+# template is the built-in default; one more template derives from each
+# workspace_nodepools entry carrying template keys, fenced to that pool by its
+# nodeSelector/toleration on the pool's role — without that pairing, CPU
+# workspaces could bind GPU nodes or GPU pods could land where no device is
+# advertised.
 locals {
   jupyterlab_template_values = {
     name             = "jupyterlab"
@@ -122,48 +124,47 @@ locals {
     }
   }
 
-  jupyterlab_gpu_template_values = {
-    name             = "jupyterlab-gpu"
-    isDefault        = "false"
-    displayName      = "JupyterLab GPU"
-    description      = "JupyterLab workspace with one NVIDIA GPU and persistent EBS storage"
-    imageUri         = module.app_jupyterlab[0].image_uri
-    appType          = var.workspace_app_jupyterlab_app_type
-    accessType       = var.workspaces_default_access_type
-    ownershipType    = var.workspaces_default_ownership_type
-    storageClassName = local.workspace_storage_class
-    # The card is one fixed shape: every size the GPU pool admits carries
-    # exactly one GPU and the workspace owns its node, so cpu/memory choice
-    # would only change which instance Karpenter buys. min == max pins all
-    # axes; cpu/memory target the g4dn.xlarge allocatable (an over-pin is
-    # permanently unschedulable — finalize against a live node, issue #336).
-    defaultResources = {
-      requests = { cpu = "3500m", memory = "13Gi", "nvidia.com/gpu" = "1" }
-      limits   = { cpu = "3500m", memory = "13Gi", "nvidia.com/gpu" = "1" }
-    }
-    resourceBounds = {
-      cpu              = { min = "3500m", max = "3500m" }
-      memory           = { min = "13Gi", max = "13Gi" }
-      "nvidia.com/gpu" = { min = "1", max = "1" }
-    }
-    nodeSelector = { "jupyter-deploy/role" = local.gpu_pool_role }
-    tolerations = [
-      { key = "jupyter-deploy/role", operator = "Equal", value = local.gpu_pool_role, effect = "NoSchedule" }
-    ]
-    readinessProbe = { port = 8888, initialDelaySeconds = 2, periodSeconds = 3, failureThreshold = 30 }
-    idleShutdown = {
-      enabled = var.workspaces_idle_shutdown_enabled
-      # Half the jupyterlab default: an idle hour on the cheapest GPU node
-      # costs $0.53. Users can still adjust within the min/max window.
-      timeoutMinutes    = 30
-      minTimeoutMinutes = var.workspaces_idle_shutdown_timeout_min
-      maxTimeoutMinutes = var.workspaces_idle_shutdown_timeout_max
-    }
-  }
+  # One derived template per pool entry with template keys. The card is one
+  # fixed shape (min == max on every axis, values from the entry): every size
+  # a GPU pool admits carries exactly one GPU and the workspace owns its node,
+  # so cpu/memory choice would only change which instance Karpenter buys.
+  workspace_pool_templates = [
+    for p in local.workspace_nodepools_effective : {
+      name             = lookup(p, "template_name", p["name"])
+      isDefault        = "false"
+      displayName      = lookup(p, "template_display_name", lookup(p, "template_name", p["name"]))
+      description      = lookup(p, "template_description", "JupyterLab workspace on the ${p["name"]} pool")
+      imageUri         = module.app_jupyterlab[0].image_uri
+      appType          = var.workspace_app_jupyterlab_app_type
+      accessType       = var.workspaces_default_access_type
+      ownershipType    = var.workspaces_default_ownership_type
+      storageClassName = local.workspace_storage_class
+      defaultResources = {
+        requests = { cpu = p["template_cpu"], memory = p["template_memory"], "nvidia.com/gpu" = p["template_gpus"] }
+        limits   = { cpu = p["template_cpu"], memory = p["template_memory"], "nvidia.com/gpu" = p["template_gpus"] }
+      }
+      resourceBounds = {
+        cpu              = { min = p["template_cpu"], max = p["template_cpu"] }
+        memory           = { min = p["template_memory"], max = p["template_memory"] }
+        "nvidia.com/gpu" = { min = p["template_gpus"], max = p["template_gpus"] }
+      }
+      nodeSelector = { "jupyter-deploy/role" = lookup(p, "role", "workspaces") }
+      tolerations = [
+        { key = "jupyter-deploy/role", operator = "Equal", value = lookup(p, "role", "workspaces"), effect = "NoSchedule" }
+      ]
+      readinessProbe = { port = 8888, initialDelaySeconds = 2, periodSeconds = 3, failureThreshold = 30 }
+      idleShutdown = {
+        enabled           = var.workspaces_idle_shutdown_enabled
+        timeoutMinutes    = tonumber(lookup(p, "template_idle_minutes", var.workspaces_idle_shutdown_timeout_default))
+        minTimeoutMinutes = var.workspaces_idle_shutdown_timeout_min
+        maxTimeoutMinutes = var.workspaces_idle_shutdown_timeout_max
+      }
+    } if contains(keys(p), "template_gpus")
+  ]
 
   workspace_templates_values = concat(
     [local.jupyterlab_template_values],
-    var.enable_gpu_pool ? [local.jupyterlab_gpu_template_values] : [],
+    local.workspace_pool_templates,
   )
 }
 
@@ -294,31 +295,31 @@ resource "null_resource" "repair_workspace_template" {
   depends_on = [helm_release.workspace_defaults, kubernetes_namespace_v1.shared]
 }
 
-data "kubernetes_resource" "jupyterlab_gpu_template" {
-  count = var.enable_gpu_pool ? 1 : 0
+data "kubernetes_resource" "pool_workspace_template" {
+  for_each = toset([for t in local.workspace_pool_templates : t.name])
 
   api_version = "workspace.jupyter.org/v1alpha1"
   kind        = "WorkspaceTemplate"
   metadata {
-    name      = "jupyterlab-gpu"
+    name      = each.key
     namespace = var.workspace_shared_namespace
   }
 
   depends_on = [helm_release.workspace_defaults, kubernetes_namespace_v1.shared]
 }
 
-resource "null_resource" "repair_workspace_gpu_template" {
-  count = var.enable_gpu_pool ? 1 : 0
+resource "null_resource" "repair_pool_workspace_template" {
+  for_each = toset([for t in local.workspace_pool_templates : t.name])
 
   triggers = {
-    present = data.kubernetes_resource.jupyterlab_gpu_template[0].object == null ? "missing" : "present"
+    present = data.kubernetes_resource.pool_workspace_template[each.key].object == null ? "missing" : "present"
     script = templatefile("${path.module}/local-repair-cr.sh.tftpl", {
       cluster_name      = local.cluster_name
       region            = var.region
       release_name      = "workspace-defaults"
       release_namespace = var.workspace_shared_namespace
       cr_kind           = "WorkspaceTemplate"
-      cr_name           = "jupyterlab-gpu"
+      cr_name           = each.key
       cr_namespace      = var.workspace_shared_namespace
     })
   }
@@ -329,4 +330,11 @@ resource "null_resource" "repair_workspace_gpu_template" {
   }
 
   depends_on = [helm_release.workspace_defaults, kubernetes_namespace_v1.shared]
+}
+
+# Deployments created while the GPU repair pair was count-gated hold the old
+# address; without this, the replacement runs the repair provisioner once.
+moved {
+  from = null_resource.repair_workspace_gpu_template[0]
+  to   = null_resource.repair_pool_workspace_template["jupyterlab-gpu"]
 }

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -410,10 +410,3 @@ resource "null_resource" "repair_pool_workspace_template" {
 
   depends_on = [helm_release.workspace_defaults, kubernetes_namespace_v1.shared]
 }
-
-# Deployments created while the GPU repair pair was count-gated hold the old
-# address; without this, the replacement runs the repair provisioner once.
-moved {
-  from = null_resource.repair_workspace_gpu_template[0]
-  to   = null_resource.repair_pool_workspace_template["jupyterlab-gpu"]
-}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -129,9 +129,10 @@ locals {
   workspace_template_refs = flatten([
     for p in local.workspace_nodepools_normalized : [
       for raw in split(",", lookup(p, "templates", "")) : {
-        pool_name   = p["name"]
-        pool_role   = lookup(p, "role", "workspaces")
-        config_name = trimspace(raw)
+        pool_name        = p["name"]
+        pool_role        = lookup(p, "role", "workspaces")
+        pool_accelerated = lookup(p, "accelerator", "") != ""
+        config_name      = trimspace(raw)
       } if trimspace(raw) != ""
     ]
   ])
@@ -149,10 +150,11 @@ locals {
   workspace_template_bindings = {
     for name, refs in { for r in local.workspace_template_refs : r.config_name => r... } :
     name => {
-      config = local.workspace_template_configs[name]
-      role   = refs[0].pool_role
-      roles  = distinct([for r in refs : r.pool_role])
-      pools  = distinct([for r in refs : r.pool_name])
+      config      = local.workspace_template_configs[name]
+      role        = refs[0].pool_role
+      roles       = distinct([for r in refs : r.pool_role])
+      pools       = distinct([for r in refs : r.pool_name])
+      accelerated = alltrue([for r in refs : r.pool_accelerated])
     } if contains(keys(local.workspace_template_configs), name)
   }
 
@@ -267,6 +269,15 @@ resource "helm_release" "workspace_defaults" {
     precondition {
       condition     = alltrue([for name, b in local.workspace_template_bindings : length(b.roles) == 1])
       error_message = "a workspace_templates config referenced from pools with different roles cannot render one WorkspaceTemplate (a template pins one nodeSelector); define one config per role: ${join("; ", [for name, b in local.workspace_template_bindings : format("%s referenced with roles %s", name, join(",", b.roles)) if length(b.roles) > 1])}."
+    }
+    precondition {
+      # A gpus config only schedules where a device is advertised; offered by
+      # a plain pool, every workspace from that card stays Pending forever.
+      condition = alltrue([
+        for name, b in local.workspace_template_bindings :
+        !contains(keys(b.config), "gpus") || b.accelerated
+      ])
+      error_message = "workspace_templates configs with gpus must be offered only by accelerator pools: ${join(", ", [for name, b in local.workspace_template_bindings : name if contains(keys(b.config), "gpus") && !b.accelerated])}."
     }
     precondition {
       # A default outside the template's own override window would reject

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -283,6 +283,16 @@ resource "helm_release" "workspace_defaults" {
       error_message = "workspace_templates configs with gpus must be offered only by accelerator pools: ${join(", ", [for name, b in local.workspace_template_bindings : name if contains(keys(b.config), "gpus") && !b.accelerated])}."
     }
     precondition {
+      # The always-rendered jupyterlab template pins the "workspaces" role;
+      # with no pool carrying it, every workspace from the default card stays
+      # Pending forever.
+      condition = anytrue([
+        for p in local.workspace_nodepools_normalized :
+        lookup(p, "accelerator", "") == "" && lookup(p, "role", "workspaces") == "workspaces"
+      ])
+      error_message = "no workspace pool serves the built-in jupyterlab template: one non-accelerator workspace_nodepools entry must keep the default \"workspaces\" role."
+    }
+    precondition {
       # A default outside the template's own override window would reject
       # every workspace from that card at creation time.
       condition = alltrue([

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -87,11 +87,11 @@ resource "helm_release" "github_rbac" {
 
 # ── Workspace templates ───────────────────────────────────────────────────────
 # One entry per UI card, rendered by charts/workspace-defaults. The jupyterlab
-# template is the built-in default; one more template derives from each
-# workspace_nodepools entry carrying template keys, fenced to that pool by its
-# nodeSelector/toleration on the pool's role — without that pairing, CPU
-# workspaces could bind GPU nodes or GPU pods could land where no device is
-# advertised.
+# template is the built-in default; the rest come from workspace_templates
+# configs bound to pools through each entry's `templates` key. The entry
+# supplies placement (nodeSelector/toleration on its role), the config supplies
+# shape, idle policy, and card copy; without that pairing, CPU workspaces could
+# bind GPU nodes or GPU pods could land where no device is advertised.
 locals {
   jupyterlab_template_values = {
     name             = "jupyterlab"
@@ -124,47 +124,90 @@ locals {
     }
   }
 
-  # One derived template per pool entry with template keys. The card is one
-  # fixed shape (min == max on every axis, values from the entry): every size
-  # a GPU pool admits carries exactly one GPU and the workspace owns its node,
-  # so cpu/memory choice would only change which instance Karpenter buys.
-  workspace_pool_templates = [
-    for p in local.workspace_nodepools_normalized : {
-      name             = lookup(p, "template_name", p["name"])
+  workspace_template_configs = { for t in local.workspace_templates_effective : t["name"] => t }
+
+  workspace_template_refs = flatten([
+    for p in local.workspace_nodepools_normalized : [
+      for raw in split(",", lookup(p, "templates", "")) : {
+        pool_name   = p["name"]
+        pool_role   = lookup(p, "role", "workspaces")
+        config_name = trimspace(raw)
+      } if trimspace(raw) != ""
+    ]
+  ])
+
+  workspace_template_dangling = [
+    for r in local.workspace_template_refs : r.config_name
+    if !contains(keys(local.workspace_template_configs), r.config_name)
+  ]
+
+  # One rendered WorkspaceTemplate per referenced config, named by the config.
+  # Multi-reference collapses to one template when every referencing pool
+  # shares a role; differing roles hard-error via the precondition below, and
+  # dangling names are filtered here so evaluation reaches that precondition
+  # instead of crashing on a bad map index.
+  workspace_template_bindings = {
+    for name, refs in { for r in local.workspace_template_refs : r.config_name => r... } :
+    name => {
+      config = local.workspace_template_configs[name]
+      role   = refs[0].pool_role
+      roles  = distinct([for r in refs : r.pool_role])
+      pools  = distinct([for r in refs : r.pool_name])
+    } if contains(keys(local.workspace_template_configs), name)
+  }
+
+  # A config with a cpu pin renders a fixed shape (min == max on every axis:
+  # a GPU workspace owns its node, so cpu/memory choice would only change
+  # which instance Karpenter buys). A config without one inherits the base
+  # jupyterlab shape through the shared local, so the two cannot drift.
+  workspace_pool_templates = {
+    for name, b in local.workspace_template_bindings : name => {
+      name             = name
       isDefault        = "false"
-      displayName      = lookup(p, "template_display_name", lookup(p, "template_name", p["name"]))
-      description      = lookup(p, "template_description", "JupyterLab workspace on the ${p["name"]} pool")
+      displayName      = lookup(b.config, "display_name", name)
+      description      = lookup(b.config, "description", "JupyterLab workspace on the ${b.pools[0]} pool")
       imageUri         = module.app_jupyterlab[0].image_uri
       appType          = var.workspace_app_jupyterlab_app_type
       accessType       = var.workspaces_default_access_type
       ownershipType    = var.workspaces_default_ownership_type
       storageClassName = local.workspace_storage_class
-      defaultResources = {
-        requests = { cpu = p["template_cpu"], memory = p["template_memory"], "nvidia.com/gpu" = p["template_gpus"] }
-        limits   = { cpu = p["template_cpu"], memory = p["template_memory"], "nvidia.com/gpu" = p["template_gpus"] }
-      }
-      resourceBounds = {
-        cpu              = { min = p["template_cpu"], max = p["template_cpu"] }
-        memory           = { min = p["template_memory"], max = p["template_memory"] }
-        "nvidia.com/gpu" = { min = p["template_gpus"], max = p["template_gpus"] }
-      }
-      nodeSelector = { "jupyter-deploy/role" = lookup(p, "role", "workspaces") }
+      defaultResources = contains(keys(b.config), "cpu") ? {
+        requests = merge(
+          { cpu = b.config["cpu"], memory = b.config["memory"] },
+          contains(keys(b.config), "gpus") ? { "nvidia.com/gpu" = b.config["gpus"] } : {},
+        )
+        limits = merge(
+          { cpu = b.config["cpu"], memory = b.config["memory"] },
+          contains(keys(b.config), "gpus") ? { "nvidia.com/gpu" = b.config["gpus"] } : {},
+        )
+      } : local.jupyterlab_template_values.defaultResources
+      resourceBounds = contains(keys(b.config), "cpu") ? merge(
+        {
+          cpu    = { min = b.config["cpu"], max = b.config["cpu"] }
+          memory = { min = b.config["memory"], max = b.config["memory"] }
+        },
+        contains(keys(b.config), "gpus") ? { "nvidia.com/gpu" = { min = b.config["gpus"], max = b.config["gpus"] } } : {},
+      ) : local.jupyterlab_template_values.resourceBounds
+      nodeSelector = { "jupyter-deploy/role" = b.role }
       tolerations = [
-        { key = "jupyter-deploy/role", operator = "Equal", value = lookup(p, "role", "workspaces"), effect = "NoSchedule" }
+        { key = "jupyter-deploy/role", operator = "Equal", value = b.role, effect = "NoSchedule" }
       ]
       readinessProbe = { port = 8888, initialDelaySeconds = 2, periodSeconds = 3, failureThreshold = 30 }
       idleShutdown = {
         enabled           = var.workspaces_idle_shutdown_enabled
-        timeoutMinutes    = tonumber(lookup(p, "template_idle_minutes", var.workspaces_idle_shutdown_timeout_default))
+        timeoutMinutes    = tonumber(lookup(b.config, "idle_minutes", var.workspaces_idle_shutdown_timeout_default))
         minTimeoutMinutes = var.workspaces_idle_shutdown_timeout_min
         maxTimeoutMinutes = var.workspaces_idle_shutdown_timeout_max
       }
-    } if contains(keys(p), "template_gpus")
-  ]
+    }
+  }
 
+  # Deterministic order; flag-on renders [jupyterlab, jupyterlab-gpu] exactly
+  # as before, keeping the injected helm values identical for existing GPU
+  # deployments.
   workspace_templates_values = concat(
     [local.jupyterlab_template_values],
-    local.workspace_pool_templates,
+    [for name in sort(keys(local.workspace_pool_templates)) : local.workspace_pool_templates[name]],
   )
 }
 
@@ -211,6 +254,21 @@ resource "helm_release" "workspace_defaults" {
       }
     ],
   )
+
+  lifecycle {
+    precondition {
+      condition     = length(local.workspace_template_dangling) == 0
+      error_message = "workspace_nodepools templates reference configs missing from workspace_templates: ${join(", ", distinct(local.workspace_template_dangling))}."
+    }
+    precondition {
+      condition     = length(distinct([for t in local.workspace_templates_effective : t["name"]])) == length(local.workspace_templates_effective)
+      error_message = "workspace_templates names must be unique, including the built-in \"jupyterlab-gpu\" config injected by enable_default_gpu_pool."
+    }
+    precondition {
+      condition     = alltrue([for name, b in local.workspace_template_bindings : length(b.roles) == 1])
+      error_message = "a workspace_templates config referenced from pools with different roles cannot render one WorkspaceTemplate (a template pins one nodeSelector); define one config per role: ${join("; ", [for name, b in local.workspace_template_bindings : format("%s referenced with roles %s", name, join(",", b.roles)) if length(b.roles) > 1])}."
+    }
+  }
 
   depends_on = [kubernetes_namespace_v1.shared, helm_release.workspace_router, helm_release.jupyter_k8s]
 }
@@ -296,7 +354,7 @@ resource "null_resource" "repair_workspace_template" {
 }
 
 data "kubernetes_resource" "pool_workspace_template" {
-  for_each = toset([for t in local.workspace_pool_templates : t.name])
+  for_each = toset(keys(local.workspace_pool_templates))
 
   api_version = "workspace.jupyter.org/v1alpha1"
   kind        = "WorkspaceTemplate"
@@ -309,7 +367,7 @@ data "kubernetes_resource" "pool_workspace_template" {
 }
 
 resource "null_resource" "repair_pool_workspace_template" {
-  for_each = toset([for t in local.workspace_pool_templates : t.name])
+  for_each = toset(keys(local.workspace_pool_templates))
 
   triggers = {
     present = data.kubernetes_resource.pool_workspace_template[each.key].object == null ? "missing" : "present"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -129,7 +129,7 @@ locals {
   # a GPU pool admits carries exactly one GPU and the workspace owns its node,
   # so cpu/memory choice would only change which instance Karpenter buys.
   workspace_pool_templates = [
-    for p in local.workspace_nodepools_effective : {
+    for p in local.workspace_nodepools_normalized : {
       name             = lookup(p, "template_name", p["name"])
       isDefault        = "false"
       displayName      = lookup(p, "template_display_name", lookup(p, "template_name", p["name"]))

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/workspaces.tf
@@ -268,6 +268,16 @@ resource "helm_release" "workspace_defaults" {
       condition     = alltrue([for name, b in local.workspace_template_bindings : length(b.roles) == 1])
       error_message = "a workspace_templates config referenced from pools with different roles cannot render one WorkspaceTemplate (a template pins one nodeSelector); define one config per role: ${join("; ", [for name, b in local.workspace_template_bindings : format("%s referenced with roles %s", name, join(",", b.roles)) if length(b.roles) > 1])}."
     }
+    precondition {
+      # A default outside the template's own override window would reject
+      # every workspace from that card at creation time.
+      condition = alltrue([
+        for t in local.workspace_templates_effective :
+        tonumber(lookup(t, "idle_minutes", var.workspaces_idle_shutdown_timeout_default)) >= var.workspaces_idle_shutdown_timeout_min &&
+        tonumber(lookup(t, "idle_minutes", var.workspaces_idle_shutdown_timeout_default)) <= var.workspaces_idle_shutdown_timeout_max
+      ])
+      error_message = "workspace_templates idle_minutes must lie within the idle-shutdown window [${var.workspaces_idle_shutdown_timeout_min}, ${var.workspaces_idle_shutdown_timeout_max}]."
+    }
   }
 
   depends_on = [kubernetes_namespace_v1.shared, helm_release.workspace_router, helm_release.jupyter_k8s]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -1098,16 +1098,6 @@ components:
         method: k8s.apps.get-daemonset-status
       show:
         method: k8s.apps.get-daemonset
-  nvidia-device-plugin:
-    type: DaemonSet
-    description: Registers nvidia.com/gpu capacity on GPU pool nodes
-    resource-name: nvidia-device-plugin
-    scope: kube_system_namespace
-    verbs:
-      status:
-        method: k8s.apps.get-daemonset-status
-      show:
-        method: k8s.apps.get-daemonset
   cluster-autoscaler:
     type: Deployment
     description: Scales managed node groups on pending pods
@@ -1180,25 +1170,6 @@ components:
     description: Default workspace template
     scope: workspace_shared_namespace
     resource-name: jupyterlab
-    crd-group: workspace.jupyter.org
-    crd-version: v1alpha1
-    crd-plural: workspacetemplates
-    details:
-      path: .metadata.namespace
-    sub-component:
-      label: access-strategy
-      path: .spec.defaultAccessStrategy.name
-    verbs:
-      status:
-        method: k8s.custom.get
-      show:
-        method: k8s.custom.get
-  jupyterlab-gpu-template:
-    type: CustomResourceWithoutStatus
-    type-display: WorkspaceTemplate
-    description: GPU workspace template (built-in GPU pool entry)
-    scope: workspace_shared_namespace
-    resource-name: jupyterlab-gpu
     crd-group: workspace.jupyter.org
     crd-version: v1alpha1
     crd-plural: workspacetemplates
@@ -1335,18 +1306,6 @@ components:
     type: HelmRelease
     description: Fluent Bit log-shipping chart (component logging)
     resource-name: fluent-bit
-    scope: kube_system_namespace
-    verbs:
-      status:
-        method: helm.status
-      show:
-        method: helm.show
-      reconcile:
-        method: helm.reconcile
-  nvidia-device-plugin-chart:
-    type: HelmRelease
-    description: NVIDIA device plugin chart (GPU workspaces)
-    resource-name: nvidia-device-plugin
     scope: kube_system_namespace
     verbs:
       status:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -1098,6 +1098,16 @@ components:
         method: k8s.apps.get-daemonset-status
       show:
         method: k8s.apps.get-daemonset
+  nvidia-device-plugin:
+    type: DaemonSet
+    description: Registers nvidia.com/gpu capacity on GPU pool nodes
+    resource-name: nvidia-device-plugin
+    scope: kube_system_namespace
+    verbs:
+      status:
+        method: k8s.apps.get-daemonset-status
+      show:
+        method: k8s.apps.get-daemonset
   cluster-autoscaler:
     type: Deployment
     description: Scales managed node groups on pending pods
@@ -1306,6 +1316,18 @@ components:
     type: HelmRelease
     description: Fluent Bit log-shipping chart (component logging)
     resource-name: fluent-bit
+    scope: kube_system_namespace
+    verbs:
+      status:
+        method: helm.status
+      show:
+        method: helm.show
+      reconcile:
+        method: helm.reconcile
+  nvidia-device-plugin-chart:
+    type: HelmRelease
+    description: NVIDIA device plugin chart (GPU workspaces)
+    resource-name: nvidia-device-plugin
     scope: kube_system_namespace
     verbs:
       status:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -1193,6 +1193,25 @@ components:
         method: k8s.custom.get
       show:
         method: k8s.custom.get
+  jupyterlab-gpu-template:
+    type: CustomResourceWithoutStatus
+    type-display: WorkspaceTemplate
+    description: GPU workspace template (enable_gpu_pool)
+    scope: workspace_shared_namespace
+    resource-name: jupyterlab-gpu
+    crd-group: workspace.jupyter.org
+    crd-version: v1alpha1
+    crd-plural: workspacetemplates
+    details:
+      path: .metadata.namespace
+    sub-component:
+      label: access-strategy
+      path: .spec.defaultAccessStrategy.name
+    verbs:
+      status:
+        method: k8s.custom.get
+      show:
+        method: k8s.custom.get
   traefik:
     type: Deployment
     description: Ingress controller and reverse proxy

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/manifest.yaml
@@ -1196,7 +1196,7 @@ components:
   jupyterlab-gpu-template:
     type: CustomResourceWithoutStatus
     type-display: WorkspaceTemplate
-    description: GPU workspace template (enable_gpu_pool)
+    description: GPU workspace template (built-in GPU pool entry)
     scope: workspace_shared_namespace
     resource-name: jupyterlab-gpu
     crd-group: workspace.jupyter.org

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
@@ -69,3 +69,4 @@ overrides:
   #     max_cpu: "512"
   #     max_memory: 2048Gi
   # enable_gpu_pool: false
+  # nvidia_device_plugin_version: "0.19.3"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
@@ -68,5 +68,5 @@ overrides:
   #     disk_size_gb: "50"
   #     max_cpu: "512"
   #     max_memory: 2048Gi
-  # enable_gpu_pool: false
+  # enable_default_gpu_pool: false
   # nvidia_device_plugin_version: "0.19.3"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
@@ -68,5 +68,6 @@ overrides:
   #     disk_size_gb: "50"
   #     max_cpu: "512"
   #     max_memory: 2048Gi
+  # workspace_templates: []
   # enable_default_gpu_pool: false
   # nvidia_device_plugin_version: "0.19.3"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/variables.yaml
@@ -68,3 +68,4 @@ overrides:
   #     disk_size_gb: "50"
   #     max_cpu: "512"
   #     max_memory: 2048Gi
+  # enable_gpu_pool: false

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/base.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/base.yaml
@@ -9,7 +9,7 @@ required_sensitive:
   oauth_app_client_secret: "${JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET}"
 overrides:
   admin_role_names: ${JD_E2E_VAR_ADMIN_ROLE_NAMES}
-  enable_gpu_pool: ${JD_E2E_VAR_ENABLE_GPU_POOL}
+  enable_default_gpu_pool: ${JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL}
   # NOTE: the idle-timeout floor is intentionally left at its production default
   # (15). test_workspace_idleshutdown needs a 1-minute timeout, but it lowers the
   # floor at runtime via the relaxed_idle_floor fixture (which reverts on teardown)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/base.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/base.yaml
@@ -9,6 +9,7 @@ required_sensitive:
   oauth_app_client_secret: "${JD_E2E_VAR_OAUTH_APP_CLIENT_SECRET}"
 overrides:
   admin_role_names: ${JD_E2E_VAR_ADMIN_ROLE_NAMES}
+  enable_gpu_pool: ${JD_E2E_VAR_ENABLE_GPU_POOL}
   # NOTE: the idle-timeout floor is intentionally left at its production default
   # (15). test_workspace_idleshutdown needs a 1-minute timeout, but it lowers the
   # floor at runtime via the relaxed_idle_floor fixture (which reverts on teardown)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/env.example
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/env.example
@@ -54,3 +54,9 @@ JD_E2E_ORG=
 JD_E2E_TEAM=
 # [user] GitHub team for workspace RBAC (RoleBinding in github-rbac chart)
 JD_E2E_RBAC_TEAM=
+
+# --- GPU TESTS ---
+# [user] Whether the deployment provisions the GPU pool (rendered into variables.yaml)
+JD_E2E_VAR_ENABLE_GPU_POOL=false
+# [user] Set to 1 to run GPU e2e tests against a GPU-enabled deployment
+JD_E2E_GPU_ENABLED=

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/env.example
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/env.example
@@ -58,5 +58,6 @@ JD_E2E_RBAC_TEAM=
 # --- GPU TESTS ---
 # [user] Whether the deployment provisions the GPU pool (rendered into variables.yaml)
 JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL=false
-# [user] Set to 1 to run GPU e2e tests against a GPU-enabled deployment
+# [user] Set to 1 to run GPU e2e tests against a GPU-enabled deployment.
+# Leave EMPTY to skip: any non-empty value (including 0) enables them.
 JD_E2E_GPU_ENABLED=

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/env.example
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/configurations/env.example
@@ -57,6 +57,6 @@ JD_E2E_RBAC_TEAM=
 
 # --- GPU TESTS ---
 # [user] Whether the deployment provisions the GPU pool (rendered into variables.yaml)
-JD_E2E_VAR_ENABLE_GPU_POOL=false
+JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL=false
 # [user] Set to 1 to run GPU e2e tests against a GPU-enabled deployment
 JD_E2E_GPU_ENABLED=

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/notebooks/gpu_check.ipynb
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/notebooks/gpu_check.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nvidia-smi",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!nvidia-smi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "install-torch",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install PyTorch into the workspace's uv project (the kernel's venv)\n",
+    "!uv add torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "import-torch",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "check-gpu",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not torch.cuda.is_available():\n",
+    "    raise RuntimeError(\"GPU not available\")\n",
+    "print(f\"GPU available: {torch.cuda.get_device_name(0)}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from pytest_jupyter_deploy.cli import JDCliError
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 
 
 def _get_manifest_components(e2e_deployment: EndToEndDeployment) -> dict:
@@ -240,6 +241,28 @@ def test_daemonset_component_status_ready(e2e_deployment: EndToEndDeployment) ->
     # Core add-on DaemonSets are always present; fluent-bit only when logging is enabled.
     for name in ("aws-node", "kube-proxy"):
         _poll_component_status(e2e_deployment, name, "Ready")
+
+
+@skip_if_testvars_not_set(["JD_E2E_GPU_ENABLED"])
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_nvidia_device_plugin_components_when_gpu_enabled(e2e_deployment: EndToEndDeployment) -> None:
+    """The device-plugin DaemonSet and chart components resolve when the GPU pool is enabled."""
+    e2e_deployment.ensure_deployed()
+
+    daemonset_names = _get_daemonset_names(e2e_deployment)
+    assert "nvidia-device-plugin" in daemonset_names, (
+        f"Expected nvidia-device-plugin DaemonSet component, got: {daemonset_names}"
+    )
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", "nvidia-device-plugin"])
+    assert result.stdout.strip(), "Expected non-empty output for nvidia-device-plugin show"
+
+    # No Ready assertion on the DaemonSet: with the GPU pool scaled to zero it has
+    # desiredNumberScheduled == 0, which jd health currently reads as Degraded (#337).
+    result = e2e_deployment.cli.run_command(
+        ["jupyter-deploy", "component", "status", "--name", "nvidia-device-plugin-chart"]
+    )
+    assert "deployed" in result.stdout.lower(), f"Expected deployed chart status, got:\n{result.stdout}"
 
 
 @pytest.mark.usefixtures("kubernetes_cluster_login")

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
@@ -255,11 +255,13 @@ def test_nvidia_device_plugin_daemonset_when_gpu_enabled(e2e_deployment: EndToEn
     """
     e2e_deployment.ensure_deployed()
 
+    # check=False: with check=True an absent daemonset dies as CalledProcessError
+    # before the assertion below can surface stdout/stderr in the test report.
     result = subprocess.run(
         ["kubectl", "get", "daemonset", "nvidia-device-plugin", "-n", "kube-system", "-o", "jsonpath={.metadata.name}"],
         capture_output=True,
         text=True,
-        check=True,
+        check=False,
     )
     assert result.stdout.strip() == "nvidia-device-plugin", (
         f"device plugin daemonset missing: {result.stdout} {result.stderr}"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_components.py
@@ -245,24 +245,25 @@ def test_daemonset_component_status_ready(e2e_deployment: EndToEndDeployment) ->
 
 @skip_if_testvars_not_set(["JD_E2E_GPU_ENABLED"])
 @pytest.mark.usefixtures("kubernetes_cluster_login")
-def test_nvidia_device_plugin_components_when_gpu_enabled(e2e_deployment: EndToEndDeployment) -> None:
-    """The device-plugin DaemonSet and chart components resolve when the GPU pool is enabled."""
+def test_nvidia_device_plugin_daemonset_when_gpu_enabled(e2e_deployment: EndToEndDeployment) -> None:
+    """The device-plugin DaemonSet exists when a GPU pool is configured.
+
+    Checked via kubectl rather than jd component: the GPU pieces are
+    deliberately absent from the manifest (components have no conditional
+    mechanism, and a declared-but-absent component reads as degraded on
+    non-GPU deployments).
+    """
     e2e_deployment.ensure_deployed()
 
-    daemonset_names = _get_daemonset_names(e2e_deployment)
-    assert "nvidia-device-plugin" in daemonset_names, (
-        f"Expected nvidia-device-plugin DaemonSet component, got: {daemonset_names}"
+    result = subprocess.run(
+        ["kubectl", "get", "daemonset", "nvidia-device-plugin", "-n", "kube-system", "-o", "jsonpath={.metadata.name}"],
+        capture_output=True,
+        text=True,
+        check=True,
     )
-
-    result = e2e_deployment.cli.run_command(["jupyter-deploy", "component", "show", "--name", "nvidia-device-plugin"])
-    assert result.stdout.strip(), "Expected non-empty output for nvidia-device-plugin show"
-
-    # No Ready assertion on the DaemonSet: with the GPU pool scaled to zero it has
-    # desiredNumberScheduled == 0, which jd health currently reads as Degraded (#337).
-    result = e2e_deployment.cli.run_command(
-        ["jupyter-deploy", "component", "status", "--name", "nvidia-device-plugin-chart"]
+    assert result.stdout.strip() == "nvidia-device-plugin", (
+        f"device plugin daemonset missing: {result.stdout} {result.stderr}"
     )
-    assert "deployed" in result.stdout.lower(), f"Expected deployed chart status, got:\n{result.stdout}"
 
 
 @pytest.mark.usefixtures("kubernetes_cluster_login")

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_pool.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_pool.py
@@ -24,6 +24,7 @@ import json
 import pytest
 from pytest_jupyter_deploy.cli import JDCliError
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 
 # One pool of each underlying kind (swap here if the template's default pools change).
 MNG_POOL = "platform"  # EKS managed node group (AWS EKS API)
@@ -50,6 +51,16 @@ def test_pool_list_includes_managed_and_karpenter_pools(e2e_deployment: EndToEnd
 
     for name in EXPECTED_POOLS:
         assert name in output, f"Expected pool '{name}' in pool list output:\n{output}"
+
+
+@skip_if_testvars_not_set(["JD_E2E_GPU_ENABLED"])
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_pool_list_includes_gpu_pool_when_enabled(e2e_deployment: EndToEndDeployment) -> None:
+    """enable_gpu_pool adds the synthesized workspace-gpu NodePool to jd pool list."""
+    e2e_deployment.ensure_deployed()
+
+    result = e2e_deployment.cli.run_command(["jupyter-deploy", "pool", "list"])
+    assert "workspace-gpu" in result.stdout, f"Expected pool 'workspace-gpu' in pool list output:\n{result.stdout}"
 
 
 @pytest.mark.usefixtures("kubernetes_cluster_login")

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_pool.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_pool.py
@@ -56,7 +56,7 @@ def test_pool_list_includes_managed_and_karpenter_pools(e2e_deployment: EndToEnd
 @skip_if_testvars_not_set(["JD_E2E_GPU_ENABLED"])
 @pytest.mark.usefixtures("kubernetes_cluster_login")
 def test_pool_list_includes_gpu_pool_when_enabled(e2e_deployment: EndToEndDeployment) -> None:
-    """enable_gpu_pool adds the synthesized workspace-gpu NodePool to jd pool list."""
+    """enable_default_gpu_pool adds the synthesized workspace-gpu NodePool to jd pool list."""
     e2e_deployment.ensure_deployed()
 
     result = e2e_deployment.cli.run_command(["jupyter-deploy", "pool", "list"])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_gpu.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_gpu.py
@@ -7,6 +7,7 @@ the account); gated on JD_E2E_GPU_ENABLED so every other run skips.
 import subprocess
 import time
 from collections.abc import Callable
+from pathlib import Path
 
 import pytest
 from pytest_jupyter_deploy.deployment import EndToEndDeployment
@@ -14,13 +15,18 @@ from pytest_jupyter_deploy.kubernetes.nodes import (
     get_node_allocatable_gpu_count,
     get_node_names,
 )
+from pytest_jupyter_deploy.notebook import delete_notebook, run_notebook_in_jupyterlab, upload_notebook
+from pytest_jupyter_deploy.oauth2_proxy.dex import DexGitHubOAuth2ProxyApplication
 from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
 from pytest_jupyter_deploy.workspaces.kubectl import (
     kubectl_apply_workspace,
     kubectl_delete_workspace,
+    kubectl_get_workspace_access_url,
 )
 
 from .conftest import WORKSPACES_DIR
+
+NOTEBOOKS_DIR = Path(__file__).parent / "notebooks"
 
 WORKSPACE_NAMESPACE = "default"
 GPU_WORKSPACE = "e2e-gpu-workspace"
@@ -111,6 +117,56 @@ def test_gpu_workspace_provisioning_nvidia_smi_and_scale_to_zero(e2e_deployment:
             ["jupyter-deploy", "server", "exec", "--name", GPU_WORKSPACE, "--", "nvidia-smi"]
         )
         assert "NVIDIA-SMI" in result.stdout, f"nvidia-smi did not see a device:\n{result.stdout}"
+    finally:
+        kubectl_delete_workspace(GPU_WORKSPACE)
+
+    _poll(
+        lambda: _gpu_node_count() == 0,
+        timeout_s=600,
+        msg="gpu NodePool did not scale to zero after workspace deletion",
+    )
+
+
+@skip_if_testvars_not_set(["JD_E2E_GPU_ENABLED", "JD_E2E_USER"])
+@pytest.mark.mutating
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_gpu_workspace_kernel_sees_cuda(
+    e2e_deployment: EndToEndDeployment,
+    dex_oauth_app: DexGitHubOAuth2ProxyApplication,
+) -> None:
+    """The notebook kernel can install torch and use CUDA on a GPU workspace.
+
+    Runs the gpu_check notebook through the JupyterLab UI, mirroring the
+    ec2-base precedent: nvidia-smi, torch installed at test time via uv (the
+    stock image ships no CUDA userland; the CUDA-enabled wheel comes from the
+    torch package itself), then torch.cuda.is_available from the kernel.
+    Targets the built-in g-family pool. No torch cleanup is needed: the
+    workspace and its volume are deleted at the end of the test.
+    """
+    e2e_deployment.ensure_deployed()
+
+    kubectl_apply_workspace(GPU_WORKSPACE, WORKSPACES_DIR)
+    try:
+        # First start provisions a node and pulls the image: minutes, not seconds.
+        e2e_deployment.cli.poll_scoped_server_status(GPU_WORKSPACE, "Running", timeout_s=600)
+        e2e_deployment.cli.wait_for_workspace_pod_exec_ready(GPU_WORKSPACE)
+
+        access_url = kubectl_get_workspace_access_url(GPU_WORKSPACE, WORKSPACE_NAMESPACE)
+        dex_oauth_app.verify_workspace_accessible(access_url)
+
+        notebook_path = NOTEBOOKS_DIR / "gpu_check.ipynb"
+        server_path = upload_notebook(
+            e2e_deployment,
+            notebook_path,
+            "e2e-test/gpu_check.ipynb",
+            name=GPU_WORKSPACE,
+            scope=WORKSPACE_NAMESPACE,
+        )
+
+        # torch pulls ~2.5 GiB of CUDA wheels; long timeout, slow poll.
+        run_notebook_in_jupyterlab(dex_oauth_app.page, server_path, timeout_ms=300000, poll_interval_ms=5000)
+
+        delete_notebook(e2e_deployment, server_path, name=GPU_WORKSPACE, scope=WORKSPACE_NAMESPACE)
     finally:
         kubectl_delete_workspace(GPU_WORKSPACE)
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_gpu.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_gpu.py
@@ -1,0 +1,121 @@
+"""E2E test for the GPU workspace journey on the EKS OIDC template.
+
+Requires a deployment with enable_gpu_pool: true (and G/VT on-demand quota in
+the account); gated on JD_E2E_GPU_ENABLED so every other run skips.
+"""
+
+import subprocess
+import time
+from collections.abc import Callable
+
+import pytest
+from pytest_jupyter_deploy.deployment import EndToEndDeployment
+from pytest_jupyter_deploy.kubernetes.nodes import (
+    get_node_allocatable_gpu_count,
+    get_node_names,
+)
+from pytest_jupyter_deploy.plugin import skip_if_testvars_not_set
+from pytest_jupyter_deploy.workspaces.kubectl import (
+    kubectl_apply_workspace,
+    kubectl_delete_workspace,
+)
+
+from .conftest import WORKSPACES_DIR
+
+WORKSPACE_NAMESPACE = "default"
+GPU_WORKSPACE = "e2e-gpu-workspace"
+GPU_ROLE = "workspaces-gpu"
+GPU_ROLE_SELECTOR = f"jupyter-deploy/role={GPU_ROLE}"
+GPU_NODEPOOL = "workspace-gpu"
+
+
+def _kubectl(*args: str) -> str:
+    result = subprocess.run(["kubectl", *args], capture_output=True, text=True, check=True)
+    return result.stdout.strip()
+
+
+def _poll(condition: "Callable[[], bool]", timeout_s: int, interval_s: int = 5, msg: str = "") -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if condition():
+            return
+        time.sleep(interval_s)
+    raise TimeoutError(f"Condition not met within {timeout_s}s: {msg}")
+
+
+def _gpu_node_count() -> int:
+    return len(get_node_names(GPU_ROLE_SELECTOR))
+
+
+@skip_if_testvars_not_set(["JD_E2E_GPU_ENABLED"])
+@pytest.mark.mutating
+@pytest.mark.usefixtures("kubernetes_cluster_login")
+def test_gpu_workspace_provisioning_nvidia_smi_and_scale_to_zero(e2e_deployment: EndToEndDeployment) -> None:
+    """Full GPU workspace lifecycle: fenced provisioning, a visible device, scale-to-zero.
+
+    1. Create a workspace from the jupyterlab-gpu template
+    2. Karpenter provisions a workspace-gpu node (role label + taint + gpu.present)
+    3. The device plugin advertises nvidia.com/gpu and nvidia-smi sees the device
+    4. Delete → the GPU pool scales back to zero
+    """
+    e2e_deployment.ensure_deployed()
+
+    # Clean up any leftover workspace from a previous test run.
+    try:
+        kubectl_delete_workspace(GPU_WORKSPACE)
+        _poll(
+            lambda: _gpu_node_count() == 0,
+            timeout_s=300,
+            msg="pre-test cleanup: gpu node did not terminate",
+        )
+    except Exception:
+        pass
+
+    kubectl_apply_workspace(GPU_WORKSPACE, WORKSPACES_DIR)
+    try:
+        # First start provisions a node and pulls the image: minutes, not seconds.
+        e2e_deployment.cli.poll_scoped_server_status(GPU_WORKSPACE, "Running", timeout_s=600)
+
+        assert _gpu_node_count() > 0, "Expected at least one gpu node after workspace creation"
+
+        pod_node = _kubectl(
+            "get",
+            "pods",
+            "-n",
+            WORKSPACE_NAMESPACE,
+            "-l",
+            f"workspace.jupyter.org/workspace-name={GPU_WORKSPACE}",
+            "-o",
+            "jsonpath={.items[0].spec.nodeName}",
+        )
+        assert pod_node, f"Could not find pod node for workspace {GPU_WORKSPACE}"
+
+        node_role = _kubectl("get", "node", pod_node, "-o", "jsonpath={.metadata.labels.jupyter-deploy/role}")
+        assert node_role == GPU_ROLE, f"GPU workspace pod landed on node with role '{node_role}', expected '{GPU_ROLE}'"
+
+        nodepool = _kubectl("get", "node", pod_node, "-o", r"jsonpath={.metadata.labels.karpenter\.sh/nodepool}")
+        assert nodepool == GPU_NODEPOOL, f"GPU pod node has nodepool '{nodepool}', expected '{GPU_NODEPOOL}'"
+
+        gpu_present = _kubectl("get", "node", pod_node, "-o", r"jsonpath={.metadata.labels.nvidia\.com/gpu\.present}")
+        assert gpu_present == "true", f"GPU node lacks the nvidia.com/gpu.present label (got '{gpu_present}')"
+
+        taints = _kubectl("get", "node", pod_node, "-o", "jsonpath={.spec.taints}")
+        assert GPU_ROLE in taints, f"GPU node is not tainted with the {GPU_ROLE} role (taints: {taints})"
+
+        assert get_node_allocatable_gpu_count(pod_node) >= 1, (
+            "Device plugin did not register nvidia.com/gpu on the node"
+        )
+
+        e2e_deployment.cli.wait_for_workspace_pod_exec_ready(GPU_WORKSPACE)
+        result = e2e_deployment.cli.run_exec_with_retry(
+            ["jupyter-deploy", "server", "exec", "--name", GPU_WORKSPACE, "--", "nvidia-smi"]
+        )
+        assert "NVIDIA-SMI" in result.stdout, f"nvidia-smi did not see a device:\n{result.stdout}"
+    finally:
+        kubectl_delete_workspace(GPU_WORKSPACE)
+
+    _poll(
+        lambda: _gpu_node_count() == 0,
+        timeout_s=600,
+        msg="gpu NodePool did not scale to zero after workspace deletion",
+    )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_gpu.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/test_workspace_gpu.py
@@ -1,6 +1,6 @@
 """E2E test for the GPU workspace journey on the EKS OIDC template.
 
-Requires a deployment with enable_gpu_pool: true (and G/VT on-demand quota in
+Requires a deployment with enable_default_gpu_pool: true (and G/VT on-demand quota in
 the account); gated on JD_E2E_GPU_ENABLED so every other run skips.
 """
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-gpu-workspace.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/e2e/workspaces/e2e-gpu-workspace.yaml
@@ -1,0 +1,15 @@
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-gpu-workspace
+  namespace: default
+spec:
+  displayName: "E2E GPU Workspace"
+  desiredStatus: Running
+  ownershipType: Public
+  accessType: Public
+  # Templates live in the shared namespace; without the explicit namespace the
+  # ref resolves in the workspace's own namespace and the template is not found.
+  templateRef:
+    name: jupyterlab-gpu
+    namespace: jupyter-k8s-shared

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu.yaml
@@ -144,7 +144,8 @@ spec:
       labels:
         # Default preserves the exact pre-GPU bytes: Karpenter hashes
         # spec.template, so any change here drift-replaces the pool's nodes
-        # and restarts every workspace on them.
+        # and restarts every workspace on them. Set values render quoted: an
+        # unquoted role like "on" would parse as a YAML boolean and fail apply.
         jupyter-deploy/role: workspaces
     spec:
       nodeClassRef:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu.yaml
@@ -1,0 +1,178 @@
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+# EC2NodeClasses define the AWS-level node configuration for Karpenter.
+# One class per pool (routing + each workspace pool).
+# All pools pin httpPutResponseHopLimit: 1 — no routing or workspace pod needs
+# IMDS: cert-manager/external-dns use Pod Identity, and traefik/dex/oauth2-proxy/
+# authmiddleware/web-app make no AWS calls. Hop 1 blocks containerized pods from
+# reaching IMDS to assume the node role; node agents (CNI, EBS CSI) use
+# hostNetwork and reach IMDS at hop 1, so they are unaffected.
+# Both pin httpTokens: required (IMDSv2).
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+# NodePools define scheduling constraints and node lifecycle for Karpenter.
+# Routing pool: always-on, conservative consolidation, small instances.
+# Workspace pools: scale-to-zero, aggressive consolidation, diverse instances.
+# Both carry taints so only pods with matching tolerations can land here.
+#
+# Disruption budget: nodes: "1" (absolute, not percentage).
+# Karpenter applies the MINIMUM of all active budgets. A percentage budget
+# (e.g. 10%) rounds down to 0 on small pools (floor(0.1×1)=0), and
+# min(0,1)=0 — the absolute floor cannot raise a zero from the percentage.
+# Using only the absolute entry guarantees at least 1 node is always
+# disruptable, enabling scale-to-zero on workspace pools.
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: routing
+spec:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  instanceProfile: "test-karpenter-node-profile"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  tags:
+    karpenter.sh/cluster-name: "test-cluster"
+  metadataOptions:
+    httpPutResponseHopLimit: 1
+    httpEndpoint: enabled
+    httpTokens: required
+    httpProtocolIPv6: disabled
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 50Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: workspace-cpu
+spec:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  instanceProfile: "test-karpenter-node-profile"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  tags:
+    karpenter.sh/cluster-name: "test-cluster"
+  metadataOptions:
+    httpPutResponseHopLimit: 1
+    httpEndpoint: enabled
+    httpTokens: required
+    httpProtocolIPv6: disabled
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        # Root volume: OS + container image cache. User data (notebooks, files)
+        # lives on the EBS volume mounted by the workspace pod via StorageClass.
+        # Override disk_size_gb in workspace_nodepools for large custom images.
+        volumeSize: 50Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: routing
+spec:
+  template:
+    metadata:
+      labels:
+        jupyter-deploy/role: routing
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: routing
+      taints:
+        - key: jupyter-deploy/role
+          value: routing
+          effect: NoSchedule
+      expireAfter: 504h
+      requirements:
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c","m"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["6"]
+        - key: karpenter.k8s.aws/instance-size
+          operator: In
+          values: ["large", "xlarge", "2xlarge"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+  limits:
+    cpu: "32"
+    memory: "128Gi"
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 120s
+    budgets:
+      - nodes: "1"
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: workspace-cpu
+spec:
+  template:
+    metadata:
+      labels:
+        jupyter-deploy/role: workspaces
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: workspace-cpu
+      taints:
+        - key: jupyter-deploy/role
+          value: workspaces
+          effect: NoSchedule
+      expireAfter: 504h
+      requirements:
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: ["c6i","m6i","r6i","c7i","m7i","r7i"]
+        - key: karpenter.k8s.aws/instance-cpu
+          operator: In
+          values: ["2", "4", "8", "16", "32"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+  limits:
+    cpu: "512"
+    memory: "2048Gi"
+  disruption:
+    # WhenEmpty (not WhenEmptyOrUnderutilized): workspace pods carry no PDB and
+    # no karpenter.sh/do-not-disrupt annotation, so underutilized-consolidation
+    # would be free to evict a running notebook to bin-pack. Restricting to
+    # WhenEmpty means a node is only reclaimed once idle-shutdown has drained its
+    # last workspace pod — scale-to-zero still works, running notebooks are safe.
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 60s
+    budgets:
+      - nodes: "1"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu.yaml
@@ -14,6 +14,9 @@
 # Routing pool: always-on, conservative consolidation, small instances.
 # Workspace pools: scale-to-zero, aggressive consolidation, diverse instances.
 # Both carry taints so only pods with matching tolerations can land here.
+# A workspace pool may set a per-pool role (label + taint value) so that only
+# workspace templates tolerating that role reach it — this is what keeps CPU
+# workspaces off GPU nodes and GPU workspaces on nodes that advertise a device.
 #
 # Disruption budget: nodes: "1" (absolute, not percentage).
 # Karpenter applies the MINIMUM of all active budgets. A percentage budget
@@ -139,6 +142,9 @@ spec:
   template:
     metadata:
       labels:
+        # Default preserves the exact pre-GPU bytes: Karpenter hashes
+        # spec.template, so any change here drift-replaces the pool's nodes
+        # and restarts every workspace on them.
         jupyter-deploy/role: workspaces
     spec:
       nodeClassRef:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu_gpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu_gpu.yaml
@@ -1,0 +1,272 @@
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+# EC2NodeClasses define the AWS-level node configuration for Karpenter.
+# One class per pool (routing + each workspace pool).
+# All pools pin httpPutResponseHopLimit: 1 — no routing or workspace pod needs
+# IMDS: cert-manager/external-dns use Pod Identity, and traefik/dex/oauth2-proxy/
+# authmiddleware/web-app make no AWS calls. Hop 1 blocks containerized pods from
+# reaching IMDS to assume the node role; node agents (CNI, EBS CSI) use
+# hostNetwork and reach IMDS at hop 1, so they are unaffected.
+# Both pin httpTokens: required (IMDSv2).
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+# NodePools define scheduling constraints and node lifecycle for Karpenter.
+# Routing pool: always-on, conservative consolidation, small instances.
+# Workspace pools: scale-to-zero, aggressive consolidation, diverse instances.
+# Both carry taints so only pods with matching tolerations can land here.
+# A workspace pool may set a per-pool role (label + taint value) so that only
+# workspace templates tolerating that role reach it — this is what keeps CPU
+# workspaces off GPU nodes and GPU workspaces on nodes that advertise a device.
+#
+# Disruption budget: nodes: "1" (absolute, not percentage).
+# Karpenter applies the MINIMUM of all active budgets. A percentage budget
+# (e.g. 10%) rounds down to 0 on small pools (floor(0.1×1)=0), and
+# min(0,1)=0 — the absolute floor cannot raise a zero from the percentage.
+# Using only the absolute entry guarantees at least 1 node is always
+# disruptable, enabling scale-to-zero on workspace pools.
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: routing
+spec:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  instanceProfile: "test-karpenter-node-profile"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  tags:
+    karpenter.sh/cluster-name: "test-cluster"
+  metadataOptions:
+    httpPutResponseHopLimit: 1
+    httpEndpoint: enabled
+    httpTokens: required
+    httpProtocolIPv6: disabled
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 50Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: workspace-cpu
+spec:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  instanceProfile: "test-karpenter-node-profile"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  tags:
+    karpenter.sh/cluster-name: "test-cluster"
+  metadataOptions:
+    httpPutResponseHopLimit: 1
+    httpEndpoint: enabled
+    httpTokens: required
+    httpProtocolIPv6: disabled
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        # Root volume: OS + container image cache. User data (notebooks, files)
+        # lives on the EBS volume mounted by the workspace pod via StorageClass.
+        # Override disk_size_gb in workspace_nodepools for large custom images.
+        volumeSize: 50Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: workspace-gpu
+spec:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  instanceProfile: "test-karpenter-node-profile"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  tags:
+    karpenter.sh/cluster-name: "test-cluster"
+  metadataOptions:
+    httpPutResponseHopLimit: 1
+    httpEndpoint: enabled
+    httpTokens: required
+    httpProtocolIPv6: disabled
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        # Root volume: OS + container image cache. User data (notebooks, files)
+        # lives on the EBS volume mounted by the workspace pod via StorageClass.
+        # Override disk_size_gb in workspace_nodepools for large custom images.
+        volumeSize: 100Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: routing
+spec:
+  template:
+    metadata:
+      labels:
+        jupyter-deploy/role: routing
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: routing
+      taints:
+        - key: jupyter-deploy/role
+          value: routing
+          effect: NoSchedule
+      expireAfter: 504h
+      requirements:
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c","m"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["6"]
+        - key: karpenter.k8s.aws/instance-size
+          operator: In
+          values: ["large", "xlarge", "2xlarge"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+  limits:
+    cpu: "32"
+    memory: "128Gi"
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 120s
+    budgets:
+      - nodes: "1"
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: workspace-cpu
+spec:
+  template:
+    metadata:
+      labels:
+        # Default preserves the exact pre-GPU bytes: Karpenter hashes
+        # spec.template, so any change here drift-replaces the pool's nodes
+        # and restarts every workspace on them. Set values render quoted: an
+        # unquoted role like "on" would parse as a YAML boolean and fail apply.
+        jupyter-deploy/role: workspaces
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: workspace-cpu
+      taints:
+        - key: jupyter-deploy/role
+          value: workspaces
+          effect: NoSchedule
+      expireAfter: 504h
+      requirements:
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: ["c6i","m6i","r6i","c7i","m7i","r7i"]
+        - key: karpenter.k8s.aws/instance-cpu
+          operator: In
+          values: ["2", "4", "8", "16", "32"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+  limits:
+    cpu: "512"
+    memory: "2048Gi"
+  disruption:
+    # WhenEmpty (not WhenEmptyOrUnderutilized): workspace pods carry no PDB and
+    # no karpenter.sh/do-not-disrupt annotation, so underutilized-consolidation
+    # would be free to evict a running notebook to bin-pack. Restricting to
+    # WhenEmpty means a node is only reclaimed once idle-shutdown has drained its
+    # last workspace pod — scale-to-zero still works, running notebooks are safe.
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 60s
+    budgets:
+      - nodes: "1"
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: workspace-gpu
+spec:
+  template:
+    metadata:
+      labels:
+        # Default preserves the exact pre-GPU bytes: Karpenter hashes
+        # spec.template, so any change here drift-replaces the pool's nodes
+        # and restarts every workspace on them. Set values render quoted: an
+        # unquoted role like "on" would parse as a YAML boolean and fail apply.
+        jupyter-deploy/role: "workspaces-gpu"
+        # Satisfies the NVIDIA device plugin's default nodeAffinity without NFD.
+        nvidia.com/gpu.present: "true"
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: workspace-gpu
+      taints:
+        - key: jupyter-deploy/role
+          value: "workspaces-gpu"
+          effect: NoSchedule
+      expireAfter: 504h
+      requirements:
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: ["g4dn","g5","g6","g6e","g7","g7e"]
+        - key: karpenter.k8s.aws/instance-cpu
+          operator: In
+          values: ["2", "4", "8", "16", "32"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+  limits:
+    cpu: "64"
+    memory: "256Gi"
+    nvidia.com/gpu: "4"
+  disruption:
+    # WhenEmpty (not WhenEmptyOrUnderutilized): workspace pods carry no PDB and
+    # no karpenter.sh/do-not-disrupt annotation, so underutilized-consolidation
+    # would be free to evict a running notebook to bin-pack. Restricting to
+    # WhenEmpty means a node is only reclaimed once idle-shutdown has drained its
+    # last workspace pod — scale-to-zero still works, running notebooks are safe.
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 60s
+    budgets:
+      - nodes: "1"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_workspace_defaults_default.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_workspace_defaults_default.yaml
@@ -36,7 +36,7 @@ spec:
 apiVersion: workspace.jupyter.org/v1alpha1
 kind: WorkspaceTemplate
 metadata:
-  name: jupyterlab
+  name: "jupyterlab"
   namespace: jupyter-k8s-shared
   labels:
     workspace.jupyter.org/default-template: "true"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_workspace_defaults_default.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_workspace_defaults_default.yaml
@@ -51,20 +51,20 @@ spec:
     name: oauth-access-strategy
     namespace: jupyter-k8s-shared
   defaultResources:
-    requests:
-      cpu: "500m"
-      memory: "1Gi"
     limits:
       cpu: "2"
-      memory: "4Gi"
+      memory: 4Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
   resourceBounds:
     resources:
       cpu:
-        min: "100m"
         max: "8"
+        min: 100m
       memory:
-        min: "256Mi"
-        max: "32Gi"
+        max: 32Gi
+        min: 256Mi
   primaryStorage:
     defaultSize: "10Gi"
     minSize: "1Gi"
@@ -85,10 +85,10 @@ spec:
   defaultNodeSelector:
     jupyter-deploy/role: workspaces
   defaultTolerations:
-    - key: jupyter-deploy/role
+    - effect: NoSchedule
+      key: jupyter-deploy/role
       operator: Equal
       value: workspaces
-      effect: NoSchedule
   defaultIdleShutdown:
     enabled: true
     idleTimeoutInMinutes: 60

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_workspace_defaults_default.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_workspace_defaults_default.yaml
@@ -41,8 +41,8 @@ metadata:
   labels:
     workspace.jupyter.org/default-template: "true"
 spec:
-  displayName: JupyterLab
-  description: JupyterLab workspace with persistent EBS storage
+  displayName: "JupyterLab"
+  description: "JupyterLab workspace with persistent EBS storage"
   defaultImage: docker.io/test/jupyterlab:latest
   appType: jupyterlab
   defaultAccessType: OwnerOnly

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_workspace_defaults_default.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_workspace_defaults_default.yaml
@@ -1,0 +1,106 @@
+---
+# Source: workspace-defaults/templates/network-policy.yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: workspace-ingress
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: jupyter-deploy
+spec:
+  # Selects every workspace pod in the namespace (label set by the operator).
+  podSelector:
+    matchLabels:
+      workspace.jupyter.org/component: workspace
+  policyTypes:
+    - Ingress
+  ingress:
+    # Traefik router proxying authenticated workspace traffic.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: jupyter-k8s-router
+      ports:
+        - port: 8888
+          protocol: TCP
+    # Operator idle-detection probes (transport: network).
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: jupyter-k8s-system
+      ports:
+        - port: 8888
+          protocol: TCP
+---
+# Source: workspace-defaults/templates/workspace-template.yaml
+apiVersion: workspace.jupyter.org/v1alpha1
+kind: WorkspaceTemplate
+metadata:
+  name: jupyterlab
+  namespace: jupyter-k8s-shared
+  labels:
+    workspace.jupyter.org/default-template: "true"
+spec:
+  displayName: JupyterLab
+  description: JupyterLab workspace with persistent EBS storage
+  defaultImage: docker.io/test/jupyterlab:latest
+  appType: jupyterlab
+  defaultAccessType: OwnerOnly
+  defaultOwnershipType: OwnerOnly
+  defaultAccessStrategy:
+    name: oauth-access-strategy
+    namespace: jupyter-k8s-shared
+  defaultResources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+  resourceBounds:
+    resources:
+      cpu:
+        min: "100m"
+        max: "8"
+      memory:
+        min: "256Mi"
+        max: "32Gi"
+  primaryStorage:
+    defaultSize: "10Gi"
+    minSize: "1Gi"
+    maxSize: "100Gi"
+    defaultStorageClassName: ebs-sc
+    defaultMountPath: "/home/jovyan"
+  # Gate workspace readiness on the app actually accepting connections, so the
+  # operator does not flip status.condition[Available]=True before the server is
+  # up. Complements the access-strategy startupProbe.
+  defaultReadinessProbe:
+    tcpSocket:
+      port: 8888
+    initialDelaySeconds: 2
+    periodSeconds: 3
+    failureThreshold: 30
+  defaultPodSecurityContext:
+    fsGroup: 1000
+  defaultNodeSelector:
+    jupyter-deploy/role: workspaces
+  defaultTolerations:
+    - key: jupyter-deploy/role
+      operator: Equal
+      value: workspaces
+      effect: NoSchedule
+  defaultIdleShutdown:
+    enabled: true
+    idleTimeoutInMinutes: 60
+    detection:
+      httpGet:
+        path: /api/status
+        port: 8888
+        transport: network
+        lastActivityTimestamp:
+          responseBodyPath: last_activity
+          format: RFC3339
+  idleShutdownOverrides:
+    allow: true
+    minIdleTimeoutInMinutes: 15
+    maxIdleTimeoutInMinutes: 480

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu.yaml
@@ -1,0 +1,21 @@
+# Mirrors what platform_karpenter.tf injects for the defaults-all.tfvars preset
+# (dummy cluster/profile names). Keep in sync with the tf `set` entries and the
+# workspaceNodepools transform, or the goldens stop representing a real deploy.
+clusterName: test-cluster
+nodeInstanceProfile: test-karpenter-node-profile
+expireAfter: 504h
+routingLimitsCpu: "32"
+routingLimitsMemory: 128Gi
+routing:
+  instanceCategories: ["c", "m"]
+  instanceGenerationMin: "6"
+  blockDevice:
+    deviceName: /dev/xvda
+    volumeSizeGi: 50
+    volumeType: gp3
+workspaceNodepools:
+  - name: workspace-cpu
+    instanceFamilies: ["c6i", "m6i", "r6i", "c7i", "m7i", "r7i"]
+    diskSizeGi: 50
+    maxCpu: "512"
+    maxMemory: 2048Gi

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu_gpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu_gpu.yaml
@@ -1,4 +1,4 @@
-# The CPU fixture plus the GPU entry exactly as the enable_gpu_pool synthesis
+# The CPU fixture plus the GPU entry exactly as the enable_default_gpu_pool synthesis
 # emits it (gpu_pool_builtin in platform_karpenter.tf) — keep the two in sync.
 clusterName: test-cluster
 nodeInstanceProfile: test-karpenter-node-profile

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu_gpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu_gpu.yaml
@@ -19,7 +19,7 @@ workspaceNodepools:
     maxCpu: "512"
     maxMemory: 2048Gi
   - name: workspace-gpu
-    instanceFamilies: ["g4dn", "g5"]
+    instanceFamilies: ["g4dn", "g5", "g6", "g6e"]
     diskSizeGi: 100
     maxCpu: "64"
     maxMemory: 256Gi

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu_gpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu_gpu.yaml
@@ -19,7 +19,7 @@ workspaceNodepools:
     maxCpu: "512"
     maxMemory: 2048Gi
   - name: workspace-gpu
-    instanceFamilies: ["g4dn", "g5", "g6", "g6e"]
+    instanceFamilies: ["g4dn", "g5", "g6", "g6e", "g7", "g7e"]
     diskSizeGi: 100
     maxCpu: "64"
     maxMemory: 256Gi

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu_gpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_cpu_gpu.yaml
@@ -1,0 +1,28 @@
+# The CPU fixture plus the GPU entry exactly as the enable_gpu_pool synthesis
+# emits it (gpu_pool_builtin in platform_karpenter.tf) — keep the two in sync.
+clusterName: test-cluster
+nodeInstanceProfile: test-karpenter-node-profile
+expireAfter: 504h
+routingLimitsCpu: "32"
+routingLimitsMemory: 128Gi
+routing:
+  instanceCategories: ["c", "m"]
+  instanceGenerationMin: "6"
+  blockDevice:
+    deviceName: /dev/xvda
+    volumeSizeGi: 50
+    volumeType: gp3
+workspaceNodepools:
+  - name: workspace-cpu
+    instanceFamilies: ["c6i", "m6i", "r6i", "c7i", "m7i", "r7i"]
+    diskSizeGi: 50
+    maxCpu: "512"
+    maxMemory: 2048Gi
+  - name: workspace-gpu
+    instanceFamilies: ["g4dn", "g5"]
+    diskSizeGi: 100
+    maxCpu: "64"
+    maxMemory: 256Gi
+    maxGpus: "4"
+    role: workspaces-gpu
+    gpu: "true"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_custom_pool.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_custom_pool.yaml
@@ -1,9 +1,10 @@
-# Custom GPU pool scenario: jupyterlab plus the template the workspaces.tf
-# workspace_pool_templates derivation emits for a hand-written entry
-# { name = "workspace-gpu-p", role = "workspaces-gpu-p",
-#   template_name = "jupyterlab-gpu-p", template_gpus = "1",
-#   template_cpu = "7500m", template_memory = "55Gi",
-#   template_idle_minutes = "20" }
+# Custom GPU pool scenario: jupyterlab plus the binding the workspaces.tf
+# workspace_pool_templates derivation emits for a hand-written config
+#   workspace_templates = [{ name = "jupyterlab-gpu-p", gpus = "1",
+#     cpu = "7500m", memory = "55Gi", idle_minutes = "20" }]
+# referenced by the entry
+#   { name = "workspace-gpu-p", accelerator = "nvidia",
+#     role = "workspaces-gpu-p", templates = "jupyterlab-gpu-p" }
 # displayName and description take the derivation defaults; dummy image as in
 # the other fixtures.
 workspaceTemplates:

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_custom_pool.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_custom_pool.yaml
@@ -1,0 +1,94 @@
+# Custom GPU pool scenario: jupyterlab plus the template the workspaces.tf
+# workspace_pool_templates derivation emits for a hand-written entry
+# { name = "workspace-gpu-p", role = "workspaces-gpu-p",
+#   template_name = "jupyterlab-gpu-p", template_gpus = "1",
+#   template_cpu = "7500m", template_memory = "55Gi",
+#   template_idle_minutes = "20" }
+# displayName and description take the derivation defaults; dummy image as in
+# the other fixtures.
+workspaceTemplates:
+  - name: jupyterlab
+    isDefault: "true"
+    displayName: JupyterLab
+    description: "JupyterLab workspace with persistent EBS storage"
+    imageUri: docker.io/test/jupyterlab:latest
+    appType: jupyterlab
+    accessType: OwnerOnly
+    ownershipType: OwnerOnly
+    storageClassName: ebs-sc
+    defaultResources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+    resourceBounds:
+      cpu:
+        min: "100m"
+        max: "8"
+      memory:
+        min: "256Mi"
+        max: "32Gi"
+    nodeSelector:
+      jupyter-deploy/role: workspaces
+    tolerations:
+      - key: jupyter-deploy/role
+        operator: Equal
+        value: workspaces
+        effect: NoSchedule
+    readinessProbe:
+      port: 8888
+      initialDelaySeconds: 2
+      periodSeconds: 3
+      failureThreshold: 30
+    idleShutdown:
+      enabled: true
+      timeoutMinutes: 60
+      minTimeoutMinutes: 15
+      maxTimeoutMinutes: 480
+  - name: jupyterlab-gpu-p
+    isDefault: "false"
+    displayName: jupyterlab-gpu-p
+    description: "JupyterLab workspace on the workspace-gpu-p pool"
+    imageUri: docker.io/test/jupyterlab:latest
+    appType: jupyterlab
+    accessType: OwnerOnly
+    ownershipType: OwnerOnly
+    storageClassName: ebs-sc
+    defaultResources:
+      requests:
+        cpu: "7500m"
+        memory: "55Gi"
+        nvidia.com/gpu: "1"
+      limits:
+        cpu: "7500m"
+        memory: "55Gi"
+        nvidia.com/gpu: "1"
+    resourceBounds:
+      cpu:
+        min: "7500m"
+        max: "7500m"
+      memory:
+        min: "55Gi"
+        max: "55Gi"
+      nvidia.com/gpu:
+        min: "1"
+        max: "1"
+    nodeSelector:
+      jupyter-deploy/role: workspaces-gpu-p
+    tolerations:
+      - key: jupyter-deploy/role
+        operator: Equal
+        value: workspaces-gpu-p
+        effect: NoSchedule
+    readinessProbe:
+      port: 8888
+      initialDelaySeconds: 2
+      periodSeconds: 3
+      failureThreshold: 30
+    idleShutdown:
+      enabled: true
+      timeoutMinutes: 20
+      minTimeoutMinutes: 15
+      maxTimeoutMinutes: 480

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_default.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_default.yaml
@@ -1,0 +1,5 @@
+# Chart defaults plus a dummy image (terraform always injects one; an empty
+# imageUri renders `defaultImage: ` with a trailing space, which yamllint
+# rejects in the committed golden).
+workspaceTemplate:
+  imageUri: docker.io/test/jupyterlab:latest

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_default.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_default.yaml
@@ -1,5 +1,45 @@
 # Chart defaults plus a dummy image (terraform always injects one; an empty
 # imageUri renders `defaultImage: ` with a trailing space, which yamllint
-# rejects in the committed golden).
-workspaceTemplate:
-  imageUri: docker.io/test/jupyterlab:latest
+# rejects in the committed golden). A values-file list replaces the chart
+# default wholesale, so the full single-entry list is restated here.
+workspaceTemplates:
+  - name: jupyterlab
+    isDefault: "true"
+    displayName: JupyterLab
+    description: "JupyterLab workspace with persistent EBS storage"
+    imageUri: docker.io/test/jupyterlab:latest
+    appType: jupyterlab
+    accessType: OwnerOnly
+    ownershipType: OwnerOnly
+    storageClassName: ebs-sc
+    defaultResources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+    resourceBounds:
+      cpu:
+        min: "100m"
+        max: "8"
+      memory:
+        min: "256Mi"
+        max: "32Gi"
+    nodeSelector:
+      jupyter-deploy/role: workspaces
+    tolerations:
+      - key: jupyter-deploy/role
+        operator: Equal
+        value: workspaces
+        effect: NoSchedule
+    readinessProbe:
+      port: 8888
+      initialDelaySeconds: 2
+      periodSeconds: 3
+      failureThreshold: 30
+    idleShutdown:
+      enabled: true
+      timeoutMinutes: 60
+      minTimeoutMinutes: 15
+      maxTimeoutMinutes: 480

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
@@ -1,0 +1,89 @@
+# Two-template list mirroring the workspaces.tf locals (jupyterlab plus the
+# enable_gpu_pool jupyterlab-gpu entry), dummy images — keep in sync with
+# jupyterlab_template_values / jupyterlab_gpu_template_values.
+workspaceTemplates:
+  - name: jupyterlab
+    isDefault: "true"
+    displayName: JupyterLab
+    description: "JupyterLab workspace with persistent EBS storage"
+    imageUri: docker.io/test/jupyterlab:latest
+    appType: jupyterlab
+    accessType: OwnerOnly
+    ownershipType: OwnerOnly
+    storageClassName: ebs-sc
+    defaultResources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+    resourceBounds:
+      cpu:
+        min: "100m"
+        max: "8"
+      memory:
+        min: "256Mi"
+        max: "32Gi"
+    nodeSelector:
+      jupyter-deploy/role: workspaces
+    tolerations:
+      - key: jupyter-deploy/role
+        operator: Equal
+        value: workspaces
+        effect: NoSchedule
+    readinessProbe:
+      port: 8888
+      initialDelaySeconds: 2
+      periodSeconds: 3
+      failureThreshold: 30
+    idleShutdown:
+      enabled: true
+      timeoutMinutes: 60
+      minTimeoutMinutes: 15
+      maxTimeoutMinutes: 480
+  - name: jupyterlab-gpu
+    isDefault: "false"
+    displayName: JupyterLab GPU
+    description: "JupyterLab workspace with one NVIDIA GPU and persistent EBS storage"
+    imageUri: docker.io/test/jupyterlab:latest
+    appType: jupyterlab
+    accessType: OwnerOnly
+    ownershipType: OwnerOnly
+    storageClassName: ebs-sc
+    defaultResources:
+      requests:
+        cpu: "3500m"
+        memory: "13Gi"
+        nvidia.com/gpu: "1"
+      limits:
+        cpu: "3500m"
+        memory: "13Gi"
+        nvidia.com/gpu: "1"
+    resourceBounds:
+      cpu:
+        min: "3500m"
+        max: "3500m"
+      memory:
+        min: "13Gi"
+        max: "13Gi"
+      nvidia.com/gpu:
+        min: "1"
+        max: "1"
+    nodeSelector:
+      jupyter-deploy/role: workspaces-gpu
+    tolerations:
+      - key: jupyter-deploy/role
+        operator: Equal
+        value: workspaces-gpu
+        effect: NoSchedule
+    readinessProbe:
+      port: 8888
+      initialDelaySeconds: 2
+      periodSeconds: 3
+      failureThreshold: 30
+    idleShutdown:
+      enabled: true
+      timeoutMinutes: 30
+      minTimeoutMinutes: 15
+      maxTimeoutMinutes: 480

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
@@ -85,6 +85,6 @@ workspaceTemplates:
       failureThreshold: 30
     idleShutdown:
       enabled: true
-      timeoutMinutes: 30
+      timeoutMinutes: 60
       minTimeoutMinutes: 15
       maxTimeoutMinutes: 480

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
@@ -54,20 +54,20 @@ workspaceTemplates:
     storageClassName: ebs-sc
     defaultResources:
       requests:
-        cpu: "3500m"
-        memory: "13Gi"
+        cpu: "3"
+        memory: "12Gi"
         nvidia.com/gpu: "1"
       limits:
-        cpu: "3500m"
-        memory: "13Gi"
+        cpu: "3"
+        memory: "12Gi"
         nvidia.com/gpu: "1"
     resourceBounds:
       cpu:
-        min: "3500m"
-        max: "3500m"
+        min: "3"
+        max: "3"
       memory:
-        min: "13Gi"
-        max: "13Gi"
+        min: "12Gi"
+        max: "12Gi"
       nvidia.com/gpu:
         min: "1"
         max: "1"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
@@ -1,7 +1,7 @@
 # Two-template list mirroring the workspaces.tf locals (jupyterlab plus the
-# template derived from the built-in GPU entry), dummy images — keep in sync
-# with jupyterlab_template_values / workspace_pool_templates and the
-# gpu_pool_builtin template keys in platform_karpenter.tf.
+# binding of the built-in jupyterlab-gpu config to the built-in GPU pool),
+# dummy images. Keep in sync with jupyterlab_template_values /
+# workspace_pool_templates and gpu_template_builtin in platform_karpenter.tf.
 workspaceTemplates:
   - name: jupyterlab
     isDefault: "true"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_workspace_defaults_two_templates.yaml
@@ -1,6 +1,7 @@
 # Two-template list mirroring the workspaces.tf locals (jupyterlab plus the
-# enable_gpu_pool jupyterlab-gpu entry), dummy images — keep in sync with
-# jupyterlab_template_values / jupyterlab_gpu_template_values.
+# template derived from the built-in GPU entry), dummy images — keep in sync
+# with jupyterlab_template_values / workspace_pool_templates and the
+# gpu_pool_builtin template keys in platform_karpenter.tf.
 workspaceTemplates:
   - name: jupyterlab
     isDefault: "true"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -43,6 +43,24 @@ def _workspace_template_docs(rendered: str) -> list[dict[str, Any]]:
     return [doc for doc in docs if doc.get("kind") == "WorkspaceTemplate"]
 
 
+def _doc_chunks(rendered: str) -> dict[tuple[str, str], str]:
+    """Split a multi-doc render into raw chunks keyed by (kind, name).
+
+    Raw text (not parsed YAML) so per-document comparisons stay byte-level:
+    parsing would erase exactly the class of drift the goldens exist to catch.
+    """
+    chunks: dict[tuple[str, str], str] = {}
+    for chunk in rendered.split("\n---\n"):
+        doc = yaml.safe_load(chunk)
+        if not doc:
+            continue
+        # Boundary newlines belong to the multi-doc container, not the document:
+        # the last doc of a file keeps its trailing newline, an inner one loses
+        # it to the separator split.
+        chunks[(doc["kind"], doc["metadata"]["name"])] = chunk.strip("\n")
+    return chunks
+
+
 class GoldenComparisonTestCase(unittest.TestCase):
     def compare_to_golden(self, rendered: str, golden_name: str) -> None:
         golden_path = DATA_DIR / golden_name
@@ -69,6 +87,65 @@ class TestKarpenterNodepoolsCpuRender(GoldenComparisonTestCase):
 
     def test_render_matches_golden(self) -> None:
         self.compare_to_golden(self.rendered, "golden_karpenter_nodepools_cpu.yaml")
+
+
+@_SKIP_WITHOUT_HELM
+class TestKarpenterNodepoolsGpuRender(unittest.TestCase):
+    """The synthesized GPU entry adds a fenced pool without touching existing pools."""
+
+    rendered: ClassVar[str]
+    chunks: ClassVar[dict[tuple[str, str], str]]
+    golden_chunks: ClassVar[dict[tuple[str, str], str]]
+    gpu_pool: ClassVar[dict[str, Any]]
+    cpu_pool: ClassVar[dict[str, Any]]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rendered = _helm_template(
+            "charts/karpenter-nodepools", "karpenter-nodepools", "values_karpenter_cpu_gpu.yaml"
+        )
+        cls.chunks = _doc_chunks(cls.rendered)
+        cls.golden_chunks = _doc_chunks((DATA_DIR / "golden_karpenter_nodepools_cpu.yaml").read_text())
+        cls.gpu_pool = yaml.safe_load(cls.chunks[("NodePool", "workspace-gpu")])
+        cls.cpu_pool = yaml.safe_load(cls.chunks[("NodePool", "workspace-cpu")])
+
+    def test_existing_docs_byte_identical(self) -> None:
+        for key in [
+            ("NodePool", "routing"),
+            ("NodePool", "workspace-cpu"),
+            ("EC2NodeClass", "routing"),
+            ("EC2NodeClass", "workspace-cpu"),
+        ]:
+            self.assertEqual(
+                self.golden_chunks[key],
+                self.chunks[key],
+                f"{key} rendered differently with the GPU entry present — Karpenter would "
+                "drift-replace its nodes and restart the workspaces on them.",
+            )
+
+    def test_gpu_nodepool_role_label_and_taint(self) -> None:
+        template = self.gpu_pool["spec"]["template"]
+        self.assertEqual(template["metadata"]["labels"]["jupyter-deploy/role"], "workspaces-gpu")
+        self.assertEqual(
+            template["spec"]["taints"],
+            [{"key": "jupyter-deploy/role", "value": "workspaces-gpu", "effect": "NoSchedule"}],
+        )
+
+    def test_gpu_nodepool_gpu_present_label(self) -> None:
+        labels = self.gpu_pool["spec"]["template"]["metadata"]["labels"]
+        self.assertEqual(labels.get("nvidia.com/gpu.present"), "true")
+
+    def test_gpu_nodepool_gpu_limit(self) -> None:
+        self.assertEqual(self.gpu_pool["spec"]["limits"].get("nvidia.com/gpu"), "4")
+        self.assertNotIn("nvidia.com/gpu", self.cpu_pool["spec"]["limits"])
+
+    def test_gpu_nodepool_instance_families(self) -> None:
+        requirements = {req["key"]: req for req in self.gpu_pool["spec"]["template"]["spec"]["requirements"]}
+        self.assertEqual(requirements["karpenter.k8s.aws/instance-family"]["values"], ["g4dn", "g5"])
+
+    def test_gpu_ec2nodeclass_root_volume(self) -> None:
+        nodeclass = yaml.safe_load(self.chunks[("EC2NodeClass", "workspace-gpu")])
+        self.assertEqual(nodeclass["spec"]["blockDeviceMappings"][0]["ebs"]["volumeSize"], "100Gi")
 
 
 @_SKIP_WITHOUT_HELM

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -141,7 +141,9 @@ class TestKarpenterNodepoolsGpuRender(unittest.TestCase):
 
     def test_gpu_nodepool_instance_families(self) -> None:
         requirements = {req["key"]: req for req in self.gpu_pool["spec"]["template"]["spec"]["requirements"]}
-        self.assertEqual(requirements["karpenter.k8s.aws/instance-family"]["values"], ["g4dn", "g5", "g6", "g6e"])
+        self.assertEqual(
+            requirements["karpenter.k8s.aws/instance-family"]["values"], ["g4dn", "g5", "g6", "g6e", "g7", "g7e"]
+        )
 
     def test_gpu_ec2nodeclass_root_volume(self) -> None:
         nodeclass = yaml.safe_load(self.chunks[("EC2NodeClass", "workspace-gpu")])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -2,7 +2,7 @@
 
 Renders each chart with `helm template` against fixture values in
 chart_render_data/ that mirror what the terraform layer injects, and compares
-the output to committed goldens. The karpenter golden is compared byte for
+the output to committed goldens. The karpenter goldens are compared byte for
 byte: Karpenter hashes a NodePool's spec.template, so any byte change to a
 rendered pool drift-replaces its nodes and restarts the workspaces on them.
 Regenerate goldens deliberately with:
@@ -90,7 +90,7 @@ class TestKarpenterNodepoolsCpuRender(GoldenComparisonTestCase):
 
 
 @_SKIP_WITHOUT_HELM
-class TestKarpenterNodepoolsGpuRender(unittest.TestCase):
+class TestKarpenterNodepoolsGpuRender(GoldenComparisonTestCase):
     """The synthesized GPU entry adds a fenced pool without touching existing pools."""
 
     rendered: ClassVar[str]
@@ -108,6 +108,9 @@ class TestKarpenterNodepoolsGpuRender(unittest.TestCase):
         cls.golden_chunks = _doc_chunks((DATA_DIR / "golden_karpenter_nodepools_cpu.yaml").read_text())
         cls.gpu_pool = yaml.safe_load(cls.chunks[("NodePool", "workspace-gpu")])
         cls.cpu_pool = yaml.safe_load(cls.chunks[("NodePool", "workspace-cpu")])
+
+    def test_render_matches_golden(self) -> None:
+        self.compare_to_golden(self.rendered, "golden_karpenter_nodepools_cpu_gpu.yaml")
 
     def test_existing_docs_byte_identical(self) -> None:
         for key in [

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -206,12 +206,12 @@ class TestWorkspaceDefaultsTwoTemplateRender(unittest.TestCase):
 
     def test_gpu_template_bounds_pinned(self) -> None:
         bounds = self.gpu["spec"]["resourceBounds"]["resources"]
-        self.assertEqual(bounds["cpu"], {"min": "3500m", "max": "3500m"})
-        self.assertEqual(bounds["memory"], {"min": "13Gi", "max": "13Gi"})
+        self.assertEqual(bounds["cpu"], {"min": "3", "max": "3"})
+        self.assertEqual(bounds["memory"], {"min": "12Gi", "max": "12Gi"})
         self.assertEqual(bounds["nvidia.com/gpu"], {"min": "1", "max": "1"})
 
     def test_gpu_template_default_resources_match_bounds(self) -> None:
-        pinned = {"cpu": "3500m", "memory": "13Gi", "nvidia.com/gpu": "1"}
+        pinned = {"cpu": "3", "memory": "12Gi", "nvidia.com/gpu": "1"}
         resources = self.gpu["spec"]["defaultResources"]
         self.assertEqual(resources["requests"], pinned)
         self.assertEqual(resources["limits"], pinned)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -225,7 +225,7 @@ class TestWorkspaceDefaultsTwoTemplateRender(unittest.TestCase):
         )
 
     def test_gpu_template_idle_timeout(self) -> None:
-        self.assertEqual(self.gpu["spec"]["defaultIdleShutdown"]["idleTimeoutInMinutes"], 30)
+        self.assertEqual(self.gpu["spec"]["defaultIdleShutdown"]["idleTimeoutInMinutes"], 60)
         overrides = self.gpu["spec"]["idleShutdownOverrides"]
         self.assertEqual(overrides["minIdleTimeoutInMinutes"], 15)
         self.assertEqual(overrides["maxIdleTimeoutInMinutes"], 480)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -173,3 +173,57 @@ class TestWorkspaceDefaultsDefaultRender(GoldenComparisonTestCase):
         golden = _workspace_template_docs((DATA_DIR / "golden_workspace_defaults_default.yaml").read_text())
         self.assertEqual(len(golden), 1)
         self.assertEqual(golden[0], self.templates[0])
+
+
+@_SKIP_WITHOUT_HELM
+class TestWorkspaceDefaultsTwoTemplateRender(unittest.TestCase):
+    """The jupyterlab-gpu entry renders a fenced fixed-shape template beside jupyterlab."""
+
+    templates: ClassVar[list[dict[str, Any]]]
+    gpu: ClassVar[dict[str, Any]]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        rendered = _helm_template(
+            "charts/workspace-defaults", "workspace-defaults", "values_workspace_defaults_two_templates.yaml"
+        )
+        cls.templates = _workspace_template_docs(rendered)
+        cls.gpu = next(doc for doc in cls.templates if doc["metadata"]["name"] == "jupyterlab-gpu")
+
+    def test_renders_both_templates(self) -> None:
+        names = [doc["metadata"]["name"] for doc in self.templates]
+        self.assertEqual(names, ["jupyterlab", "jupyterlab-gpu"])
+
+    def test_jupyterlab_unchanged_beside_gpu_template(self) -> None:
+        golden = _workspace_template_docs((DATA_DIR / "golden_workspace_defaults_default.yaml").read_text())
+        jupyterlab = next(doc for doc in self.templates if doc["metadata"]["name"] == "jupyterlab")
+        self.assertEqual(golden[0], jupyterlab)
+
+    def test_gpu_template_bounds_pinned(self) -> None:
+        bounds = self.gpu["spec"]["resourceBounds"]["resources"]
+        self.assertEqual(bounds["cpu"], {"min": "3500m", "max": "3500m"})
+        self.assertEqual(bounds["memory"], {"min": "13Gi", "max": "13Gi"})
+        self.assertEqual(bounds["nvidia.com/gpu"], {"min": "1", "max": "1"})
+
+    def test_gpu_template_default_resources_match_bounds(self) -> None:
+        pinned = {"cpu": "3500m", "memory": "13Gi", "nvidia.com/gpu": "1"}
+        resources = self.gpu["spec"]["defaultResources"]
+        self.assertEqual(resources["requests"], pinned)
+        self.assertEqual(resources["limits"], pinned)
+
+    def test_gpu_template_placement(self) -> None:
+        spec = self.gpu["spec"]
+        self.assertEqual(spec["defaultNodeSelector"], {"jupyter-deploy/role": "workspaces-gpu"})
+        self.assertEqual(
+            spec["defaultTolerations"],
+            [{"key": "jupyter-deploy/role", "operator": "Equal", "value": "workspaces-gpu", "effect": "NoSchedule"}],
+        )
+
+    def test_gpu_template_idle_timeout(self) -> None:
+        self.assertEqual(self.gpu["spec"]["defaultIdleShutdown"]["idleTimeoutInMinutes"], 30)
+        overrides = self.gpu["spec"]["idleShutdownOverrides"]
+        self.assertEqual(overrides["minIdleTimeoutInMinutes"], 15)
+        self.assertEqual(overrides["maxIdleTimeoutInMinutes"], 480)
+
+    def test_gpu_template_not_default(self) -> None:
+        self.assertEqual(self.gpu["metadata"]["labels"]["workspace.jupyter.org/default-template"], "false")

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -141,7 +141,7 @@ class TestKarpenterNodepoolsGpuRender(unittest.TestCase):
 
     def test_gpu_nodepool_instance_families(self) -> None:
         requirements = {req["key"]: req for req in self.gpu_pool["spec"]["template"]["spec"]["requirements"]}
-        self.assertEqual(requirements["karpenter.k8s.aws/instance-family"]["values"], ["g4dn", "g5"])
+        self.assertEqual(requirements["karpenter.k8s.aws/instance-family"]["values"], ["g4dn", "g5", "g6", "g6e"])
 
     def test_gpu_ec2nodeclass_root_volume(self) -> None:
         nodeclass = yaml.safe_load(self.chunks[("EC2NodeClass", "workspace-gpu")])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -1,0 +1,98 @@
+"""Render pins for the local helm charts.
+
+Renders each chart with `helm template` against fixture values in
+chart_render_data/ that mirror what the terraform layer injects, and compares
+the output to committed goldens. The karpenter golden is compared byte for
+byte: Karpenter hashes a NodePool's spec.template, so any byte change to a
+rendered pool drift-replaces its nodes and restarts the workspaces on them.
+Regenerate goldens deliberately with:
+JD_UPDATE_GOLDENS=1 uv run pytest tests/unit/test_chart_render.py
+"""
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any, ClassVar
+
+import yaml
+
+from jupyter_deploy_tf_aws_eks_oidc.template import TEMPLATE_PATH
+
+DATA_DIR = Path(__file__).parent / "chart_render_data"
+_HELM = shutil.which("helm")
+
+# CI must never skip these silently (the byte-identity guarantee would vanish
+# without a red build); laptops without helm may.
+_SKIP_WITHOUT_HELM = unittest.skipIf(_HELM is None and not os.environ.get("CI"), "helm not installed")
+
+
+def _helm_template(chart_dir: str, release_name: str, values_file: str | None) -> str:
+    cmd = ["helm", "template", release_name, str(TEMPLATE_PATH / chart_dir)]
+    if values_file is not None:
+        cmd.extend(["-f", str(DATA_DIR / values_file)])
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise AssertionError(f"helm template failed for {chart_dir}: {result.stderr}")
+    return result.stdout
+
+
+def _workspace_template_docs(rendered: str) -> list[dict[str, Any]]:
+    docs = [doc for doc in yaml.safe_load_all(rendered) if doc]
+    return [doc for doc in docs if doc.get("kind") == "WorkspaceTemplate"]
+
+
+class GoldenComparisonTestCase(unittest.TestCase):
+    def compare_to_golden(self, rendered: str, golden_name: str) -> None:
+        golden_path = DATA_DIR / golden_name
+        if os.environ.get("JD_UPDATE_GOLDENS"):
+            golden_path.write_text(rendered)
+            return
+        self.assertEqual(
+            golden_path.read_text(),
+            rendered,
+            f"{golden_name} drifted from the chart render. If the change is deliberate and its "
+            "node-replacement impact is understood, regenerate with JD_UPDATE_GOLDENS=1.",
+        )
+
+
+@_SKIP_WITHOUT_HELM
+class TestKarpenterNodepoolsCpuRender(GoldenComparisonTestCase):
+    """Default (flag-off) karpenter-nodepools render is byte-stable."""
+
+    rendered: ClassVar[str]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rendered = _helm_template("charts/karpenter-nodepools", "karpenter-nodepools", "values_karpenter_cpu.yaml")
+
+    def test_render_matches_golden(self) -> None:
+        self.compare_to_golden(self.rendered, "golden_karpenter_nodepools_cpu.yaml")
+
+
+@_SKIP_WITHOUT_HELM
+class TestWorkspaceDefaultsDefaultRender(GoldenComparisonTestCase):
+    """Default workspace-defaults render carries exactly the jupyterlab template."""
+
+    rendered: ClassVar[str]
+    templates: ClassVar[list[dict[str, Any]]]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rendered = _helm_template(
+            "charts/workspace-defaults", "workspace-defaults", "values_workspace_defaults_default.yaml"
+        )
+        cls.templates = _workspace_template_docs(cls.rendered)
+
+    def test_single_template_rendered(self) -> None:
+        names = [doc["metadata"]["name"] for doc in self.templates]
+        self.assertEqual(names, ["jupyterlab"])
+
+    def test_jupyterlab_doc_matches_golden(self) -> None:
+        self.compare_to_golden(self.rendered, "golden_workspace_defaults_default.yaml")
+
+    def test_jupyterlab_spec_matches_golden_semantically(self) -> None:
+        golden = _workspace_template_docs((DATA_DIR / "golden_workspace_defaults_default.yaml").read_text())
+        self.assertEqual(len(golden), 1)
+        self.assertEqual(golden[0], self.templates[0])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -227,3 +227,47 @@ class TestWorkspaceDefaultsTwoTemplateRender(unittest.TestCase):
 
     def test_gpu_template_not_default(self) -> None:
         self.assertEqual(self.gpu["metadata"]["labels"]["workspace.jupyter.org/default-template"], "false")
+
+
+@_SKIP_WITHOUT_HELM
+class TestWorkspaceDefaultsCustomPoolRender(unittest.TestCase):
+    """A hand-written GPU pool entry renders its own template fenced to its role."""
+
+    templates: ClassVar[list[dict[str, Any]]]
+    custom: ClassVar[dict[str, Any]]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        rendered = _helm_template(
+            "charts/workspace-defaults", "workspace-defaults", "values_workspace_defaults_custom_pool.yaml"
+        )
+        cls.templates = _workspace_template_docs(rendered)
+        cls.custom = next(doc for doc in cls.templates if doc["metadata"]["name"] == "jupyterlab-gpu-p")
+
+    def test_renders_both_templates(self) -> None:
+        names = [doc["metadata"]["name"] for doc in self.templates]
+        self.assertEqual(names, ["jupyterlab", "jupyterlab-gpu-p"])
+
+    def test_placement_follows_entry_role(self) -> None:
+        spec = self.custom["spec"]
+        self.assertEqual(spec["defaultNodeSelector"], {"jupyter-deploy/role": "workspaces-gpu-p"})
+        self.assertEqual(
+            spec["defaultTolerations"],
+            [
+                {
+                    "key": "jupyter-deploy/role",
+                    "operator": "Equal",
+                    "value": "workspaces-gpu-p",
+                    "effect": "NoSchedule",
+                }
+            ],
+        )
+
+    def test_bounds_pinned_from_entry(self) -> None:
+        bounds = self.custom["spec"]["resourceBounds"]["resources"]
+        self.assertEqual(bounds["cpu"], {"min": "7500m", "max": "7500m"})
+        self.assertEqual(bounds["memory"], {"min": "55Gi", "max": "55Gi"})
+        self.assertEqual(bounds["nvidia.com/gpu"], {"min": "1", "max": "1"})
+
+    def test_idle_timeout_from_entry(self) -> None:
+        self.assertEqual(self.custom["spec"]["defaultIdleShutdown"]["idleTimeoutInMinutes"], 20)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -22,6 +22,9 @@ MANDATORY_TEMPLATE_STRPATHS: list[str] = [
     "engine/local-destroy-workspaces.sh.tftpl",
     "charts/workspace-defaults/Chart.yaml",
     "charts/github-rbac/Chart.yaml",
+    # Existence only — its version is deliberately decoupled from the template
+    # version (see CHART_DIRS), so it does not belong there.
+    "charts/karpenter-nodepools/Chart.yaml",
 ]
 
 CHART_DIRS: list[str] = [

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
@@ -251,12 +251,12 @@ class TestManifest(unittest.TestCase):
         components = self.MANIFEST.get("components", {})
         helm_components = {name: c for name, c in components.items() if c["type"] == "HelmRelease"}
 
-        # All seven chart releases are surfaced as components (five platform charts plus
-        # the cluster-autoscaler and fluent-bit charts added for autoscaling / logging).
+        # Every helm_release in the template is surfaced as a component, so
+        # adding a release means adding a component entry (and bumping this).
         self.assertEqual(
             len(helm_components),
-            10,
-            f"Expected 10 HelmRelease components, got {len(helm_components)}: {list(helm_components)}",
+            11,
+            f"Expected 11 HelmRelease components, got {len(helm_components)}: {list(helm_components)}",
         )
         for name, comp in helm_components.items():
             self.assertIn("reconcile", comp["verbs"], f"HelmRelease component '{name}' must declare a reconcile verb")

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
@@ -251,7 +251,8 @@ class TestManifest(unittest.TestCase):
         components = self.MANIFEST.get("components", {})
         helm_components = {name: c for name, c in components.items() if c["type"] == "HelmRelease"}
 
-        # Every helm_release in the template is surfaced as a component, so
+        # Every helm_release in the template is surfaced as a component, except
+        # deliberately optional ones (see test_no_gpu_components_declared), so
         # adding a release means adding a component entry (and bumping this).
         self.assertEqual(
             len(helm_components),

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
@@ -400,3 +400,14 @@ class TestManifest(unittest.TestCase):
         self.assertEqual(chart["resource-name"], "nvidia-device-plugin")
         self.assertEqual(chart["scope"], "kube_system_namespace")
         self.assertIn("reconcile", chart["verbs"])
+
+    def test_gpu_workspace_template_component_declared(self) -> None:
+        """The jupyterlab-gpu template surfaces in jd health beside jupyterlab."""
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        component = self.MANIFEST.get("components", {})["jupyterlab-gpu-template"]
+        self.assertEqual(component["type"], "CustomResourceWithoutStatus")
+        self.assertEqual(component["resource-name"], "jupyterlab-gpu")
+        self.assertEqual(component["scope"], "workspace_shared_namespace")
+        self.assertEqual(component["crd-plural"], "workspacetemplates")

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
@@ -255,8 +255,8 @@ class TestManifest(unittest.TestCase):
         # adding a release means adding a component entry (and bumping this).
         self.assertEqual(
             len(helm_components),
-            11,
-            f"Expected 11 HelmRelease components, got {len(helm_components)}: {list(helm_components)}",
+            10,
+            f"Expected 10 HelmRelease components, got {len(helm_components)}: {list(helm_components)}",
         )
         for name, comp in helm_components.items():
             self.assertIn("reconcile", comp["verbs"], f"HelmRelease component '{name}' must declare a reconcile verb")
@@ -379,35 +379,15 @@ class TestManifest(unittest.TestCase):
         daemonset_names = {name for name, comp in components.items() if comp["type"] == "DaemonSet"}
         self.assertIn("aws-node", daemonset_names)
         self.assertIn("kube-proxy", daemonset_names)
-        self.assertIn("nvidia-device-plugin", daemonset_names)
 
-    def test_nvidia_device_plugin_components_declared(self) -> None:
-        """The GPU device plugin surfaces in jd health as its DaemonSet and its chart."""
+    def test_no_gpu_components_declared(self) -> None:
+        # Manifest components have no conditional mechanism and jd health reads a
+        # missing resource as degraded, so the GPU pieces (present only when a
+        # pool entry sets accelerator) must stay out until optional components exist.
         if self.MANIFEST is None:
             self.fail("MANIFEST is None")
 
         components = self.MANIFEST.get("components", {})
-
-        daemonset = components["nvidia-device-plugin"]
-        self.assertEqual(daemonset["type"], "DaemonSet")
-        self.assertEqual(daemonset["resource-name"], "nvidia-device-plugin")
-        self.assertEqual(daemonset["scope"], "kube_system_namespace")
-        self.assertIn("status", daemonset["verbs"])
-        self.assertIn("show", daemonset["verbs"])
-
-        chart = components["nvidia-device-plugin-chart"]
-        self.assertEqual(chart["type"], "HelmRelease")
-        self.assertEqual(chart["resource-name"], "nvidia-device-plugin")
-        self.assertEqual(chart["scope"], "kube_system_namespace")
-        self.assertIn("reconcile", chart["verbs"])
-
-    def test_gpu_workspace_template_component_declared(self) -> None:
-        """The jupyterlab-gpu template surfaces in jd health beside jupyterlab."""
-        if self.MANIFEST is None:
-            self.fail("MANIFEST is None")
-
-        component = self.MANIFEST.get("components", {})["jupyterlab-gpu-template"]
-        self.assertEqual(component["type"], "CustomResourceWithoutStatus")
-        self.assertEqual(component["resource-name"], "jupyterlab-gpu")
-        self.assertEqual(component["scope"], "workspace_shared_namespace")
-        self.assertEqual(component["crd-plural"], "workspacetemplates")
+        self.assertNotIn("nvidia-device-plugin", components)
+        self.assertNotIn("nvidia-device-plugin-chart", components)
+        self.assertNotIn("jupyterlab-gpu-template", components)

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_manifest_yaml.py
@@ -379,3 +379,24 @@ class TestManifest(unittest.TestCase):
         daemonset_names = {name for name, comp in components.items() if comp["type"] == "DaemonSet"}
         self.assertIn("aws-node", daemonset_names)
         self.assertIn("kube-proxy", daemonset_names)
+        self.assertIn("nvidia-device-plugin", daemonset_names)
+
+    def test_nvidia_device_plugin_components_declared(self) -> None:
+        """The GPU device plugin surfaces in jd health as its DaemonSet and its chart."""
+        if self.MANIFEST is None:
+            self.fail("MANIFEST is None")
+
+        components = self.MANIFEST.get("components", {})
+
+        daemonset = components["nvidia-device-plugin"]
+        self.assertEqual(daemonset["type"], "DaemonSet")
+        self.assertEqual(daemonset["resource-name"], "nvidia-device-plugin")
+        self.assertEqual(daemonset["scope"], "kube_system_namespace")
+        self.assertIn("status", daemonset["verbs"])
+        self.assertIn("show", daemonset["verbs"])
+
+        chart = components["nvidia-device-plugin-chart"]
+        self.assertEqual(chart["type"], "HelmRelease")
+        self.assertEqual(chart["resource-name"], "nvidia-device-plugin")
+        self.assertEqual(chart["scope"], "kube_system_namespace")
+        self.assertIn("reconcile", chart["verbs"])

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
@@ -233,9 +233,15 @@ class TestVariablesYaml(unittest.TestCase):
         )
 
     def test_gpu_pool_flag_off_in_preset(self) -> None:
-        """enable_gpu_pool must default to false so existing deployments see zero deltas."""
-        self.assertIn("enable_gpu_pool", self.DEFAULTS_ALL_TFVARS, "enable_gpu_pool must be set in defaults-all.tfvars")
-        self.assertIs(self.DEFAULTS_ALL_TFVARS["enable_gpu_pool"], False, "enable_gpu_pool must default to false")
+        """enable_default_gpu_pool must default to false so existing deployments see zero deltas."""
+        self.assertIn(
+            "enable_default_gpu_pool",
+            self.DEFAULTS_ALL_TFVARS,
+            "enable_default_gpu_pool must be set in defaults-all.tfvars",
+        )
+        self.assertIs(
+            self.DEFAULTS_ALL_TFVARS["enable_default_gpu_pool"], False, "enable_default_gpu_pool must default to false"
+        )
 
     def test_preset_nodepools_carry_only_base_keys(self) -> None:
         """Preset pool entries must not carry the optional GPU keys.
@@ -252,7 +258,7 @@ class TestVariablesYaml(unittest.TestCase):
                 len(extra),
                 0,
                 f"preset pool '{pool['name']}' carries non-base keys {extra} — move GPU pool "
-                "settings to the enable_gpu_pool synthesis or a deployment override, not the preset",
+                "settings to the enable_default_gpu_pool synthesis or a deployment override, not the preset",
             )
 
     @classmethod

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_variables_yaml.py
@@ -232,6 +232,29 @@ class TestVariablesYaml(unittest.TestCase):
             "node_expire_after must be set in defaults-all.tfvars",
         )
 
+    def test_gpu_pool_flag_off_in_preset(self) -> None:
+        """enable_gpu_pool must default to false so existing deployments see zero deltas."""
+        self.assertIn("enable_gpu_pool", self.DEFAULTS_ALL_TFVARS, "enable_gpu_pool must be set in defaults-all.tfvars")
+        self.assertIs(self.DEFAULTS_ALL_TFVARS["enable_gpu_pool"], False, "enable_gpu_pool must default to false")
+
+    def test_preset_nodepools_carry_only_base_keys(self) -> None:
+        """Preset pool entries must not carry the optional GPU keys.
+
+        An optional key (role, max_gpus, gpu) on a preset pool would change its
+        rendered NodePool, and Karpenter drift-replaces the nodes of a changed
+        pool — restarting every workspace on them on upgrade. The built-in GPU
+        entry is synthesized in terraform, never written into the preset.
+        """
+        base_keys = {"name", "instance_families", "disk_size_gb", "max_cpu", "max_memory"}
+        for pool in self.DEFAULTS_ALL_TFVARS["workspace_nodepools"]:
+            extra = set(pool.keys()) - base_keys
+            self.assertEqual(
+                len(extra),
+                0,
+                f"preset pool '{pool['name']}' carries non-base keys {extra} — move GPU pool "
+                "settings to the enable_gpu_pool synthesis or a deployment override, not the preset",
+            )
+
     @classmethod
     def _parse_commented_overrides(cls) -> dict:
         """Parse commented-out key-value pairs from the overrides section of variables.yaml."""

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_workspace_default_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_workspace_default_template.py
@@ -38,23 +38,13 @@ def test_parameters_sanity() -> None:
     )
 
 
-def test_gpu_template_idle_timeout_within_window() -> None:
-    """The built-in GPU pool's idle default must sit inside the shared override window.
+def test_gpu_template_idle_follows_deployment_default() -> None:
+    """The built-in GPU config must not hardcode an idle literal.
 
-    The built-in GPU entry pins its template's idle default as a literal
-    (idle_minutes in platform_karpenter.tf) while the derived template
-    reuses the preset min/max window; a literal outside the window would be
-    rejected by the operator's override validation on every GPU workspace.
+    A literal can fall outside the deployment's idle-shutdown window, failing
+    every plan with an error naming a config the admin never wrote.
     """
     karpenter_tf = (TEMPLATE_PATH / "engine" / "platform_karpenter.tf").read_text()
-    match = re.search(r'^\s*idle_minutes\s*=\s*"(\d+)"\s*$', karpenter_tf, re.MULTILINE)
-    assert match is not None, "idle_minutes literal not found in platform_karpenter.tf"
-    gpu_timeout = int(match.group(1))
-
-    tfvars = (TEMPLATE_PATH / "engine" / "presets" / "defaults-all.tfvars").read_text()
-    timeout_min = _read_number_tfvar(tfvars, "workspaces_idle_shutdown_timeout_min")
-    timeout_max = _read_number_tfvar(tfvars, "workspaces_idle_shutdown_timeout_max")
-
-    assert timeout_min <= gpu_timeout <= timeout_max, (
-        f"GPU idle default ({gpu_timeout}) must be within [min, max] = [{timeout_min}, {timeout_max}]"
+    assert re.search(r"idle_minutes\s*=\s*tostring\(var\.workspaces_idle_shutdown_timeout_default\)", karpenter_tf), (
+        "the built-in gpu template must inherit workspaces_idle_shutdown_timeout_default"
     )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_workspace_default_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_workspace_default_template.py
@@ -39,15 +39,16 @@ def test_parameters_sanity() -> None:
 
 
 def test_gpu_template_idle_timeout_within_window() -> None:
-    """The GPU template's idle default must sit inside the shared override window.
+    """The built-in GPU pool's idle default must sit inside the shared override window.
 
-    The GPU template pins its own idle default as a literal in workspaces.tf
-    while reusing the preset min/max window; a literal outside the window would
-    be rejected by the operator's override validation on every GPU workspace.
+    The built-in GPU entry pins its template's idle default as a literal
+    (template_idle_minutes in platform_karpenter.tf) while the derived template
+    reuses the preset min/max window; a literal outside the window would be
+    rejected by the operator's override validation on every GPU workspace.
     """
-    workspaces_tf = (TEMPLATE_PATH / "engine" / "workspaces.tf").read_text()
-    match = re.search(r"^\s*timeoutMinutes\s*=\s*(\d+)\s*$", workspaces_tf, re.MULTILINE)
-    assert match is not None, "GPU idle timeout literal not found in workspaces.tf"
+    karpenter_tf = (TEMPLATE_PATH / "engine" / "platform_karpenter.tf").read_text()
+    match = re.search(r'^\s*template_idle_minutes\s*=\s*"(\d+)"\s*$', karpenter_tf, re.MULTILINE)
+    assert match is not None, "template_idle_minutes literal not found in platform_karpenter.tf"
     gpu_timeout = int(match.group(1))
 
     tfvars = (TEMPLATE_PATH / "engine" / "presets" / "defaults-all.tfvars").read_text()

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_workspace_default_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_workspace_default_template.py
@@ -36,3 +36,24 @@ def test_parameters_sanity() -> None:
     assert timeout_min <= timeout_default <= timeout_max, (
         f"default ({timeout_default}) must be within [min, max] = [{timeout_min}, {timeout_max}]"
     )
+
+
+def test_gpu_template_idle_timeout_within_window() -> None:
+    """The GPU template's idle default must sit inside the shared override window.
+
+    The GPU template pins its own idle default as a literal in workspaces.tf
+    while reusing the preset min/max window; a literal outside the window would
+    be rejected by the operator's override validation on every GPU workspace.
+    """
+    workspaces_tf = (TEMPLATE_PATH / "engine" / "workspaces.tf").read_text()
+    match = re.search(r"^\s*timeoutMinutes\s*=\s*(\d+)\s*$", workspaces_tf, re.MULTILINE)
+    assert match is not None, "GPU idle timeout literal not found in workspaces.tf"
+    gpu_timeout = int(match.group(1))
+
+    tfvars = (TEMPLATE_PATH / "engine" / "presets" / "defaults-all.tfvars").read_text()
+    timeout_min = _read_number_tfvar(tfvars, "workspaces_idle_shutdown_timeout_min")
+    timeout_max = _read_number_tfvar(tfvars, "workspaces_idle_shutdown_timeout_max")
+
+    assert timeout_min <= gpu_timeout <= timeout_max, (
+        f"GPU idle default ({gpu_timeout}) must be within [min, max] = [{timeout_min}, {timeout_max}]"
+    )

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_workspace_default_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_workspace_default_template.py
@@ -42,13 +42,13 @@ def test_gpu_template_idle_timeout_within_window() -> None:
     """The built-in GPU pool's idle default must sit inside the shared override window.
 
     The built-in GPU entry pins its template's idle default as a literal
-    (template_idle_minutes in platform_karpenter.tf) while the derived template
+    (idle_minutes in platform_karpenter.tf) while the derived template
     reuses the preset min/max window; a literal outside the window would be
     rejected by the operator's override validation on every GPU workspace.
     """
     karpenter_tf = (TEMPLATE_PATH / "engine" / "platform_karpenter.tf").read_text()
-    match = re.search(r'^\s*template_idle_minutes\s*=\s*"(\d+)"\s*$', karpenter_tf, re.MULTILINE)
-    assert match is not None, "template_idle_minutes literal not found in platform_karpenter.tf"
+    match = re.search(r'^\s*idle_minutes\s*=\s*"(\d+)"\s*$', karpenter_tf, re.MULTILINE)
+    assert match is not None, "idle_minutes literal not found in platform_karpenter.tf"
     gpu_timeout = int(match.group(1))
 
     tfvars = (TEMPLATE_PATH / "engine" / "presets" / "defaults-all.tfvars").read_text()

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/kubernetes/nodes.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/kubernetes/nodes.py
@@ -11,7 +11,7 @@ from pytest_jupyter_deploy.kubernetes.kubectl import run_kubectl
 
 
 def get_node_names(label_selector: str) -> list[str]:
-    """Names of Ready nodes matching a label selector (e.g. 'jupyter-deploy/role=platform')."""
+    """Names of nodes matching a label selector (e.g. 'jupyter-deploy/role=platform'), regardless of readiness."""
     result = subprocess.run(
         ["kubectl", "get", "nodes", "-l", label_selector, "-o", "jsonpath={.items[*].metadata.name}"],
         capture_output=True,

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/kubernetes/nodes.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/kubernetes/nodes.py
@@ -68,3 +68,19 @@ def get_node_allocatable_cpu_millicores(node_name: str) -> int:
         check=True,
     )
     return parse_cpu_to_millicores(result.stdout.strip())
+
+
+def get_node_allocatable_gpu_count(node_name: str) -> int:
+    """Allocatable nvidia.com/gpu count of a node.
+
+    Empty output means the key is absent — a GPU node before the device plugin
+    registers, or a non-GPU node — and reads as 0, never an error.
+    """
+    result = subprocess.run(
+        ["kubectl", "get", "node", node_name, "-o", r"jsonpath={.status.allocatable.nvidia\.com/gpu}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = result.stdout.strip()
+    return int(out) if out else 0

--- a/libs/pytest-jupyter-deploy/tests/test_nodes.py
+++ b/libs/pytest-jupyter-deploy/tests/test_nodes.py
@@ -1,8 +1,9 @@
 """Unit tests for the kubernetes.nodes helpers."""
 
 import unittest
+from unittest.mock import Mock, patch
 
-from pytest_jupyter_deploy.kubernetes.nodes import parse_cpu_to_millicores
+from pytest_jupyter_deploy.kubernetes.nodes import get_node_allocatable_gpu_count, parse_cpu_to_millicores
 
 
 class TestParseCpuToMillicores(unittest.TestCase):
@@ -17,3 +18,17 @@ class TestParseCpuToMillicores(unittest.TestCase):
 
     def test_strips_whitespace(self) -> None:
         self.assertEqual(parse_cpu_to_millicores("  4  "), 4000)
+
+
+class TestGetNodeAllocatableGpuCount(unittest.TestCase):
+    @patch("pytest_jupyter_deploy.kubernetes.nodes.subprocess.run")
+    def test_gpu_node(self, mock_run: Mock) -> None:
+        mock_run.return_value = Mock(stdout="1\n")
+        self.assertEqual(get_node_allocatable_gpu_count("node-a"), 1)
+
+    @patch("pytest_jupyter_deploy.kubernetes.nodes.subprocess.run")
+    def test_absent_key_reads_zero(self, mock_run: Mock) -> None:
+        # A node without the nvidia.com/gpu key (CPU node, or GPU node before the
+        # device plugin registers) yields empty output, which must read as 0.
+        mock_run.return_value = Mock(stdout="")
+        self.assertEqual(get_node_allocatable_gpu_count("node-a"), 0)

--- a/scripts/env_setup_eks.py
+++ b/scripts/env_setup_eks.py
@@ -53,7 +53,7 @@ OPTION_MAP = {
     "org": "JD_E2E_ORG",
     "team": "JD_E2E_TEAM",
     "rbac-team": "JD_E2E_RBAC_TEAM",
-    "enable-gpu-pool": "JD_E2E_VAR_ENABLE_GPU_POOL",
+    "enable-default-gpu-pool": "JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL",
 }
 
 
@@ -254,16 +254,18 @@ def main() -> None:
 
     # 1e. Default the GPU pool flag to false when absent: envsubst renders an
     # unset var as empty, which YAML-parses to null and fails bool validation.
-    if "JD_E2E_VAR_ENABLE_GPU_POOL" not in option_env_vars and not os.environ.get("JD_E2E_VAR_ENABLE_GPU_POOL"):
+    if "JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL" not in option_env_vars and not os.environ.get(
+        "JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL"
+    ):
         env_has_gpu_flag = False
         if ENV_FILE.exists():
             for line in ENV_FILE.read_text().splitlines():
-                if line.startswith("JD_E2E_VAR_ENABLE_GPU_POOL=") and line.split("=", 1)[1].strip():
+                if line.startswith("JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL=") and line.split("=", 1)[1].strip():
                     env_has_gpu_flag = True
                     break
         if not env_has_gpu_flag:
-            set_env_var("JD_E2E_VAR_ENABLE_GPU_POOL", "false")
-            print("  JD_E2E_VAR_ENABLE_GPU_POOL=false (default)")
+            set_env_var("JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL", "false")
+            print("  JD_E2E_VAR_ENABLE_DEFAULT_GPU_POOL=false (default)")
 
     # 2. Fetch OAuth credentials from CI infrastructure
     print(f"\nFetching OAuth app #{oauth_app_num} credentials from CI ({ci_dir})...")

--- a/scripts/env_setup_eks.py
+++ b/scripts/env_setup_eks.py
@@ -53,6 +53,7 @@ OPTION_MAP = {
     "org": "JD_E2E_ORG",
     "team": "JD_E2E_TEAM",
     "rbac-team": "JD_E2E_RBAC_TEAM",
+    "enable-gpu-pool": "JD_E2E_VAR_ENABLE_GPU_POOL",
 }
 
 
@@ -250,6 +251,19 @@ def main() -> None:
         if not env_has_admin_roles:
             print("Error: JD_E2E_VAR_ADMIN_ROLE_NAMES not set and no admin-roles option provided")
             sys.exit(1)
+
+    # 1e. Default the GPU pool flag to false when absent: envsubst renders an
+    # unset var as empty, which YAML-parses to null and fails bool validation.
+    if "JD_E2E_VAR_ENABLE_GPU_POOL" not in option_env_vars and not os.environ.get("JD_E2E_VAR_ENABLE_GPU_POOL"):
+        env_has_gpu_flag = False
+        if ENV_FILE.exists():
+            for line in ENV_FILE.read_text().splitlines():
+                if line.startswith("JD_E2E_VAR_ENABLE_GPU_POOL=") and line.split("=", 1)[1].strip():
+                    env_has_gpu_flag = True
+                    break
+        if not env_has_gpu_flag:
+            set_env_var("JD_E2E_VAR_ENABLE_GPU_POOL", "false")
+            print("  JD_E2E_VAR_ENABLE_GPU_POOL=false (default)")
 
     # 2. Fetch OAuth credentials from CI infrastructure
     print(f"\nFetching OAuth app #{oauth_app_num} credentials from CI ({ci_dir})...")


### PR DESCRIPTION
This PR enables the eks-oidc template to run GPU workspaces end to end. A `workspace_nodepools` entry can now declare an `accelerator` and reference template configs from the new `workspace_templates` variable; for these entries the platform installs the NVIDIA device plugin (the component that makes a node's GPUs schedulable to pods) and creates one workspace template per referenced config, each rendered as a create-page option by the web UI.

Deriving templates from pool entries keeps configuration in one place and prevents pool/template mismatches. Every GPU pool is fenced by its own role taint, so CPU workspaces never occupy GPU nodes. Workspace nodes are consolidated and their capacity reclaimed once every workspace on the node has stopped or idled out (Karpenter's `WhenEmpty` consolidation policy), so nodes with running notebooks are never evicted to reclaim capacity and user workflows are never interrupted.

Closes: #336

### User experience

Admins enable GPU workspaces in one of two ways, depending on how much they want to customize the pools:

1. Admins who just want to offer GPU workspaces and don't need custom settings such as their own instance families, `max_gpus` cap or idle shutdown timeout set `enable_default_gpu_pool: true` in the `overrides:` block of `variables.yaml` and run `jd config` and `jd up`. This adds a default GPU pool and workspace template: the `workspace-gpu` pool provisions on-demand instances from the `g4dn`, `g5`, `g6`, `g6e`, `g7` and `g7e` families, capped at 4 GPUs total, and the `jupyterlab-gpu` template offers one NVIDIA GPU per workspace with the deployment's default idle shutdown (60 minutes stock). A spec like this should be enough for the majority of single-GPU notebook work such as CUDA development, fine-tuning and inference on models that fit one GPU.
2. Admins who need a custom GPU setup, such as `p` instance pools, several GPU tiers with different idle rules, or their own capacity caps, write `workspace_nodepools` entries and `workspace_templates` configs directly in the same `overrides:` block. The pool entry declares the hardware side: instance families, disk size, capacity caps and the `accelerator`. The template config declares the workspace side: GPU count, cpu/memory, idle minutes, display name and description. The entry's `templates` key connects the two; one pool can offer several configs, and a config can be reused by pools that share a role. Full examples live in the [`workspace_nodepools`](https://github.com/andrii-i/jupyter-deploy/blob/f2a9be356bec2f7bf6b961b96f99dd743c9a7e50/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf#L248) and [`workspace_templates`](https://github.com/andrii-i/jupyter-deploy/blob/f2a9be356bec2f7bf6b961b96f99dd743c9a7e50/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/variables.tf#L376) docstrings and the [autoscaling docs page](https://github.com/andrii-i/jupyter-deploy/blob/f2a9be356bec2f7bf6b961b96f99dd743c9a7e50/docs/source/templates/aws-eks-oidc-template/autoscaling.md).

End-users pick a workspace type from plainly-named cards on the create page, with no pool or GPU knowledge needed: in the web UI, rendered by [jupyter-k8s-ui](https://github.com/jupyter-infra/jupyter-k8s-ui) (a separate package, not changed by this PR), each workspace template appears as one card.

### Implementation

1. `engine/variables.tf`: four new optional keys on `workspace_nodepools` entries: `accelerator` (device stack the pool provides; "nvidia" is the only supported value), `max_gpus` (fleet GPU ceiling; absent means unbounded; requires `accelerator`), `role` (node label/taint value; defaults to "workspaces", or to the pool name when `accelerator` is set, so each GPU pool is fenced by construction), and `templates` (comma-separated config names the pool offers).
2. `engine/variables.tf`: new `workspace_templates` variable, a list of named configs with `gpus`/`cpu`/`memory`, `idle_minutes`, `display_name` and `description`. Both variables keep the template's existing `list(map(string))` shape, so the new keys are optional strings; moving to `list(object)` with typed fields stays open for a later iteration if the config needs more structure or stricter validation.
3. `engine/workspaces.tf`: for each (pool entry, referenced config) pair, terraform creates one `WorkspaceTemplate` next to the existing `jupyterlab` one; the entry supplies placement (nodeSelector + toleration from its role), the config supplies the rest. A config with `gpus` must also set cpu and memory, and its card offers exactly those values with nothing for the user to adjust: the node is provisioned for the workspace, so a different cpu/memory pick would only change which instance Karpenter buys. A config without cpu/memory uses the same default values as the standard `jupyterlab` template. Several pools can offer the same config when they share a role; pools with different roles need separate configs, since the rendered template pins one nodeSelector.
4. `engine/platform_karpenter.tf`: `enable_default_gpu_pool` (renamed from `enable_gpu_pool`) injects the default `workspace-gpu` entry and `jupyterlab-gpu` config; combining the flag with hand-written accelerator entries raises a plan-time error.
5. `engine/platform_nvidia_device_plugin.tf`: the NVIDIA device plugin as a platform Helm release, installed whenever an accelerator entry exists; its DaemonSet targets nodes with the `nvidia.com/gpu.present` label and tolerates every GPU pool's taint, so several GPU pools work.
6. Scale-to-zero lifecycle: a GPU pool holds zero nodes and costs nothing until a GPU workspace starts, so the first start takes a few minutes (Karpenter provisions a node, the image is pulled). After the idle timeout (the deployment's `workspaces_idle_shutdown_timeout_default`, 60 minutes stock, shared with the `jupyterlab` template) the operator stops the workspace: its pod is deleted and the emptied node is reclaimed, while the workspace's EBS volume is kept. Restarting the workspace provisions a fresh node and reattaches the volume, so users resume with all their files intact.
7. Admins never pick an AMI and no separate GPU image is maintained, which removes both the setup burden and the risk of driver/version mismatches: GPU nodes boot with working NVIDIA drivers on their own. The `al2023@latest` AMI alias resolves GPU instance types to the NVIDIA variant, the AMI carries the driver, the container toolkit injects it into workspace containers, and CUDA ships in framework wheels.
8. Misconfiguration fails at plan time, not on the cluster: the flag conflict, duplicate pool or config names, `templates` referencing a missing config, cross-role config reuse, a `gpus` config offered by a pool without an accelerator (its workspaces could never schedule), `idle_minutes` or the deployment idle default outside the idle-shutdown window, an accelerator pool sharing a role with a CPU pool or claiming the base `jupyterlab` template's `workspaces` role (either would let CPU pods onto GPU nodes), any pool claiming the routing pool's `routing` role, a pool set that leaves no pool on the `workspaces` role the base template schedules on, and the pairing rules (`max_gpus` requires `accelerator`, `gpus` requires cpu and memory).
9. `charts/karpenter-nodepools`: workspace pool entries gain optional `role`, `gpu` and `maxGpus` values (`role` sets the node label and taint value, `gpu: "true"` adds the `nvidia.com/gpu.present` node label, `maxGpus` renders a `nvidia.com/gpu` limit); terraform maps `accelerator: nvidia` onto them. Entries without the new keys render exactly the same objects as before, so nothing changes for existing deployments (verified by tests).
10. AWS prerequisite: accounts without prior GPU usage have the `Running On-Demand G and VT instances` quota at 0 and need it raised before the first GPU node can launch; documented in the variable docstring and TROUBLESHOOT.

### Testing

- Added unit tests covering the default GPU pool and template rendering, custom pool scenarios
- Added e2e tests, opt-in via `JD_E2E_GPU_ENABLED`, testing the GPU workspace lifecycle and kernel-level CUDA
- Verified the user flows on a real deployment with GPUs available: deploy with the default GPU pool (`enable_default_gpu_pool: true`), a custom GPU pool with its own template config, autoscaling from and back to zero. Also tested the web UI flows end to end: create/open/stop/restart of a GPU workspace with files surviving onto a fresh node, automatic idle shutdown. Note that creating a GPU workspace from the card needs jupyter-infra/jupyter-k8s-ui#69 fixed first (verified with the GPU request patched onto the workspace).

Next steps beyond this PR:
- jupyter-infra/jupyter-k8s-ui#69
- `mig_profile` on a pool entry to offer fractions of a GPU, a `namespaces` field to copy a template into more workspace namespaces, and per-config images for other IDEs and non-NVIDIA hardware.
- Optional-component support in the CLI: currently GPU components do not appear in `jd component`/`jd health` because the manifest has no way to mark a component optional


### Screenshots

Create page with the GPU card selected: both template cards, locked image, pinned resources, 30-minute idle default
<img width="1274" height="907" alt="Screenshot 2026-08-20 at 1 26 03 AM" src="https://github.com/user-attachments/assets/542b27f1-bd43-4881-a53d-34af431900d4" />
<img width="1260" height="904" alt="Screenshot 2026-08-20 at 1 26 11 AM" src="https://github.com/user-attachments/assets/a0f1753a-636c-4c72-90fa-eabad652aae9" />

Running GPU workspace card
<img width="1283" height="903" alt="Screenshot 2026-08-20 at 1 36 08 AM" src="https://github.com/user-attachments/assets/f3c2b7b1-2823-405f-ae3f-9b027bbd35fe" />


