### PR TITLE
chore: proxy ci

### DIFF
--- a/.github/AGENT.md
+++ b/.github/AGENT.md
@@ -4,9 +4,10 @@
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `ci.yml` | push/PR | Lint + unit tests |
-| `lint.yml`, `test.yml` | `workflow_call` | Reusable lint/test jobs |
+| `ci.yml` | push/PR | Lint + unit tests + client-proxy functional tests |
+| `lint.yml`, `test.yml`, `functional-test.yml` | `workflow_call` | Reusable lint / unit-test / client-proxy functional-test jobs |
 | `release-cli.yml` | `workflow_dispatch` | Release `jupyter-deploy` CLI to PyPI — pre-publish smoke gate (local wheel) → Test PyPI → E2E gate → PyPI |
+| `release-proxy.yml` | `workflow_dispatch` | Release `jupyter-deploy-client-proxy` to PyPI — functional gate → Test PyPI → CLI-with-proxy smoke → PyPI (no live-deploy E2E; cloud-blind) |
 | `release-base.yml` | `workflow_dispatch` | Release `jupyter-deploy-tf-aws-ec2-base` to PyPI (with E2E gate) |
 | `release-plugin.yml` | `workflow_dispatch` | Release `pytest-jupyter-deploy` to PyPI |
 | `e2e-cli.yml` | `workflow_call` | CLI release E2E gate — smoke tests (bare/aws/aws-k8s) + functional tests against base app #2 and EKS app #5 |
@@ -59,7 +60,11 @@ deploys the published package). The ~30-min deploy is readable in its own job; t
 
 Lessons from coordinated plugin/CLI/template releases — read before releasing:
 
-- **Release order for coupled changes: plugin → CLI → templates.** A template's
+- **Release order for coupled changes: plugin → proxy → CLI → templates.** The CLI's `[proxy]`
+  extra pins `jupyter-deploy-client-proxy>=0.1.0`; publish the proxy (a final, non-pre-release
+  version) **before** a CLI release so the CLI's `[proxy]` extra resolves from prod PyPI. (A
+  pre-release like `0.1.0rc1` does NOT satisfy `>=0.1.0` — the CLI-with-proxy smoke in
+  `release-proxy.yml` pins the exact version to work around this for the gate.) A template's
   `manifest.yaml` can require CLI features (e.g. new component/health command schema);
   the eks-oidc release gate installs the CLI *unpinned from prod PyPI*, so the CLI must
   be published **first** or the gate's deploy fails at `jd config` with a manifest schema

--- a/.github/AGENT.md
+++ b/.github/AGENT.md
@@ -7,7 +7,7 @@
 | `ci.yml` | push/PR | Lint + unit tests + client-proxy functional tests |
 | `lint.yml`, `test.yml`, `functional-test.yml` | `workflow_call` | Reusable lint / unit-test / client-proxy functional-test jobs |
 | `release-cli.yml` | `workflow_dispatch` | Release `jupyter-deploy` CLI to PyPI — pre-publish smoke gate (local wheel) → Test PyPI → E2E gate → PyPI |
-| `release-proxy.yml` | `workflow_dispatch` | Release `jupyter-deploy-client-proxy` to PyPI — functional gate → Test PyPI → CLI-with-proxy smoke → PyPI (no live-deploy E2E; cloud-blind) |
+| `release-proxy.yml` | `workflow_dispatch` | Release `jupyter-deploy-client-proxy` to PyPI — functional gate → Test PyPI → PyPI (no live-deploy E2E; cloud-blind) |
 | `release-base.yml` | `workflow_dispatch` | Release `jupyter-deploy-tf-aws-ec2-base` to PyPI (with E2E gate) |
 | `release-plugin.yml` | `workflow_dispatch` | Release `pytest-jupyter-deploy` to PyPI |
 | `e2e-cli.yml` | `workflow_call` | CLI release E2E gate — smoke tests (bare/aws/aws-k8s) + functional tests against base app #2 and EKS app #5 |
