### PR TITLE
fix: github hostname in plugin

### DIFF
--- a/libs/pytest-jupyter-deploy/pyproject.toml
+++ b/libs/pytest-jupyter-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytest-jupyter-deploy"
-version = "0.2.11"
+version = "0.2.12"
 description = "Pytest plugin for E2E testing of jupyter-deploy templates"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/dex.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/dex.py
@@ -45,13 +45,9 @@ class DexGitHubOAuth2ProxyApplication(GitHubOAuth2ProxyApplication):
             except Exception:
                 self._handle_oauth_authorize_page()
 
-        if self._is_on_app_domain():
-            return True
-
-        if "github.com" in self.page.url:
-            return False
-
-        return False
+        # Back on the app domain means the flow completed; otherwise we are still
+        # mid-flow (GitHub/Dex) or on an error page.
+        return self._is_on_app_domain()
 
     def _try_auth_session(self) -> bool:
         """Try authenticating through the Dex OAuth flow with existing cookies.

--- a/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
+++ b/libs/pytest-jupyter-deploy/pytest_jupyter_deploy/oauth2_proxy/github.py
@@ -300,7 +300,7 @@ class GitHubOAuth2ProxyApplication:
             return True
 
         # Check if we ended up on the GitHub login page (cookies expired)
-        if "github.com" in current_url:
+        if urlparse(current_url).hostname == "github.com":
             # Page is on GitHub login — caller must handle credentials
             return False
 
@@ -363,7 +363,7 @@ class GitHubOAuth2ProxyApplication:
                 self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=5000)
             except Exception:
                 self._handle_oauth_authorize_page()
-        elif "github.com" in current_url:
+        elif urlparse(current_url).hostname == "github.com":
             # Wait a bit for any redirects to complete
             with contextlib.suppress(Exception):
                 self.page.wait_for_url(lambda url: urlparse(url).hostname != "github.com", timeout=10000)
@@ -461,7 +461,7 @@ class GitHubOAuth2ProxyApplication:
         """
         current_url = self.page.url
         # If we're on GitHub or see the OAuth2 sign-in button, not authenticated
-        if "github.com" in current_url:
+        if urlparse(current_url).hostname == "github.com":
             return False
         if self.page.get_by_role("button", name="Sign in with GitHub").is_visible():
             return False

--- a/uv.lock
+++ b/uv.lock
@@ -2178,7 +2178,7 @@ wheels = [
 
 [[package]]
 name = "pytest-jupyter-deploy"
-version = "0.2.11"
+version = "0.2.12"
 source = { editable = "libs/pytest-jupyter-deploy" }
 dependencies = [
     { name = "jupyter-deploy" },


### PR DESCRIPTION
This PR fixes the E2E GitHub OAuth helper mistaking the app's own URL for the GitHub login page. GitHub now appends `&iss=…github.com…` (RFC 9207) to its OAuth callback, so a rejected user's oauth2-proxy error page — served on the app domain — matched the helper's substring `"github.com" in current_url` check, and the harness tried to re-fill GitHub login fields, leading to a `TimeoutError`. Comparing the parsed hostname to `github.com` fixes it.

Closes: #362

### Implementation
1. `pytest-jupyter-deploy/oauth2_proxy/github.py`: replace the three bare `"github.com" in url` checks with `urlparse(url).hostname == "github.com"`
2. `pytest-jupyter-deploy/oauth2_proxy/dex.py`: drop the equivalent dead substring branch (both arms returned `False`) → `return self._is_on_app_domain()`
3. bump plugin to `0.2.12` for the canary release

### Testing
- e2e: `test_org_and_teams.py` against a live base-template deployment; all 10 pass (previously errored in setup)
- e2e: `test_workspace_jupyterlab.py` against a live eks-oidc deployment; exercises the touched Dex flow, passes