### PR TITLE
fix: drop instance-cpu allowlist from accelerator pools

### DIFF
--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
@@ -89,10 +89,11 @@ spec:
         - key: karpenter.k8s.aws/instance-family
           operator: In
           values: {{ .instanceFamilies | toJson }}
-        {{- /* Template comment (not rendered): accelerator families ship sizes
-             above this allowlist (p4d.24xlarge = 96 vCPUs, p5en.48xlarge = 192),
-             so on a GPU pool it can only exclude instances; the family list and
-             the gpu limit already pin the node size there. */}}
+        {{- /* On an accelerator pool the workspace's GPU request and the family
+             list determine the node choice; vCPU is noise there, and accelerator
+             families ship sizes far above this allowlist (p4d.24xlarge = 96
+             vCPUs), so the allowlist could only exclude instances. Per-node
+             size is deliberately unbounded on accelerator pools. */}}
         {{- if not .gpu }}
         - key: karpenter.k8s.aws/instance-cpu
           operator: In

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
@@ -89,11 +89,9 @@ spec:
         - key: karpenter.k8s.aws/instance-family
           operator: In
           values: {{ .instanceFamilies | toJson }}
-        {{- /* On an accelerator pool the workspace's GPU request and the family
-             list determine the node choice; vCPU is noise there, and accelerator
-             families ship sizes far above this allowlist (p4d.24xlarge = 96
-             vCPUs), so the allowlist could only exclude instances. Per-node
-             size is deliberately unbounded on accelerator pools. */}}
+        {{- /* Accelerator families ship sizes above this allowlist (p4d.24xlarge =
+             96 vCPUs), so it would block their provisioning (#351). Per-node size
+             is deliberately unbounded on accelerator pools (#352 review). */}}
         {{- if not .gpu }}
         - key: karpenter.k8s.aws/instance-cpu
           operator: In

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/templates/nodepools.yaml
@@ -89,9 +89,15 @@ spec:
         - key: karpenter.k8s.aws/instance-family
           operator: In
           values: {{ .instanceFamilies | toJson }}
+        {{- /* Template comment (not rendered): accelerator families ship sizes
+             above this allowlist (p4d.24xlarge = 96 vCPUs, p5en.48xlarge = 192),
+             so on a GPU pool it can only exclude instances; the family list and
+             the gpu limit already pin the node size there. */}}
+        {{- if not .gpu }}
         - key: karpenter.k8s.aws/instance-cpu
           operator: In
           values: ["2", "4", "8", "16", "32"]
+        {{- end }}
         - key: karpenter.sh/capacity-type
           operator: In
           values: ["on-demand"]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/values.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/charts/karpenter-nodepools/values.yaml
@@ -24,5 +24,6 @@ routingLimitsMemory: "128Gi"
 # Injected by platform_karpenter.tf from var.workspace_nodepools.
 # Optional per-entry keys: role (label/taint value, defaults to "workspaces"),
 # maxGpus (renders a nvidia.com/gpu NodePool limit), gpu ("true" adds the
-# nvidia.com/gpu.present node label the NVIDIA device plugin selects on).
+# nvidia.com/gpu.present node label the NVIDIA device plugin selects on and
+# drops the instance-cpu size allowlist from the pool's requirements).
 workspaceNodepools: []

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/jupyter_deploy_tf_aws_eks_oidc/template/engine/platform_karpenter.tf
@@ -332,9 +332,10 @@ resource "helm_release" "karpenter_nodepools" {
           },
           contains(keys(p), "role") ? { role = p["role"] } : {},
           contains(keys(p), "max_gpus") ? { maxGpus = p["max_gpus"] } : {},
-          # The chart's gpu value adds the nvidia.com/gpu.present node label;
-          # the key stays at the chart boundary so rendered pool bytes are
-          # untouched by the accelerator rename.
+          # The chart's gpu value adds the nvidia.com/gpu.present node label and
+          # drops the instance-cpu allowlist from the pool's requirements; the key
+          # stays at the chart boundary so rendered pool bytes are untouched by
+          # the accelerator rename.
           lookup(p, "accelerator", "") == "nvidia" ? { gpu = "true" } : {},
         )
       ]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_accel_unbounded.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_accel_unbounded.yaml