@@ -62,9 +62,8 @@ Lessons from coordinated plugin/CLI/template releases — read before releasing:
 
 - **Release order for coupled changes: plugin → proxy → CLI → templates.** The CLI's `[proxy]`
   extra pins `jupyter-deploy-client-proxy>=0.1.0`; publish the proxy (a final, non-pre-release
-  version) **before** a CLI release so the CLI's `[proxy]` extra resolves from prod PyPI. (A
-  pre-release like `0.1.0rc1` does NOT satisfy `>=0.1.0` — the CLI-with-proxy smoke in
-  `release-proxy.yml` pins the exact version to work around this for the gate.) A template's
+  version) **before** a CLI release so the CLI's `[proxy]` extra resolves from prod PyPI. (Note a
+  pre-release like `0.1.0rc1` does NOT satisfy `>=0.1.0` — a final version is required.) A template's
   `manifest.yaml` can require CLI features (e.g. new component/health command schema);
   the eks-oidc release gate installs the CLI *unpinned from prod PyPI*, so the CLI must
   be published **first** or the gate's deploy fails at `jd config` with a manifest schema

--- a/.github/e2e-cli/Dockerfile
+++ b/.github/e2e-cli/Dockerfile
@@ -33,11 +33,13 @@ ARG INDEX_FORMAT=""
 USER root
 COPY --chown=testuser:testuser pyproject.toml /workspace/
 COPY --chown=testuser:testuser libs/jupyter-deploy/pyproject.toml /workspace/libs/jupyter-deploy/
+COPY --chown=testuser:testuser libs/jupyter-deploy-client-proxy/pyproject.toml /workspace/libs/jupyter-deploy-client-proxy/
 COPY --chown=testuser:testuser libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml /workspace/libs/jupyter-deploy-tf-aws-ec2-base/
+COPY --chown=testuser:testuser libs/jupyter-deploy-tf-aws-ec2-jupyterlab/pyproject.toml /workspace/libs/jupyter-deploy-tf-aws-ec2-jupyterlab/
 COPY --chown=testuser:testuser libs/jupyter-deploy-tf-aws-eks-oidc/pyproject.toml /workspace/libs/jupyter-deploy-tf-aws-eks-oidc/
 COPY --chown=testuser:testuser libs/jupyter-infra-tf-aws-iam-ci/pyproject.toml /workspace/libs/jupyter-infra-tf-aws-iam-ci/
 COPY --chown=testuser:testuser libs/pytest-jupyter-deploy/pyproject.toml /workspace/libs/pytest-jupyter-deploy/
-RUN for lib in jupyter-deploy jupyter-deploy-tf-aws-ec2-base jupyter-deploy-tf-aws-eks-oidc jupyter-infra-tf-aws-iam-ci pytest-jupyter-deploy; do \
+RUN for lib in jupyter-deploy jupyter-deploy-client-proxy jupyter-deploy-tf-aws-ec2-base jupyter-deploy-tf-aws-ec2-jupyterlab jupyter-deploy-tf-aws-eks-oidc jupyter-infra-tf-aws-iam-ci pytest-jupyter-deploy; do \
         touch /workspace/libs/$lib/LICENSE /workspace/libs/$lib/README.md; \
     done && chown -R testuser /workspace/libs
 USER testuser

--- a/.github/e2e-shared/Dockerfile
+++ b/.github/e2e-shared/Dockerfile
@@ -36,11 +36,13 @@ ARG TEMPLATE=base
 USER root
 COPY --chown=testuser:testuser pyproject.toml /workspace/
 COPY --chown=testuser:testuser libs/jupyter-deploy/pyproject.toml /workspace/libs/jupyter-deploy/
+COPY --chown=testuser:testuser libs/jupyter-deploy-client-proxy/pyproject.toml /workspace/libs/jupyter-deploy-client-proxy/
 COPY --chown=testuser:testuser libs/jupyter-deploy-tf-aws-ec2-base/pyproject.toml /workspace/libs/jupyter-deploy-tf-aws-ec2-base/
+COPY --chown=testuser:testuser libs/jupyter-deploy-tf-aws-ec2-jupyterlab/pyproject.toml /workspace/libs/jupyter-deploy-tf-aws-ec2-jupyterlab/
 COPY --chown=testuser:testuser libs/jupyter-deploy-tf-aws-eks-oidc/pyproject.toml /workspace/libs/jupyter-deploy-tf-aws-eks-oidc/
 COPY --chown=testuser:testuser libs/jupyter-infra-tf-aws-iam-ci/pyproject.toml /workspace/libs/jupyter-infra-tf-aws-iam-ci/
 COPY --chown=testuser:testuser libs/pytest-jupyter-deploy/pyproject.toml /workspace/libs/pytest-jupyter-deploy/
