### PR TITLE
fix: allow karpenter to read its generated instance profiles

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/iam.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/iam.tf
@@ -353,10 +353,17 @@ data "aws_iam_policy_document" "karpenter_controller" {
     }
   }
 
+  # Must also cover the <cluster>_<hash> profile names Karpenter auto-generates:
+  # the EC2NodeClass termination reconciler probes them on every delete even in
+  # pre-created-profile mode, and a 403 there (vs the expected 404) blocks the
+  # finalizer, wedging the NodeClass in Terminating forever.
   statement {
-    sid       = "AllowInstanceProfileGet"
-    actions   = ["iam:GetInstanceProfile"]
-    resources = [aws_iam_instance_profile.karpenter_node.arn]
+    sid     = "AllowInstanceProfileGet"
+    actions = ["iam:GetInstanceProfile"]
+    resources = [
+      aws_iam_instance_profile.karpenter_node.arn,
+      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:instance-profile/${module.eks_cluster.cluster_name}_*",
+    ]
   }
 
   # Karpenter >=1.7 runs an instance-profile garbage-collection reconciler that calls

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/iam.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/iam.tf
@@ -353,10 +353,12 @@ data "aws_iam_policy_document" "karpenter_controller" {
     }
   }
 
-  # Must also cover the <cluster>_<hash> profile names Karpenter auto-generates:
-  # the EC2NodeClass termination reconciler probes them on every delete even in
-  # pre-created-profile mode, and a 403 there (vs the expected 404) blocks the
-  # finalizer, wedging the NodeClass in Terminating forever.
+  # Must also cover the <cluster>_<hash> profile names Karpenter auto-generates
+  # (EC2NodeClass.LegacyInstanceProfileName as of karpenter v1.13.1): the termination
+  # reconciler probes them on every delete even in pre-created-profile mode, and a 403
+  # there (vs the expected 404) blocks the finalizer, leaving the NodeClass stuck in
+  # Terminating. New-style profiles live under an IAM path (/karpenter/<region>/...)
+  # and are only touched by ListInstanceProfiles, granted below.
   statement {
     sid     = "AllowInstanceProfileGet"
     actions = ["iam:GetInstanceProfile"]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -114,6 +114,21 @@ def test_all_eks_addons_gated_by_cluster_addons() -> None:
     )
 
 
+def test_karpenter_can_read_generated_instance_profiles() -> None:
+    """The AllowInstanceProfileGet statement MUST cover the <cluster>_* instance
+    profile names Karpenter generates: its EC2NodeClass termination reconciler
+    probes them with GetInstanceProfile, and a 403 there (vs the expected 404)
+    blocks the finalizer, wedging the NodeClass in Terminating forever.
+    """
+    iam_tf = (TEMPLATE_PATH / "engine" / "iam.tf").read_text()
+    statement = re.search(r'sid\s*=\s*"AllowInstanceProfileGet"(.*?)(?=\n  statement)', iam_tf, re.DOTALL)
+    assert statement is not None, "AllowInstanceProfileGet statement not found in iam.tf"
+    assert "instance-profile/${module.eks_cluster.cluster_name}_*" in statement.group(1), (
+        "iam:GetInstanceProfile no longer covers Karpenter's generated <cluster>_* "
+        "instance profiles — deleting an EC2NodeClass will wedge on a 403 probe."
+    )
+
+
 def _iter_resource_blocks(content: str) -> list[tuple[str, str, str]]:
     """Yield (resource_type, resource_name, body) for every resource block in content."""
     blocks: list[tuple[str, str, str]] = []

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -115,17 +115,15 @@ def test_all_eks_addons_gated_by_cluster_addons() -> None:
 
 
 def test_karpenter_can_read_generated_instance_profiles() -> None:
-    """The AllowInstanceProfileGet statement MUST cover the <cluster>_* instance
-    profile names Karpenter generates: its EC2NodeClass termination reconciler
-    probes them with GetInstanceProfile, and a 403 there (vs the expected 404)
-    blocks the finalizer, wedging the NodeClass in Terminating forever.
+    """Karpenter's termination reconciler probes generated <cluster>_* profile
+    names with GetInstanceProfile; a 403 there blocks EC2NodeClass deletion (#349).
     """
     iam_tf = (TEMPLATE_PATH / "engine" / "iam.tf").read_text()
-    statement = re.search(r'sid\s*=\s*"AllowInstanceProfileGet"(.*?)(?=\n  statement)', iam_tf, re.DOTALL)
+    statement = re.search(r'sid\s*=\s*"AllowInstanceProfileGet"(.*?)(?=\n  statement|\n\})', iam_tf, re.DOTALL)
     assert statement is not None, "AllowInstanceProfileGet statement not found in iam.tf"
     assert "instance-profile/${module.eks_cluster.cluster_name}_*" in statement.group(1), (
         "iam:GetInstanceProfile no longer covers Karpenter's generated <cluster>_* "
-        "instance profiles — deleting an EC2NodeClass will wedge on a 403 probe."
+        "instance profiles; deleting an EC2NodeClass will hang on a 403 probe (#349)."
     )
 
 

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_eks_template.py
@@ -114,16 +114,36 @@ def test_all_eks_addons_gated_by_cluster_addons() -> None:
     )
 
 
+def _extract_statement_block(content: str, sid: str) -> str:
+    """Return the body of the policy `statement { ... }` carrying `sid`, comment lines stripped."""
+    for start in re.finditer(r"statement\s*\{", content):
+        depth = 1
+        idx = start.end()
+        while idx < len(content) and depth > 0:
+            if content[idx] == "{":
+                depth += 1
+            elif content[idx] == "}":
+                depth -= 1
+            idx += 1
+        body = content[start.end() : idx - 1]
+        if re.search(rf'sid\s*=\s*"{re.escape(sid)}"', body):
+            return "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
+    raise AssertionError(f'statement with sid "{sid}" not found in content')
+
+
 def test_karpenter_can_read_generated_instance_profiles() -> None:
     """Karpenter's termination reconciler probes generated <cluster>_* profile
     names with GetInstanceProfile; a 403 there blocks EC2NodeClass deletion (#349).
     """
     iam_tf = (TEMPLATE_PATH / "engine" / "iam.tf").read_text()
-    statement = re.search(r'sid\s*=\s*"AllowInstanceProfileGet"(.*?)(?=\n  statement|\n\})', iam_tf, re.DOTALL)
-    assert statement is not None, "AllowInstanceProfileGet statement not found in iam.tf"
-    assert "instance-profile/${module.eks_cluster.cluster_name}_*" in statement.group(1), (
+    statement = _extract_statement_block(iam_tf, "AllowInstanceProfileGet")
+    assert "instance-profile/${module.eks_cluster.cluster_name}_*" in statement, (
         "iam:GetInstanceProfile no longer covers Karpenter's generated <cluster>_* "
         "instance profiles; deleting an EC2NodeClass will hang on a 403 probe (#349)."
+    )
+    assert "aws_iam_instance_profile.karpenter_node.arn" in statement, (
+        "iam:GetInstanceProfile no longer covers the pre-created node profile; "
+        "Karpenter's read of the profile recorded in Status.InstanceProfile will fail."
     )
 
 


### PR DESCRIPTION
Fixes #349.

Adds the cluster-prefixed generated names to the `AllowInstanceProfileGet` statement: `arn:<partition>:iam::<account>:instance-profile/<cluster>_*` alongside the pre-created profile ARN. With the read allowed on those names, IAM would no longer reject the probe before it can look anything up: the lookup finds no such profile and returns `NoSuchEntity`, which the reconciler treats as nothing to clean up, so the finalizer clears and deletion completes. The added permission is read-only.