@@ -1,0 +1,184 @@
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+# EC2NodeClasses define the AWS-level node configuration for Karpenter.
+# One class per pool (routing + each workspace pool).
+# All pools pin httpPutResponseHopLimit: 1 — no routing or workspace pod needs
+# IMDS: cert-manager/external-dns use Pod Identity, and traefik/dex/oauth2-proxy/
+# authmiddleware/web-app make no AWS calls. Hop 1 blocks containerized pods from
+# reaching IMDS to assume the node role; node agents (CNI, EBS CSI) use
+# hostNetwork and reach IMDS at hop 1, so they are unaffected.
+# Both pin httpTokens: required (IMDSv2).
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+# NodePools define scheduling constraints and node lifecycle for Karpenter.
+# Routing pool: always-on, conservative consolidation, small instances.
+# Workspace pools: scale-to-zero, aggressive consolidation, diverse instances.
+# Both carry taints so only pods with matching tolerations can land here.
+# A workspace pool may set a per-pool role (label + taint value) so that only
+# workspace templates tolerating that role reach it — this is what keeps CPU
+# workspaces off GPU nodes and GPU workspaces on nodes that advertise a device.
+#
+# Disruption budget: nodes: "1" (absolute, not percentage).
+# Karpenter applies the MINIMUM of all active budgets. A percentage budget
+# (e.g. 10%) rounds down to 0 on small pools (floor(0.1×1)=0), and
+# min(0,1)=0 — the absolute floor cannot raise a zero from the percentage.
+# Using only the absolute entry guarantees at least 1 node is always
+# disruptable, enabling scale-to-zero on workspace pools.
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: routing
+spec:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  instanceProfile: "test-karpenter-node-profile"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  tags:
+    karpenter.sh/cluster-name: "test-cluster"
+  metadataOptions:
+    httpPutResponseHopLimit: 1
+    httpEndpoint: enabled
+    httpTokens: required
+    httpProtocolIPv6: disabled
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        volumeSize: 50Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+---
+# Source: karpenter-nodepools/templates/ec2nodeclasses.yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: workspace-gpu-p
+spec:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  instanceProfile: "test-karpenter-node-profile"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "test-cluster"
+  tags:
+    karpenter.sh/cluster-name: "test-cluster"
+  metadataOptions:
+    httpPutResponseHopLimit: 1
+    httpEndpoint: enabled
+    httpTokens: required
+    httpProtocolIPv6: disabled
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        # Root volume: OS + container image cache. User data (notebooks, files)
+        # lives on the EBS volume mounted by the workspace pod via StorageClass.
+        # Override disk_size_gb in workspace_nodepools for large custom images.
+        volumeSize: 200Gi
+        volumeType: gp3
+        encrypted: true
+        deleteOnTermination: true
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: routing
+spec:
+  template:
+    metadata:
+      labels:
+        jupyter-deploy/role: routing
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: routing
+      taints:
+        - key: jupyter-deploy/role
+          value: routing
+          effect: NoSchedule
+      expireAfter: 504h
+      requirements:
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c","m"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["6"]
+        - key: karpenter.k8s.aws/instance-size
+          operator: In
+          values: ["large", "xlarge", "2xlarge"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+  limits:
+    cpu: "32"
+    memory: "128Gi"
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 120s
+    budgets:
+      - nodes: "1"
+---
+# Source: karpenter-nodepools/templates/nodepools.yaml
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: workspace-gpu-p
+spec:
+  template:
+    metadata:
+      labels:
+        # Default preserves the exact pre-GPU bytes: Karpenter hashes
+        # spec.template, so any change here drift-replaces the pool's nodes
+        # and restarts every workspace on them. Set values render quoted: an
+        # unquoted role like "on" would parse as a YAML boolean and fail apply.
+        jupyter-deploy/role: "workspace-gpu-p"
+        # Satisfies the NVIDIA device plugin's default nodeAffinity without NFD.
+        nvidia.com/gpu.present: "true"
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: workspace-gpu-p
+      taints:
+        - key: jupyter-deploy/role
+          value: "workspace-gpu-p"
+          effect: NoSchedule
+      expireAfter: 504h
+      requirements:
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: ["p4d","p5","p5en"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+  limits:
+    cpu: "384"
+    memory: "3000Gi"
+  disruption:
+    # WhenEmpty (not WhenEmptyOrUnderutilized): workspace pods carry no PDB and
+    # no karpenter.sh/do-not-disrupt annotation, so underutilized-consolidation
+    # would be free to evict a running notebook to bin-pack. Restricting to
+    # WhenEmpty means a node is only reclaimed once idle-shutdown has drained its
+    # last workspace pod — scale-to-zero still works, running notebooks are safe.
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 60s
+    budgets:
+      - nodes: "1"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu_gpu.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/golden_karpenter_nodepools_cpu_gpu.yaml
@@ -247,9 +247,6 @@ spec:
         - key: karpenter.k8s.aws/instance-family
           operator: In
           values: ["g4dn","g5","g6","g6e","g7","g7e"]
-        - key: karpenter.k8s.aws/instance-cpu
-          operator: In
-          values: ["2", "4", "8", "16", "32"]
         - key: karpenter.sh/capacity-type
           operator: In
           values: ["on-demand"]

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_accel_unbounded.yaml
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/chart_render_data/values_karpenter_accel_unbounded.yaml
@@ -1,0 +1,22 @@
+# An accelerator entry without maxGpus, as platform_karpenter.tf emits for a custom
+# pool that sets accelerator but not max_gpus (the docs' p4d,p5,p5en example).
+clusterName: test-cluster
+nodeInstanceProfile: test-karpenter-node-profile
+expireAfter: 504h
+routingLimitsCpu: "32"
+routingLimitsMemory: 128Gi
+routing:
+  instanceCategories: ["c", "m"]
+  instanceGenerationMin: "6"
+  blockDevice:
+    deviceName: /dev/xvda
+    volumeSizeGi: 50
+    volumeType: gp3
+workspaceNodepools:
+  - name: workspace-gpu-p
+    instanceFamilies: ["p4d", "p5", "p5en"]
+    diskSizeGi: 200
+    maxCpu: "384"
+    maxMemory: 3000Gi
+    role: workspace-gpu-p
+    gpu: "true"

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -142,6 +142,15 @@ class TestKarpenterNodepoolsGpuRender(GoldenComparisonTestCase):
         self.assertEqual(self.gpu_pool["spec"]["limits"].get("nvidia.com/gpu"), "4")
         self.assertNotIn("nvidia.com/gpu", self.cpu_pool["spec"]["limits"])
 
+    def test_gpu_nodepool_no_instance_cpu_allowlist(self) -> None:
+        """Accelerator families ship sizes above the CPU allowlist (p4d.24xlarge
+        = 96 vCPUs); a GPU pool carrying it could never provision those families.
+        """
+        gpu_keys = {req["key"] for req in self.gpu_pool["spec"]["template"]["spec"]["requirements"]}
+        self.assertNotIn("karpenter.k8s.aws/instance-cpu", gpu_keys)
+        cpu_keys = {req["key"] for req in self.cpu_pool["spec"]["template"]["spec"]["requirements"]}
+        self.assertIn("karpenter.k8s.aws/instance-cpu", cpu_keys)
+
     def test_gpu_nodepool_instance_families(self) -> None:
         requirements = {req["key"]: req for req in self.gpu_pool["spec"]["template"]["spec"]["requirements"]}
         self.assertEqual(

--- a/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
+++ b/libs/jupyter-deploy-tf-aws-eks-oidc/tests/unit/test_chart_render.py
@@ -163,6 +163,31 @@ class TestKarpenterNodepoolsGpuRender(GoldenComparisonTestCase):
 
 
 @_SKIP_WITHOUT_HELM
+class TestKarpenterNodepoolsAccelUnboundedRender(GoldenComparisonTestCase):
+    """An accelerator entry without maxGpus renders no instance-cpu allowlist and
+    no nvidia.com/gpu limit: per-node size is deliberately unbounded (#352 review).
+    """
+
+    rendered: ClassVar[str]
+    pool: ClassVar[dict[str, Any]]
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rendered = _helm_template(
+            "charts/karpenter-nodepools", "karpenter-nodepools", "values_karpenter_accel_unbounded.yaml"
+        )
+        cls.pool = yaml.safe_load(_doc_chunks(cls.rendered)[("NodePool", "workspace-gpu-p")])
+
+    def test_render_matches_golden(self) -> None:
+        self.compare_to_golden(self.rendered, "golden_karpenter_nodepools_accel_unbounded.yaml")
+
+    def test_no_instance_cpu_and_no_gpu_limit(self) -> None:
+        keys = {req["key"] for req in self.pool["spec"]["template"]["spec"]["requirements"]}
+        self.assertNotIn("karpenter.k8s.aws/instance-cpu", keys)
+        self.assertNotIn("nvidia.com/gpu", self.pool["spec"]["limits"])
+
+
+@_SKIP_WITHOUT_HELM
 class TestWorkspaceDefaultsDefaultRender(GoldenComparisonTestCase):
     """Default workspace-defaults render carries exactly the jupyterlab template."""
 


### PR DESCRIPTION
Fixes #351.

Omits the instance-cpu requirement for accelerator pools. With the requirement gone, the pool's instance families and the workspace's GPU request determine the node size, and Karpenter provisions the cheapest instance that satisfies the pending pod, so small workloads still get small nodes.