-RUN for lib in jupyter-deploy jupyter-deploy-tf-aws-ec2-base jupyter-deploy-tf-aws-eks-oidc jupyter-infra-tf-aws-iam-ci pytest-jupyter-deploy; do \
+RUN for lib in jupyter-deploy jupyter-deploy-client-proxy jupyter-deploy-tf-aws-ec2-base jupyter-deploy-tf-aws-ec2-jupyterlab jupyter-deploy-tf-aws-eks-oidc jupyter-infra-tf-aws-iam-ci pytest-jupyter-deploy; do \
         touch /workspace/libs/$lib/LICENSE /workspace/libs/$lib/README.md; \
     done && chown -R testuser /workspace/libs
 USER testuser

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,12 @@ jobs:
     with:
       working-directory: ${{ matrix.working-directory }}
 
+  # The client-proxy functional suite is excluded from the per-dir `test` run (root
+  # `norecursedirs`), so it runs here on every PR as its own job.
+  functional-test:
+    name: Run functional tests
+    uses: ./.github/workflows/functional-test.yml
+
   docs-sync:
     name: Verify CLI reference docs are in sync
     runs-on: ubuntu-latest

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -1,0 +1,35 @@
+name: functional-test
+
+# Reusable: the client-proxy functional suite (real proxy in-process against a trustme
+# self-signed origin — no cloud). Excluded from the root `unit-test` run via `norecursedirs`,
+# so it needs its own job. Called by `ci.yml` (on PRs touching the proxy) and `release-proxy.yml`.
+on:
+  workflow_call:
+
+jobs:
+  functional-test:
+    name: Run client-proxy functional tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.12', '3.13']
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: ${{ matrix.python-version }}
+          working-directory: '.'
+
+      - name: Install just
+        uses: ./.github/actions/install-just
+
+      - name: Install unpinned dependencies
+        run: |
+          rm -f uv.lock
+          uv sync --all-extras
+
+      - name: Run functional tests
+        run: just functional-test

--- a/.github/workflows/release-proxy.yml
+++ b/.github/workflows/release-proxy.yml
@@ -1,0 +1,224 @@
+name: Release proxy (jupyter-deploy-client-proxy)
+
+run-name: Release jupyter-deploy-client-proxy
+
+# Mirrors release-plugin.yml (no live-deploy E2E gate — the proxy is cloud-blind). Its gate is
+# the offline functional suite; the Test PyPI install-check doubles as a CLI-with-proxy smoke.
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+      pkg-name: ${{ steps.get-version.outputs.pkg-name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: '3.13'
+          working-directory: '.'
+
+      - name: Build package
+        run: |
+          cd libs/jupyter-deploy-client-proxy
+          uv build
+
+      - name: Get package version
+        id: get-version
+        run: |
+          cd libs/jupyter-deploy-client-proxy
+          echo version=$(uv version --short) >> $GITHUB_OUTPUT
+          echo pkg-name="$(uv version | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  lint:
+    name: Run linters
+    needs: [build]
+    uses: ./.github/workflows/lint.yml
+    with:
+      working-directory: libs/jupyter-deploy-client-proxy
+
+  test:
+    name: Run tests
+    needs: [lint]
+    uses: ./.github/workflows/test.yml
+    with:
+      working-directory: libs/jupyter-deploy-client-proxy
+
+  functional:
+    name: Run functional tests
+    needs: [test]
+    uses: ./.github/workflows/functional-test.yml
+
+  test-pypi-publish:
+    name: Publish to Test PyPI
+    needs: [functional, build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: test-release
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: List build artifacts
+        run: ls -la dist/
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Publish to Test PyPI
+        run: |
+          uv publish \
+            --publish-url https://test.pypi.org/legacy/ \
+            --check-url https://test.pypi.org/simple \
+            --trusted-publishing always
+
+  test-pypi-install:
+    name: Check Test PyPI build + CLI-with-proxy smoke
+    needs: [test-pypi-publish, build]
+    runs-on: ubuntu-latest
+    env:
+      PKG_NAME: ${{ needs.build.outputs.pkg-name }}
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Wait for Test PyPI availability
+        run: |
+          url="https://test.pypi.org/pypi/${PKG_NAME}/${VERSION}/json"
+          echo "Polling ${url}"
+          for i in $(seq 1 20); do
+            if curl -fsS -o /dev/null "${url}"; then
+              echo "${PKG_NAME}==${VERSION} is available on Test PyPI"
+              exit 0
+            fi
+            echo "Attempt ${i}/20: not yet available, retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::${PKG_NAME}==${VERSION} did not appear on Test PyPI within 5 minutes"
+          exit 1
+
+      - name: Test installation from Test PyPI
+        run: |
+          uv venv
+          for i in 1 2; do
+            if uv pip install \
+              --extra-index-url https://test.pypi.org/simple/ \
+              --index-strategy unsafe-best-match \
+              ${{ env.PKG_NAME }}==${{ env.VERSION }} 2>&1 | tee /tmp/install.log; then
+              exit 0
+            fi
+            if ! grep -qi "No solution found\|no version of" /tmp/install.log; then
+              echo "::error::Install failed with non-transient error"
+              exit 1
+            fi
+            echo "Attempt ${i}/2 failed (package not yet installable), retrying in 60s..."
+            sleep 60
+          done
+          echo "::error::Test PyPI install failed after 2 attempts"
+          exit 1
+
+      # CLI-with-proxy smoke: install the CLI (prod PyPI, [aws]) alongside the just-published
+      # proxy build (Test PyPI, pinned exactly so a pre-release like 0.1.0rc1 resolves — the
+      # CLI's [proxy] extra pins `>=0.1.0`, which excludes pre-releases). Assert the proxy
+      # console script is on PATH and `jd proxy` is wired.
+      - name: CLI-with-proxy smoke
+        run: |
+          uv venv smoke-venv
+          uv pip install --python smoke-venv \
+            --extra-index-url https://test.pypi.org/simple/ \
+            --index-strategy unsafe-best-match \
+            "jupyter-deploy[aws]" \
+            "${{ env.PKG_NAME }}==${{ env.VERSION }}"
+          echo "--- proxy console script ---"
+          smoke-venv/bin/jupyter-deploy-client-proxy --help
+          echo "--- jd proxy group ---"
+          smoke-venv/bin/jd proxy --help | tee /tmp/proxy-help.txt
+          for cmd in connect-info start open stop status show; do
+            grep -q "$cmd" /tmp/proxy-help.txt || { echo "::error::jd proxy missing '$cmd'"; exit 1; }
+          done
+          echo "CLI-with-proxy smoke passed"
+
+  prod-pypi-publish:
+    name: Publish to PyPI
+    needs: [test-pypi-install, build]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: release
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: List build artifacts
+        run: ls -la dist/
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v3
+
+      - name: Publish to PyPI
+        run: |
+          uv publish \
+            --trusted-publishing always
+
+  mark-release:
+    name: Create GitHub Release
+    needs: [prod-pypi-publish, build]
+    if: always() && needs.prod-pypi-publish.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      PKG_NAME: ${{ needs.build.outputs.pkg-name }}
+      VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install UV and Python
+        uses: ./.github/actions/install-uv
+        with:
+          python-version: '3.13'
+          working-directory: '.'
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          generateReleaseNotes: true
+          prerelease: ${{ contains(env.VERSION, 'rc') || contains(env.VERSION, 'a') || contains(env.VERSION, 'b') }}
+          tag: ${{ env.PKG_NAME }}==${{ env.VERSION }}
+          commit: ${{ github.sha }}

--- a/.github/workflows/release-proxy.yml
+++ b/.github/workflows/release-proxy.yml
@@ -95,7 +95,7 @@ jobs:
             --trusted-publishing always
 
   test-pypi-install:
-    name: Check Test PyPI build + CLI-with-proxy smoke
+    name: Check installation of the Test PyPI build
     needs: [test-pypi-publish, build]
     runs-on: ubuntu-latest
     env:
@@ -139,27 +139,6 @@ jobs:
           done
           echo "::error::Test PyPI install failed after 2 attempts"
           exit 1
-
-      # CLI-with-proxy smoke: install the CLI (prod PyPI, [aws]) alongside the just-published
-      # proxy build (Test PyPI, pinned exactly so a pre-release like 0.1.0rc1 resolves — the
-      # CLI's [proxy] extra pins `>=0.1.0`, which excludes pre-releases). Assert the proxy
-      # console script is on PATH and `jd proxy` is wired.
-      - name: CLI-with-proxy smoke
-        run: |
-          uv venv smoke-venv
-          uv pip install --python smoke-venv \
-            --extra-index-url https://test.pypi.org/simple/ \
-            --index-strategy unsafe-best-match \
-            "jupyter-deploy[aws]" \
-            "${{ env.PKG_NAME }}==${{ env.VERSION }}"
-          echo "--- proxy console script ---"
-          smoke-venv/bin/jupyter-deploy-client-proxy --help
-          echo "--- jd proxy group ---"
-          smoke-venv/bin/jd proxy --help | tee /tmp/proxy-help.txt
-          for cmd in connect-info start open stop status show; do
-            grep -q "$cmd" /tmp/proxy-help.txt || { echo "::error::jd proxy missing '$cmd'"; exit 1; }
-          done
-          echo "CLI-with-proxy smoke passed"
 
   prod-pypi-publish:
     name: Publish to PyPI

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![PyPI - base template](https://img.shields.io/pypi/v/jupyter-deploy-tf-aws-ec2-base?label=base-template)](https://pypi.org/project/jupyter-deploy-tf-aws-ec2-base/)
 [![PyPI - eks-oidc template](https://img.shields.io/pypi/v/jupyter-deploy-tf-aws-eks-oidc?label=eks-oidc-template)](https://pypi.org/project/jupyter-deploy-tf-aws-eks-oidc/)
 [![PyPI - pytest plugin](https://img.shields.io/pypi/v/pytest-jupyter-deploy?label=pytest-plugin)](https://pypi.org/project/pytest-jupyter-deploy/)
+[![PyPI - client proxy](https://img.shields.io/pypi/v/jupyter-deploy-client-proxy?label=client-proxy)](https://pypi.org/project/jupyter-deploy-client-proxy/)
 
 An open-source command line interface (CLI) to deploy interactive applications to the Cloud.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![PyPI - base template](https://img.shields.io/pypi/v/jupyter-deploy-tf-aws-ec2-base?label=base-template)](https://pypi.org/project/jupyter-deploy-tf-aws-ec2-base/)
 [![PyPI - eks-oidc template](https://img.shields.io/pypi/v/jupyter-deploy-tf-aws-eks-oidc?label=eks-oidc-template)](https://pypi.org/project/jupyter-deploy-tf-aws-eks-oidc/)
 [![PyPI - pytest plugin](https://img.shields.io/pypi/v/pytest-jupyter-deploy?label=pytest-plugin)](https://pypi.org/project/pytest-jupyter-deploy/)
-[![PyPI - client proxy](https://img.shields.io/pypi/v/jupyter-deploy-client-proxy?label=client-proxy)](https://pypi.org/project/jupyter-deploy-client-proxy/)
+[![PyPI - proxy](https://img.shields.io/pypi/v/jupyter-deploy-client-proxy?label=client-proxy)](https://pypi.org/project/jupyter-deploy-client-proxy/)
 
 An open-source command line interface (CLI) to deploy interactive applications to the Cloud.
 

--- a/libs/jupyter-deploy-client-proxy/pyproject.toml
+++ b/libs/jupyter-deploy-client-proxy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jupyter-deploy-client-proxy"
-version = "0.1.0"
+version = "0.1.0rc1"
 description = "Local client that routes an app from localhost to a jupyter-deploy-managed remote host."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -4,12 +4,13 @@
 Usage:
     python scripts/update_version.py <target> <bump-or-version>
 
-    <target>           cli | plugin | base-template | eks-oidc-template
+    <target>           cli | plugin | proxy | base-template | eks-oidc-template
     <bump-or-version>  patch | minor | major | an explicit version (e.g. 0.1.4, 0.1.0rc1)
 
 Dispatch:
     - cli               bumps BOTH the root and CLI pyproject.toml (they move in lockstep)
     - plugin            bumps the plugin pyproject.toml
+    - proxy             bumps the client-proxy pyproject.toml
     - base-template     delegates to scripts/upgrade_base_template_version.py
     - eks-oidc-template delegates to scripts/upgrade_eks_oidc_template_version.py
 
@@ -33,6 +34,7 @@ REPO_ROOT = Path(__file__).parent.parent
 TARGET_PYPROJECT: dict[str, Path] = {
     "cli": REPO_ROOT / "libs" / "jupyter-deploy" / "pyproject.toml",
     "plugin": REPO_ROOT / "libs" / "pytest-jupyter-deploy" / "pyproject.toml",
+    "proxy": REPO_ROOT / "libs" / "jupyter-deploy-client-proxy" / "pyproject.toml",
     "base-template": REPO_ROOT / "libs" / "jupyter-deploy-tf-aws-ec2-base" / "pyproject.toml",
     "eks-oidc-template": REPO_ROOT / "libs" / "jupyter-deploy-tf-aws-eks-oidc" / "pyproject.toml",
 }
@@ -114,8 +116,8 @@ def main() -> None:
         # root and CLI versions move in lockstep
         set_pyproject_version(REPO_ROOT / "pyproject.toml", new_version)
         set_pyproject_version(TARGET_PYPROJECT["cli"], new_version)
-    else:  # plugin
-        set_pyproject_version(TARGET_PYPROJECT["plugin"], new_version)
+    else:  # plugin | proxy — single-file bump
+        set_pyproject_version(TARGET_PYPROJECT[args.target], new_version)
 
     print("\nRun `uv lock` to update the lockfile (the just recipe does this).")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1050,7 +1050,7 @@ dev = [
 
 [[package]]
 name = "jupyter-deploy-client-proxy"
-version = "0.1.0"
+version = "0.1.0rc1"
 source = { editable = "libs/jupyter-deploy-client-proxy" }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR stands up CI for the standalone client proxy and unbreaks the e2e image builds. a/ fixes the shared + CLI e2e image builds, which started failing once `jupyter-deploy-client-proxy` and the jupyterlab template joined the `uv` workspace; b/ adds proxy CI: b.1/ functional tests on every PR, b.2/ a `release-proxy` workflow, and b.3/ a CLI-with-proxy install smoke — and cuts the proxy to `0.1.0rc1`.

### Developer experience
- the client-proxy functional suite now runs on every PR (previously local-only via `just functional-test`)
- `just update-version proxy <patch|minor|major|version>` bumps the client-proxy package
- `release-proxy` workflow (`workflow_dispatch`) publishes the proxy to test-PyPI, then to PyPI

### Implementation
1. `.github/e2e-shared/Dockerfile` + `.github/e2e-cli/Dockerfile`: copy the `jupyter-deploy-client-proxy` and `jupyter-deploy-tf-aws-ec2-jupyterlab` pyproject (+ LICENSE/README stubs) in the dep layer, so `uv sync --all-packages` resolves them as workspace members
2. `.github/workflows/functional-test.yml`: reusable (`workflow_call`) job running `just functional-test` on the 3.12/3.13 matrix
3. `.github/workflows/ci.yml`: call it on every push/PR — the functional suite is excluded from the per-dir `test` run by root `norecursedirs`
4. `.github/workflows/release-proxy.yml`: build → lint → test → functional gate → Test PyPI → install-check → PyPI → GH release; `prerelease` auto-flagged for rc/a/b tags
5. `scripts/update_version.py`: add a `proxy` target (single-file bump)
6. `libs/jupyter-deploy-client-proxy/pyproject.toml`: `0.1.0` → `0.1.0rc1` (+ `uv.lock`)
7. update `.github/AGENT.md`
8. add GitHub pill for new package to root `README.md`

### Testing
- ci: client-proxy functional suite (21) + proxy unit (109) green
- manual: reproduced the `not a workspace member` failure, then confirmed `uv sync --all-packages` passes with the fixed dep-layer COPY set; `uv build` produces the `0.1.0rc1` sdist + wheel; new/changed workflow YAML validated